### PR TITLE
fix(ci): always build all services on main branch push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # On main branch pushes, always build all services.
+          # Production deploys require every service image to be present in prod ECR
+          # tagged with the current SHA — smart change detection would leave gaps.
+          if [ "${{ github.ref }}" = "refs/heads/main" ] && [ "${{ github.event_name }}" = "push" ]; then
+            echo "✓ Push to main — building all services for production ECR"
+            echo "build=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Determine base and head SHA for comparison
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # PRs: compare against base branch (existing behavior)


### PR DESCRIPTION
## Summary

- On main branch push events, skip smart change detection and always build all services
- Production deploys require every service image in prod ECR tagged with the current SHA — change detection leaves gaps when only some services changed

## Root cause

The first prod build (merge commit from PR #514) only changed `api-gateway/build.gradle` and `build.yml`. The diff-based detection saw only those files changed, so all other services got `build=false` and skipped the prod ECR push. The Deploy to Production workflow would fail because those images don't exist in prod ECR.

## Test plan

- [ ] Merge → triggers build on main → all services build and push to prod ECR

🤖 Generated with [Claude Code](https://claude.com/claude-code)