### PR TITLE
fix(infra): make email FROM address environment-aware for SES

### DIFF
--- a/infrastructure/lib/lambda/triggers/custom-email-sender.ts
+++ b/infrastructure/lib/lambda/triggers/custom-email-sender.ts
@@ -52,6 +52,7 @@ interface CustomEmailSenderEvent {
  */
 interface EnvironmentConfig {
   FRONTEND_DOMAIN: string;
+  FROM_EMAIL: string;
   KEY_ARN: string;
   KEY_ID: string;
 }
@@ -60,7 +61,7 @@ interface EnvironmentConfig {
  * Validate required environment variables
  */
 function getEnvironmentConfig(): EnvironmentConfig {
-  const requiredVars = ['FRONTEND_DOMAIN', 'KEY_ARN', 'KEY_ID'];
+  const requiredVars = ['FRONTEND_DOMAIN', 'FROM_EMAIL', 'KEY_ARN', 'KEY_ID'];
   const missing = requiredVars.filter((varName) => !process.env[varName]);
 
   if (missing.length > 0) {
@@ -69,6 +70,7 @@ function getEnvironmentConfig(): EnvironmentConfig {
 
   return {
     FRONTEND_DOMAIN: process.env.FRONTEND_DOMAIN!,
+    FROM_EMAIL: process.env.FROM_EMAIL!,
     KEY_ARN: process.env.KEY_ARN!,
     KEY_ID: process.env.KEY_ID!,
   };
@@ -463,7 +465,7 @@ export const handler: Handler<CustomEmailSenderEvent, CustomEmailSenderEvent> = 
     // Send email directly via SES
     const sesClient = new SESClient({ region: process.env.AWS_REGION || 'eu-central-1' });
     const sendEmailCommand = new SendEmailCommand({
-      Source: 'BATbern <noreply@berner-architekten-treffen.ch>',
+      Source: config.FROM_EMAIL,
       Destination: {
         ToAddresses: [email],
       },

--- a/infrastructure/lib/stacks/cognito-stack.ts
+++ b/infrastructure/lib/stacks/cognito-stack.ts
@@ -113,6 +113,12 @@ export class CognitoStack extends cdk.Stack {
         ? 'https://staging.batbern.ch'
         : 'http://localhost:3000';
 
+    // FROM address must use a domain verified in SES for the environment
+    const fromEmail =
+      envName === 'production'
+        ? 'BATbern <noreply@batbern.ch>'
+        : 'BATbern <noreply@berner-architekten-treffen.ch>';
+
     const customEmailSenderLambda = new NodejsFunction(this, 'CustomEmailSenderTrigger', {
       functionName: `batbern-${envName}-custom-email-sender-trigger`,
       runtime: lambda.Runtime.NODEJS_20_X,
@@ -122,6 +128,7 @@ export class CognitoStack extends cdk.Stack {
       logGroup: customEmailSenderLogGroup,
       environment: {
         FRONTEND_DOMAIN: frontendDomain,
+        FROM_EMAIL: fromEmail,
         KEY_ID: cognitoEmailKmsKey.keyId,
         KEY_ARN: cognitoEmailKmsKey.keyArn,
         // AWS_REGION is automatically provided by Lambda runtime


### PR DESCRIPTION
## Problem

Cognito password reset emails were silently failing on production. The custom email sender Lambda used a hardcoded FROM address `noreply@berner-architekten-treffen.ch` which is not registered in the prod SES account.

## Fix

- Add `FROM_EMAIL` env var to the `CustomEmailSenderTrigger` Lambda, set per environment in `cognito-stack.ts`
  - Production: `BATbern <noreply@batbern.ch>`
  - Staging/dev: `BATbern <noreply@berner-architekten-treffen.ch>` (unchanged)
- Read `FROM_EMAIL` in `custom-email-sender.ts` instead of hardcoded string
- Added `_amazonses.batbern.ch` TXT record to Route53 hosted zone for SES domain verification

## After deploy

⚠️ SES is still in **sandbox mode** in the prod account. In sandbox mode only verified email addresses can receive emails. `nissim@buchs.be` is already verified so the bootstrap user can test. To send to real users, request SES production access in the AWS console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)