### PR TITLE
fix(speaker-pool): show submitted content for speakers without ContentSubmission record

### DIFF
--- a/services/event-management-service/src/main/java/ch/batbern/events/service/SpeakerPoolService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/SpeakerPoolService.java
@@ -2,6 +2,7 @@ package ch.batbern.events.service;
 
 import ch.batbern.events.domain.ContentSubmission;
 import ch.batbern.events.domain.Event;
+import ch.batbern.events.domain.Session;
 import ch.batbern.events.domain.SessionMaterial;
 import ch.batbern.events.domain.SpeakerPool;
 import ch.batbern.events.dto.AddSpeakerToPoolRequest;
@@ -10,6 +11,7 @@ import ch.batbern.events.exception.EventNotFoundException;
 import ch.batbern.events.repository.ContentSubmissionRepository;
 import ch.batbern.events.repository.EventRepository;
 import ch.batbern.events.repository.SessionMaterialsRepository;
+import ch.batbern.events.repository.SessionRepository;
 import ch.batbern.events.repository.SpeakerPoolRepository;
 import ch.batbern.events.security.SecurityContextHelper;
 import ch.batbern.shared.events.SpeakerAddedToPoolEvent;
@@ -36,6 +38,7 @@ public class SpeakerPoolService {
     private final SpeakerPoolRepository speakerPoolRepository;
     private final EventRepository eventRepository;
     private final ContentSubmissionRepository contentSubmissionRepository;
+    private final SessionRepository sessionRepository;
     private final SessionMaterialsRepository sessionMaterialsRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final SecurityContextHelper securityContextHelper;
@@ -43,12 +46,14 @@ public class SpeakerPoolService {
     public SpeakerPoolService(SpeakerPoolRepository speakerPoolRepository,
                               EventRepository eventRepository,
                               ContentSubmissionRepository contentSubmissionRepository,
+                              SessionRepository sessionRepository,
                               SessionMaterialsRepository sessionMaterialsRepository,
                               ApplicationEventPublisher eventPublisher,
                               SecurityContextHelper securityContextHelper) {
         this.speakerPoolRepository = speakerPoolRepository;
         this.eventRepository = eventRepository;
         this.contentSubmissionRepository = contentSubmissionRepository;
+        this.sessionRepository = sessionRepository;
         this.sessionMaterialsRepository = sessionMaterialsRepository;
         this.eventPublisher = eventPublisher;
         this.securityContextHelper = securityContextHelper;
@@ -140,6 +145,17 @@ public class SpeakerPoolService {
                         cs -> cs
                 ));
 
+        // Batch-fetch sessions for speakers that have sessionIds (for title fallback + materials)
+        List<UUID> sessionIds = speakers.stream()
+                .map(SpeakerPool::getSessionId)
+                .filter(id -> id != null)
+                .distinct()
+                .collect(Collectors.toList());
+        Map<UUID, Session> sessionMap = sessionIds.isEmpty()
+                ? Map.of()
+                : sessionRepository.findAllById(sessionIds).stream()
+                        .collect(Collectors.toMap(Session::getId, s -> s));
+
         return speakers.stream()
                 .map(speaker -> {
                     ContentSubmission content = contentMap.get(speaker.getId());
@@ -150,6 +166,20 @@ public class SpeakerPoolService {
                                 content.getTitle(),
                                 content.getContentAbstract()
                         );
+                    } else if (speaker.getSessionId() != null) {
+                        // Fallback: use session title/description when no ContentSubmission exists
+                        // This handles content submitted via organizer path (SpeakerContentSubmissionService)
+                        // which stores content on Session, not in speaker_content_submissions table
+                        Session session = sessionMap.get(speaker.getSessionId());
+                        if (session != null && session.getTitle() != null) {
+                            response = SpeakerPoolResponse.fromEntityWithContent(
+                                    speaker,
+                                    session.getTitle(),
+                                    session.getDescription()
+                            );
+                        } else {
+                            response = SpeakerPoolResponse.fromEntity(speaker);
+                        }
                     } else {
                         response = SpeakerPoolResponse.fromEntity(speaker);
                     }

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/SpeakerPoolServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/SpeakerPoolServiceTest.java
@@ -1,12 +1,14 @@
 package ch.batbern.events.service;
 
 import ch.batbern.events.domain.Event;
+import ch.batbern.events.domain.Session;
 import ch.batbern.events.domain.SessionMaterial;
 import ch.batbern.events.domain.SpeakerPool;
 import ch.batbern.events.dto.SpeakerPoolResponse;
 import ch.batbern.events.repository.ContentSubmissionRepository;
 import ch.batbern.events.repository.EventRepository;
 import ch.batbern.events.repository.SessionMaterialsRepository;
+import ch.batbern.events.repository.SessionRepository;
 import ch.batbern.events.repository.SpeakerPoolRepository;
 import ch.batbern.events.security.SecurityContextHelper;
 import ch.batbern.shared.types.SpeakerWorkflowState;
@@ -44,6 +46,9 @@ class SpeakerPoolServiceTest {
     private ContentSubmissionRepository contentSubmissionRepository;
 
     @Mock
+    private SessionRepository sessionRepository;
+
+    @Mock
     private SessionMaterialsRepository sessionMaterialsRepository;
 
     @Mock
@@ -61,7 +66,7 @@ class SpeakerPoolServiceTest {
     void setUp() {
         service = new SpeakerPoolService(
                 speakerPoolRepository, eventRepository, contentSubmissionRepository,
-                sessionMaterialsRepository, eventPublisher, securityContextHelper
+                sessionRepository, sessionMaterialsRepository, eventPublisher, securityContextHelper
         );
 
         eventId = UUID.randomUUID();
@@ -177,6 +182,86 @@ class SpeakerPoolServiceTest {
             assertThat(result).hasSize(1);
             assertThat(result.get(0).getMaterialFileName()).isNull();
             assertThat(result.get(0).getMaterialCloudFrontUrl()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("getSpeakerPool - session title fallback")
+    class GetSpeakerPoolSessionFallbackTests {
+
+        @Test
+        @DisplayName("should use session title as fallback when no ContentSubmission exists")
+        void shouldUseSessionTitle_whenNoContentSubmission() {
+            UUID speakerId = UUID.randomUUID();
+            UUID sessionId = UUID.randomUUID();
+
+            SpeakerPool speaker = SpeakerPool.builder()
+                    .id(speakerId)
+                    .eventId(eventId)
+                    .speakerName("Confirmed Speaker")
+                    .status(SpeakerWorkflowState.CONFIRMED)
+                    .sessionId(sessionId)
+                    .build();
+
+            Session session = Session.builder()
+                    .id(sessionId)
+                    .eventId(eventId)
+                    .title("Digital Twins in Architecture")
+                    .description("A talk about digital twins and their impact")
+                    .sessionType("presentation")
+                    .build();
+
+            when(eventRepository.findByEventCode("BATbern99")).thenReturn(Optional.of(testEvent));
+            when(speakerPoolRepository.findByEventId(eventId)).thenReturn(List.of(speaker));
+            when(contentSubmissionRepository.findFirstBySpeakerPoolIdOrderBySubmissionVersionDesc(speakerId))
+                    .thenReturn(Optional.empty());
+            when(sessionRepository.findAllById(List.of(sessionId))).thenReturn(List.of(session));
+            when(sessionMaterialsRepository.findBySession_IdOrderByCreatedAtAsc(sessionId))
+                    .thenReturn(List.of());
+
+            List<SpeakerPoolResponse> result = service.getSpeakerPoolForEvent("BATbern99");
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getSubmittedTitle()).isEqualTo("Digital Twins in Architecture");
+            assertThat(result.get(0).getSubmittedAbstract()).isEqualTo("A talk about digital twins and their impact");
+        }
+
+        @Test
+        @DisplayName("should not use session fallback when ContentSubmission exists")
+        void shouldPreferContentSubmission_overSessionFallback() {
+            UUID speakerId = UUID.randomUUID();
+            UUID sessionId = UUID.randomUUID();
+
+            SpeakerPool speaker = SpeakerPool.builder()
+                    .id(speakerId)
+                    .eventId(eventId)
+                    .speakerName("Speaker with Submission")
+                    .status(SpeakerWorkflowState.CONTENT_SUBMITTED)
+                    .sessionId(sessionId)
+                    .build();
+
+            ch.batbern.events.domain.ContentSubmission submission =
+                    ch.batbern.events.domain.ContentSubmission.builder()
+                            .id(UUID.randomUUID())
+                            .speakerPool(speaker)
+                            .title("Updated Title from Portal")
+                            .contentAbstract("Updated abstract via speaker portal")
+                            .abstractCharCount(38)
+                            .submissionVersion(1)
+                            .build();
+
+            when(eventRepository.findByEventCode("BATbern99")).thenReturn(Optional.of(testEvent));
+            when(speakerPoolRepository.findByEventId(eventId)).thenReturn(List.of(speaker));
+            when(contentSubmissionRepository.findFirstBySpeakerPoolIdOrderBySubmissionVersionDesc(speakerId))
+                    .thenReturn(Optional.of(submission));
+            when(sessionMaterialsRepository.findBySession_IdOrderByCreatedAtAsc(sessionId))
+                    .thenReturn(List.of());
+
+            List<SpeakerPoolResponse> result = service.getSpeakerPoolForEvent("BATbern99");
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getSubmittedTitle()).isEqualTo("Updated Title from Portal");
+            assertThat(result.get(0).getSubmittedAbstract()).isEqualTo("Updated abstract via speaker portal");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Content submitted via the organizer path (`SpeakerContentSubmissionService`) stores title/abstract on the `Session` entity but does NOT create a `ContentSubmission` record
- The `getSpeakerPoolForEvent` method only looked at `ContentSubmission` records for `submittedTitle`, causing CONFIRMED speakers to show no content in the SpeakerOutreachDetailsDrawer
- Now falls back to `Session.title`/`description` when no `ContentSubmission` exists but the speaker has a `sessionId`
- Batch-fetches sessions via `findAllById` to avoid N+1 queries

## Test plan
- [x] Existing 3 material enrichment tests pass
- [x] New test: session title fallback when no ContentSubmission
- [x] New test: ContentSubmission takes priority over session fallback
- [ ] Verify on staging: CONFIRMED speaker content now visible in SpeakerOutreachDetailsDrawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)