### PR TITLE
Make smoke tests non-blocking in staging deployment

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -845,8 +845,7 @@ jobs:
               https://api.staging.batbern.ch
             echo "✅ Smoke tests passed"
           else
-            echo "::error::Smoke tests script not found at scripts/ci/smoke-tests.sh"
-            exit "::warning::Smoke Tests failed, non blocking"
+            echo "::warning::Smoke tests script not found at scripts/ci/smoke-tests.sh - skipping"
           fi
 
       - name: Run CORS validation tests


### PR DESCRIPTION
## Summary
Modified the staging deployment workflow to make smoke tests non-blocking when the test script is not found, allowing the deployment pipeline to continue without failure.

## Key Changes
- Changed error handling in the smoke tests step from `exit` with error status to a warning message
- Consolidated the error and warning messages into a single warning that indicates the smoke tests script is missing and will be skipped
- Removed the `exit` command that was causing the workflow to fail when the script was not found

## Implementation Details
The previous implementation had conflicting exit logic (`exit "::warning::..."`) which would have caused the workflow to fail. The updated approach uses a single `echo` statement with the `::warning::` GitHub Actions annotation, making the missing smoke tests script a non-blocking issue that logs a warning but allows the deployment to proceed.

This is useful for scenarios where the smoke tests script may not be available in all deployment contexts, but the deployment should still be allowed to complete.