### PR TITLE
fix(ci): resolve short SHA to full SHA before creating GitHub release

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -344,10 +344,13 @@ jobs:
               "${VERSION}" "${DATE}" "${WORKFLOW_URL}")
           fi
 
+          # Resolve short SHA to full 40-char SHA (GitHub API requires full SHA for target_commitish)
+          FULL_SHA=$(gh api "repos/${{ github.repository }}/commits/${VERSION}" --jq '.sha')
+
           gh release create "${TAG}" \
             --title "${TITLE}" \
             --notes "${NOTES}" \
-            --target "${VERSION}"
+            --target "${FULL_SHA}"
 
           echo "✅ GitHub Release created: ${TAG}"
 


### PR DESCRIPTION
## Summary

The GitHub releases API requires a full 40-char commit SHA for `target_commitish`. The workflow was passing the 7-char short SHA (e.g. `179000f`), which returns:

```
HTTP 403: Resource not accessible by integration
```

## Fix

Before calling `gh release create`, resolve the short SHA using the GitHub API:

```bash
FULL_SHA=$(gh api "repos/${{ github.repository }}/commits/${VERSION}" --jq '.sha')
gh release create "${TAG}" --target "${FULL_SHA}" ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)