### PR TITLE
feat(presentation): per-image presentation position for teaser images

### DIFF
--- a/_bmad-output/implementation-artifacts/10-8c-teaser-image-presentation-position.md
+++ b/_bmad-output/implementation-artifacts/10-8c-teaser-image-presentation-position.md
@@ -1,0 +1,88 @@
+# Story 10.8c: Teaser Image Presentation Position
+
+Status: done
+
+## Story
+
+As an **event moderator / organizer**,
+I want to specify, for each uploaded teaser image, where it should appear in the presentation,
+so that I can place sponsor logos, topic teasers, or sponsor slides at the most contextually relevant point in the evening.
+
+## Acceptance Criteria
+
+1. Each teaser image has a `presentationPosition` field that controls where it appears in the moderator presentation.
+2. The organizer can change the position per image via a dropdown in the Event Settings tab (Teaser Images gallery).
+3. Allowed positions:
+   - **After Welcome slide** (`AFTER_WELCOME`) — between welcome and about
+   - **After Committee slide** (`AFTER_COMMITTEE`) — between committee and topic-reveal
+   - **After Topic Reveal slide** (`AFTER_TOPIC_REVEAL`) — between topic-reveal and agenda-preview (default)
+   - **After Upcoming Events slide** (`AFTER_UPCOMING_EVENTS`) — between upcoming-events and apero
+4. Multiple images can share the same position; they appear in ascending `displayOrder` order at that position.
+5. Default position for newly uploaded images is `AFTER_TOPIC_REVEAL` (preserves existing behavior).
+6. Changing position triggers a PATCH call and updates immediately (optimistic invalidation via React Query).
+7. All 15 implementation steps have passing tests (backend unit + integration, frontend unit).
+
+## Technical Notes
+
+- New DB column: `presentation_position VARCHAR(30) NOT NULL DEFAULT 'AFTER_TOPIC_REVEAL'` with CHECK constraint
+- New API: `PATCH /api/v1/events/{eventCode}/teaser-images/{imageId}` with `{ presentationPosition }`
+- Frontend: position dropdown (`<Select>`) below each image thumbnail in the gallery grid
+- Presentation logic: `insertTeaserImages()` helper in `usePresentationSections.ts` called at 4 insertion points
+
+## Implementation Summary
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `services/event-management-service/src/main/resources/db/migration/V81__add_teaser_image_presentation_position.sql` | NEW — ALTER TABLE adds column |
+| `docs/api/events-api.openapi.yml` | Add `TeaserImagePresentationPosition` enum, extend `TeaserImageItem`, add `TeaserImageUpdateRequest`, add PATCH operation |
+| `services/event-management-service/src/main/java/ch/batbern/events/domain/EventTeaserImage.java` | Add `presentationPosition` field (default `"AFTER_TOPIC_REVEAL"`) |
+| `services/event-management-service/src/main/java/ch/batbern/events/service/EventTeaserImageService.java` | Update `toItem()` to map position; add `updatePresentationPosition()` |
+| `services/event-management-service/src/main/java/ch/batbern/events/controller/EventTeaserImageController.java` | Add `@PatchMapping` handler |
+| `services/event-management-service/src/test/java/ch/batbern/events/service/EventTeaserImageServiceTest.java` | Add `UpdatePresentationPositionTests`; update confirm test assertion |
+| `services/event-management-service/src/test/java/ch/batbern/events/controller/EventTeaserImageControllerIntegrationTest.java` | Add 3 PATCH tests; update confirm + GET event assertions |
+| `web-frontend/src/types/generated/events-api.types.ts` | Regenerated — adds `TeaserImagePresentationPosition`, `TeaserImageUpdateRequest`, updates `TeaserImageItem` |
+| `web-frontend/src/services/eventApiClient.ts` | Add `updateTeaserImage()` method |
+| `web-frontend/src/hooks/useEventTeaserImages.ts` | Add `useUpdateTeaserImagePosition()` mutation |
+| `web-frontend/src/components/organizer/EventPage/EventSettingsTab.tsx` | Add position Select dropdown per image card |
+| `web-frontend/public/locales/en/events.json` | Add `teaserImage.position.*` keys; update `description` |
+| `web-frontend/public/locales/de/events.json` | Add `teaserImage.position.*` keys (DE); update `description` |
+| `web-frontend/src/hooks/usePresentationSections.ts` | Extract `insertTeaserImages()` helper; add 4 insertion points |
+| `web-frontend/src/hooks/usePresentationSections.test.ts` | Update existing + add 6 new tests covering all 4 positions |
+
+## Dev Agent Record
+
+**Implemented by:** Amelia (dev agent)
+**Date:** 2026-03-05
+**Branch:** `feature/10-8a-moderator-presentation-page`
+
+### Implementation decisions
+- Used `String` (not enum) for `presentationPosition` in the JPA entity, converting to/from the generated `TeaserImagePresentationPosition` enum in `toItem()` using `fromValue()`. Reason: `@Enumerated(EnumType.STRING)` stores the enum name (`TOPIC_REVEAL`), not the value (`AFTER_TOPIC_REVEAL`), which would conflict with the DB CHECK constraint.
+- PATCH-only API (no position in confirm request) — position is logically independent of upload; users can rearrange after seeing all images.
+- `insertTeaserImages()` is a module-level function (not a hook member) since it is pure: sections array + images + position string → void.
+- `?? 'AFTER_TOPIC_REVEAL'` null-coalescing guard in `insertTeaserImages()` protects against missing position on legacy data.
+
+### Tests
+- Backend unit: 2 new + 1 updated (17 total pass)
+- Backend integration: 3 new + 2 updated assertions (11 total pass)
+- Frontend unit: 6 new + 2 updated (21 total pass)
+- Type-check: ✅ clean
+
+## File List
+
+- `services/event-management-service/src/main/resources/db/migration/V81__add_teaser_image_presentation_position.sql`
+- `docs/api/events-api.openapi.yml`
+- `services/event-management-service/src/main/java/ch/batbern/events/domain/EventTeaserImage.java`
+- `services/event-management-service/src/main/java/ch/batbern/events/service/EventTeaserImageService.java`
+- `services/event-management-service/src/main/java/ch/batbern/events/controller/EventTeaserImageController.java`
+- `services/event-management-service/src/test/java/ch/batbern/events/service/EventTeaserImageServiceTest.java`
+- `services/event-management-service/src/test/java/ch/batbern/events/controller/EventTeaserImageControllerIntegrationTest.java`
+- `web-frontend/src/types/generated/events-api.types.ts`
+- `web-frontend/src/services/eventApiClient.ts`
+- `web-frontend/src/hooks/useEventTeaserImages.ts`
+- `web-frontend/src/components/organizer/EventPage/EventSettingsTab.tsx`
+- `web-frontend/public/locales/en/events.json`
+- `web-frontend/public/locales/de/events.json`
+- `web-frontend/src/hooks/usePresentationSections.ts`
+- `web-frontend/src/hooks/usePresentationSections.test.ts`

--- a/docs/api/events-api.openapi.yml
+++ b/docs/api/events-api.openapi.yml
@@ -4878,6 +4878,44 @@ paths:
           $ref: '#/components/responses/Forbidden'
 
   /events/{eventCode}/teaser-images/{imageId}:
+    patch:
+      tags: [Events]
+      operationId: updateTeaserImage
+      summary: Update presentation position of a teaser image
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: eventCode
+          in: path
+          required: true
+          schema:
+            type: string
+          example: "BATbern57"
+        - name: imageId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TeaserImageUpdateRequest'
+      responses:
+        '200':
+          description: Teaser image updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeaserImageItem'
+        '404':
+          description: Teaser image not found
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     delete:
       tags: [Events]
       operationId: deleteTeaserImage
@@ -5397,9 +5435,18 @@ components:
 
     # ── Event Teaser Image Schemas (Story 10.22) ──────────────────────────────
 
+    TeaserImagePresentationPosition:
+      type: string
+      description: Controls which slide the image appears after in the moderator presentation.
+      enum:
+        - AFTER_WELCOME
+        - AFTER_COMMITTEE
+        - AFTER_TOPIC_REVEAL
+        - AFTER_UPCOMING_EVENTS
+
     TeaserImageItem:
       type: object
-      required: [id, imageUrl, displayOrder]
+      required: [id, imageUrl, displayOrder, presentationPosition]
       description: A single teaser image for the moderator presentation page.
       properties:
         id:
@@ -5415,6 +5462,15 @@ components:
           type: integer
           description: Order in which the image is displayed (ascending).
           example: 0
+        presentationPosition:
+          $ref: '#/components/schemas/TeaserImagePresentationPosition'
+
+    TeaserImageUpdateRequest:
+      type: object
+      required: [presentationPosition]
+      properties:
+        presentationPosition:
+          $ref: '#/components/schemas/TeaserImagePresentationPosition'
 
     TeaserImageUploadUrlRequest:
       type: object

--- a/services/event-management-service/src/main/java/ch/batbern/events/controller/EventTeaserImageController.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/controller/EventTeaserImageController.java
@@ -3,6 +3,7 @@ package ch.batbern.events.controller;
 import ch.batbern.events.config.CacheConfig;
 import ch.batbern.events.dto.generated.TeaserImageConfirmRequest;
 import ch.batbern.events.dto.generated.TeaserImageItem;
+import ch.batbern.events.dto.generated.TeaserImageUpdateRequest;
 import ch.batbern.events.dto.generated.TeaserImageUploadUrlRequest;
 import ch.batbern.events.dto.generated.TeaserImageUploadUrlResponse;
 import ch.batbern.events.service.EventTeaserImageService;
@@ -12,6 +13,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,6 +65,21 @@ public class EventTeaserImageController {
             @RequestBody TeaserImageConfirmRequest request) {
         return ResponseEntity.ok(
                 teaserImageService.confirmUpload(eventCode, request.getS3Key())
+        );
+    }
+
+    /**
+     * Update the presentation position of a teaser image.
+     */
+    @PatchMapping("/events/{eventCode}/teaser-images/{imageId}")
+    @PreAuthorize("hasRole('ORGANIZER')")
+    @CacheEvict(value = CacheConfig.EVENT_WITH_INCLUDES_CACHE, allEntries = true)
+    public ResponseEntity<TeaserImageItem> updateTeaserImage(
+            @PathVariable String eventCode,
+            @PathVariable UUID imageId,
+            @RequestBody TeaserImageUpdateRequest request) {
+        return ResponseEntity.ok(
+                teaserImageService.updatePresentationPosition(eventCode, imageId, request.getPresentationPosition())
         );
     }
 

--- a/services/event-management-service/src/main/java/ch/batbern/events/domain/EventTeaserImage.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/domain/EventTeaserImage.java
@@ -43,6 +43,9 @@ public class EventTeaserImage {
     @Column(name = "display_order", nullable = false)
     private int displayOrder;
 
+    @Column(name = "presentation_position", nullable = false, length = 30)
+    private String presentationPosition = "AFTER_TOPIC_REVEAL";
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt = OffsetDateTime.now();
 }

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/EventTeaserImageService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/EventTeaserImageService.java
@@ -2,6 +2,7 @@ package ch.batbern.events.service;
 
 import ch.batbern.events.domain.EventTeaserImage;
 import ch.batbern.events.dto.generated.TeaserImageItem;
+import ch.batbern.events.dto.generated.TeaserImagePresentationPosition;
 import ch.batbern.events.dto.generated.TeaserImageUploadUrlResponse;
 import ch.batbern.events.exception.TeaserImageLimitExceededException;
 import ch.batbern.events.exception.TeaserImageNotFoundException;
@@ -187,13 +188,28 @@ public class EventTeaserImageService {
                 .toList();
     }
 
+    /**
+     * Update the presentation position of an existing teaser image.
+     * The position controls which slide the image appears after in the moderator presentation.
+     */
+    public TeaserImageItem updatePresentationPosition(String eventCode, UUID imageId,
+                                                      TeaserImagePresentationPosition position) {
+        EventTeaserImage image = teaserImageRepository.findByIdAndEventCode(imageId, eventCode)
+                .orElseThrow(() -> new TeaserImageNotFoundException(imageId.toString()));
+        image.setPresentationPosition(position.getValue());
+        EventTeaserImage saved = teaserImageRepository.save(image);
+        log.info("Teaser image {} position updated to {} for event {}", imageId, position.getValue(), eventCode);
+        return toItem(saved);
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────────
 
     private TeaserImageItem toItem(EventTeaserImage entity) {
         return new TeaserImageItem(
                 entity.getId(),
                 URI.create(entity.getImageUrl()),
-                entity.getDisplayOrder()
+                entity.getDisplayOrder(),
+                TeaserImagePresentationPosition.fromValue(entity.getPresentationPosition())
         );
     }
 

--- a/services/event-management-service/src/main/resources/db/migration/V81__add_teaser_image_presentation_position.sql
+++ b/services/event-management-service/src/main/resources/db/migration/V81__add_teaser_image_presentation_position.sql
@@ -1,0 +1,12 @@
+-- V81: Add presentation_position to event_teaser_images
+-- Controls which slide the image appears after in the moderator presentation.
+-- Default: AFTER_TOPIC_REVEAL (preserves existing behaviour).
+ALTER TABLE event_teaser_images
+    ADD COLUMN presentation_position VARCHAR(30)
+        NOT NULL DEFAULT 'AFTER_TOPIC_REVEAL'
+        CHECK (presentation_position IN (
+            'AFTER_WELCOME',
+            'AFTER_COMMITTEE',
+            'AFTER_TOPIC_REVEAL',
+            'AFTER_UPCOMING_EVENTS'
+        ));

--- a/services/event-management-service/src/test/java/ch/batbern/events/controller/EventTeaserImageControllerIntegrationTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/controller/EventTeaserImageControllerIntegrationTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -142,7 +143,8 @@ class EventTeaserImageControllerIntegrationTest extends AbstractIntegrationTest 
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").isNotEmpty())
                 .andExpect(jsonPath("$.imageUrl").isNotEmpty())
-                .andExpect(jsonPath("$.displayOrder").value(0));
+                .andExpect(jsonPath("$.displayOrder").value(0))
+                .andExpect(jsonPath("$.presentationPosition").value("AFTER_TOPIC_REVEAL"));
 
         // AC8: verify actual DB state
         assertThat(teaserImageRepository.findByEventCodeOrderByDisplayOrderAsc(EVENT_CODE)).hasSize(1);
@@ -193,6 +195,7 @@ class EventTeaserImageControllerIntegrationTest extends AbstractIntegrationTest 
                 .andExpect(jsonPath("$.teaserImages").isArray())
                 .andExpect(jsonPath("$.teaserImages.length()").value(2))
                 .andExpect(jsonPath("$.teaserImages[0].displayOrder").value(0))
+                .andExpect(jsonPath("$.teaserImages[0].presentationPosition").value("AFTER_TOPIC_REVEAL"))
                 .andExpect(jsonPath("$.teaserImages[1].displayOrder").value(1));
     }
 
@@ -203,6 +206,45 @@ class EventTeaserImageControllerIntegrationTest extends AbstractIntegrationTest 
         mockMvc.perform(get("/api/v1/events/{code}", EVENT_CODE))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.teaserImages").isEmpty());
+    }
+
+    // ── patch (presentation position) ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("PATCH teaser image updates presentationPosition in DB and response - AC (position)")
+    @WithMockUser(roles = "ORGANIZER")
+    void patchTeaserImage_asOrganizer_updatesPresentationPosition() throws Exception {
+        EventTeaserImage image = createTeaserImage("events/" + EVENT_CODE + "/teaser/img.jpg", 0);
+
+        mockMvc.perform(patch("/api/v1/events/{code}/teaser-images/{id}", EVENT_CODE, image.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"presentationPosition\":\"AFTER_WELCOME\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(image.getId().toString()))
+                .andExpect(jsonPath("$.presentationPosition").value("AFTER_WELCOME"));
+
+        // Verify DB state
+        EventTeaserImage dbState = teaserImageRepository.findById(image.getId()).orElseThrow();
+        assertThat(dbState.getPresentationPosition()).isEqualTo("AFTER_WELCOME");
+    }
+
+    @Test
+    @DisplayName("PATCH unknown imageId returns 404")
+    @WithMockUser(roles = "ORGANIZER")
+    void patchTeaserImage_withUnknownId_returns404() throws Exception {
+        mockMvc.perform(patch("/api/v1/events/{code}/teaser-images/{id}", EVENT_CODE, UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"presentationPosition\":\"AFTER_WELCOME\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PATCH as anonymous returns 403")
+    void patchTeaserImage_asAnonymous_returns403() throws Exception {
+        mockMvc.perform(patch("/api/v1/events/{code}/teaser-images/{id}", EVENT_CODE, UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"presentationPosition\":\"AFTER_WELCOME\"}"))
+                .andExpect(status().isForbidden());
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────────

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/EventTeaserImageServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/EventTeaserImageServiceTest.java
@@ -2,6 +2,7 @@ package ch.batbern.events.service;
 
 import ch.batbern.events.domain.EventTeaserImage;
 import ch.batbern.events.dto.generated.TeaserImageItem;
+import ch.batbern.events.dto.generated.TeaserImagePresentationPosition;
 import ch.batbern.events.dto.generated.TeaserImageUploadUrlResponse;
 import ch.batbern.events.exception.TeaserImageLimitExceededException;
 import ch.batbern.events.exception.TeaserImageNotFoundException;
@@ -182,6 +183,7 @@ class EventTeaserImageServiceTest {
             verify(teaserImageRepository).save(any(EventTeaserImage.class));
             assertThat(result.getId()).isEqualTo(saved.getId());
             assertThat(result.getDisplayOrder()).isEqualTo(0);
+            assertThat(result.getPresentationPosition()).isEqualTo(TeaserImagePresentationPosition.TOPIC_REVEAL);
         }
 
         @Test
@@ -255,6 +257,63 @@ class EventTeaserImageServiceTest {
             img.setDisplayOrder(displayOrder);
             img.setCreatedAt(OffsetDateTime.now());
             return img;
+        }
+    }
+
+    // ── updatePresentationPosition ───────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("updatePresentationPosition")
+    class UpdatePresentationPositionTests {
+
+        @Test
+        @DisplayName("should update position and return updated TeaserImageItem")
+        void should_updatePresentationPosition_returnsUpdatedItem() {
+            // Given
+            UUID imageId = UUID.randomUUID();
+            EventTeaserImage existing = new EventTeaserImage();
+            existing.setId(imageId);
+            existing.setEventCode(EVENT_CODE);
+            existing.setS3Key("events/" + EVENT_CODE + "/teaser/img.jpg");
+            existing.setImageUrl(CLOUDFRONT_DOMAIN + "/events/" + EVENT_CODE + "/teaser/img.jpg");
+            existing.setDisplayOrder(0);
+            existing.setPresentationPosition("AFTER_TOPIC_REVEAL");
+
+            EventTeaserImage updated = new EventTeaserImage();
+            updated.setId(imageId);
+            updated.setEventCode(EVENT_CODE);
+            updated.setS3Key(existing.getS3Key());
+            updated.setImageUrl(existing.getImageUrl());
+            updated.setDisplayOrder(0);
+            updated.setPresentationPosition("AFTER_WELCOME");
+
+            when(teaserImageRepository.findByIdAndEventCode(imageId, EVENT_CODE))
+                    .thenReturn(Optional.of(existing));
+            when(teaserImageRepository.save(any(EventTeaserImage.class))).thenReturn(updated);
+
+            // When
+            TeaserImageItem result = service.updatePresentationPosition(EVENT_CODE, imageId,
+                    TeaserImagePresentationPosition.WELCOME);
+
+            // Then
+            verify(teaserImageRepository).save(any(EventTeaserImage.class));
+            assertThat(result.getPresentationPosition()).isEqualTo(TeaserImagePresentationPosition.WELCOME);
+        }
+
+        @Test
+        @DisplayName("should throw TeaserImageNotFoundException when image not found")
+        void should_throw_TeaserImageNotFoundException_whenImageNotFound() {
+            // Given
+            UUID imageId = UUID.randomUUID();
+            when(teaserImageRepository.findByIdAndEventCode(imageId, EVENT_CODE))
+                    .thenReturn(Optional.empty());
+
+            // When / Then
+            assertThatThrownBy(() -> service.updatePresentationPosition(EVENT_CODE, imageId,
+                    TeaserImagePresentationPosition.WELCOME))
+                    .isInstanceOf(TeaserImageNotFoundException.class);
+
+            verify(teaserImageRepository, never()).save(any());
         }
     }
 

--- a/web-frontend/public/locales/de/events.json
+++ b/web-frontend/public/locales/de/events.json
@@ -788,11 +788,19 @@
   },
   "teaserImage": {
     "title": "Teaser-Bilder",
-    "description": "Bilder, die auf der Präsentationsseite als Vollbild-Folien zwischen Themenbekanntgabe und Agenda-Vorschau angezeigt werden.",
+    "description": "Bilder, die auf der Präsentationsseite als Vollbild-Folien angezeigt werden.",
     "uploadButton": "Teaser-Bild hinzufügen",
     "uploading": "Wird hochgeladen...",
     "uploadError": "Upload fehlgeschlagen. Bitte versuchen Sie es erneut.",
     "removeError": "Entfernen fehlgeschlagen. Bitte versuchen Sie es erneut.",
-    "limitReached": "Maximum von {{max}} Teaser-Bildern erreicht."
+    "positionError": "Folienposition konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut.",
+    "limitReached": "Maximum von {{max}} Teaser-Bildern erreicht.",
+    "position": {
+      "label": "Anzeigen nach",
+      "afterWelcome": "Willkommens-Folie",
+      "afterCommittee": "Komitee-Folie",
+      "afterTopicReveal": "Themenbekanntgabe-Folie",
+      "afterUpcomingEvents": "Kommende Events-Folie"
+    }
   }
 }

--- a/web-frontend/public/locales/en/events.json
+++ b/web-frontend/public/locales/en/events.json
@@ -788,11 +788,19 @@
   },
   "teaserImage": {
     "title": "Teaser Images",
-    "description": "Images shown as full-screen slides on the presentation page between topic reveal and agenda preview.",
+    "description": "Images shown as full-screen slides on the presentation page.",
     "uploadButton": "Add Teaser Image",
     "uploading": "Uploading...",
     "uploadError": "Upload failed. Please try again.",
     "removeError": "Remove failed. Please try again.",
-    "limitReached": "Maximum of {{max}} teaser images reached."
+    "positionError": "Failed to update slide position. Please try again.",
+    "limitReached": "Maximum of {{max}} teaser images reached.",
+    "position": {
+      "label": "Show after",
+      "afterWelcome": "Welcome slide",
+      "afterCommittee": "Committee slide",
+      "afterTopicReveal": "Topic Reveal slide",
+      "afterUpcomingEvents": "Upcoming Events slide"
+    }
   }
 }

--- a/web-frontend/src/components/organizer/EventPage/EventSettingsTab.tsx
+++ b/web-frontend/src/components/organizer/EventPage/EventSettingsTab.tsx
@@ -28,6 +28,10 @@ import {
   Snackbar,
   TextField,
   CircularProgress,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
 } from '@mui/material';
 import {
   Notifications as NotificationsIcon,
@@ -44,7 +48,11 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
 import { useDeleteEvent, useUpdateEvent } from '@/hooks/useEvents';
-import { useUploadTeaserImage, useDeleteTeaserImage } from '@/hooks/useEventTeaserImages';
+import {
+  useUploadTeaserImage,
+  useDeleteTeaserImage,
+  useUpdateTeaserImagePosition,
+} from '@/hooks/useEventTeaserImages';
 import type { Event, EventDetailUI } from '@/types/event.types';
 import type { components } from '@/types/generated/events-api.types';
 import { OrganizerSelect } from '@/components/shared/OrganizerSelect/OrganizerSelect';
@@ -92,9 +100,11 @@ export const EventSettingsTab: React.FC<EventSettingsTabProps> = ({ event, event
   const MAX_TEASER_IMAGES = 10;
   const uploadTeaserImageMutation = useUploadTeaserImage(eventCode);
   const deleteTeaserImageMutation = useDeleteTeaserImage(eventCode);
+  const updateTeaserImagePositionMutation = useUpdateTeaserImagePosition(eventCode);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [teaserUploadError, setTeaserUploadError] = useState<string | null>(null);
   const [teaserRemoveError, setTeaserRemoveError] = useState<string | null>(null);
+  const [teaserPositionError, setTeaserPositionError] = useState<string | null>(null);
 
   // ⚠️ MOCK DATA - Notification rules (backend integration pending)
   const [notifications, setNotifications] = useState<NotificationRule[]>([
@@ -225,6 +235,22 @@ export const EventSettingsTab: React.FC<EventSettingsTabProps> = ({ event, event
     }
   };
 
+  const handleTeaserImagePositionChange = async (imageId: string, position: string) => {
+    setTeaserPositionError(null);
+    try {
+      await updateTeaserImagePositionMutation.mutateAsync({
+        imageId,
+        request: { presentationPosition: position as TeaserImageItem['presentationPosition'] },
+      });
+    } catch (err) {
+      setTeaserPositionError(
+        err instanceof Error
+          ? err.message
+          : t('teaserImage.positionError', 'Failed to update slide position. Please try again.')
+      );
+    }
+  };
+
   return (
     <Stack spacing={3}>
       {/* Event Moderator */}
@@ -336,7 +362,7 @@ export const EventSettingsTab: React.FC<EventSettingsTabProps> = ({ event, event
         <Typography variant="body2" color="text.secondary" mb={2}>
           {t(
             'teaserImage.description',
-            'Images shown as full-screen slides on the presentation page between topic reveal and agenda preview.'
+            'Images shown as full-screen slides on the presentation page.'
           )}
         </Typography>
 
@@ -350,13 +376,18 @@ export const EventSettingsTab: React.FC<EventSettingsTabProps> = ({ event, event
             {teaserRemoveError}
           </Alert>
         )}
+        {teaserPositionError && (
+          <Alert severity="error" onClose={() => setTeaserPositionError(null)} sx={{ mb: 2 }}>
+            {teaserPositionError}
+          </Alert>
+        )}
 
         {/* Gallery */}
         {teaserImages.length > 0 && (
           <Box
             sx={{
               display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
               gap: 1.5,
               mb: 2,
             }}
@@ -364,37 +395,64 @@ export const EventSettingsTab: React.FC<EventSettingsTabProps> = ({ event, event
             {[...teaserImages]
               .sort((a, b) => a.displayOrder - b.displayOrder)
               .map((img) => (
-                <Box
-                  key={img.id}
-                  sx={{
-                    position: 'relative',
-                    borderRadius: 1,
-                    overflow: 'hidden',
-                    aspectRatio: '16/9',
-                    bgcolor: 'grey.100',
-                  }}
-                >
-                  <img
-                    src={img.imageUrl}
-                    alt=""
-                    style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-                  />
-                  <IconButton
-                    size="small"
-                    onClick={() => void handleDeleteTeaserImage(img.id)}
-                    disabled={isArchived || deleteTeaserImageMutation.isPending}
+                <Stack key={img.id} spacing={0.75}>
+                  <Box
                     sx={{
-                      position: 'absolute',
-                      top: 4,
-                      right: 4,
-                      bgcolor: 'rgba(0,0,0,0.55)',
-                      color: '#fff',
-                      '&:hover': { bgcolor: 'rgba(200,0,0,0.75)' },
+                      position: 'relative',
+                      borderRadius: 1,
+                      overflow: 'hidden',
+                      aspectRatio: '16/9',
+                      bgcolor: 'grey.100',
                     }}
                   >
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </Box>
+                    <img
+                      src={img.imageUrl}
+                      alt=""
+                      style={{
+                        width: '100%',
+                        height: '100%',
+                        objectFit: 'cover',
+                        display: 'block',
+                      }}
+                    />
+                    <IconButton
+                      size="small"
+                      onClick={() => void handleDeleteTeaserImage(img.id)}
+                      disabled={isArchived || deleteTeaserImageMutation.isPending}
+                      sx={{
+                        position: 'absolute',
+                        top: 4,
+                        right: 4,
+                        bgcolor: 'rgba(0,0,0,0.55)',
+                        color: '#fff',
+                        '&:hover': { bgcolor: 'rgba(200,0,0,0.75)' },
+                      }}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
+                  <FormControl size="small" fullWidth disabled={isArchived}>
+                    <InputLabel>{t('teaserImage.position.label', 'Show after')}</InputLabel>
+                    <Select
+                      value={img.presentationPosition}
+                      label={t('teaserImage.position.label', 'Show after')}
+                      onChange={(e) => void handleTeaserImagePositionChange(img.id, e.target.value)}
+                    >
+                      <MenuItem value="AFTER_WELCOME">
+                        {t('teaserImage.position.afterWelcome', 'Welcome slide')}
+                      </MenuItem>
+                      <MenuItem value="AFTER_COMMITTEE">
+                        {t('teaserImage.position.afterCommittee', 'Committee slide')}
+                      </MenuItem>
+                      <MenuItem value="AFTER_TOPIC_REVEAL">
+                        {t('teaserImage.position.afterTopicReveal', 'Topic Reveal slide')}
+                      </MenuItem>
+                      <MenuItem value="AFTER_UPCOMING_EVENTS">
+                        {t('teaserImage.position.afterUpcomingEvents', 'Upcoming Events slide')}
+                      </MenuItem>
+                    </Select>
+                  </FormControl>
+                </Stack>
               ))}
           </Box>
         )}
@@ -470,6 +528,7 @@ export const EventSettingsTab: React.FC<EventSettingsTabProps> = ({ event, event
             >
               <ListItemText
                 primary={rule.name}
+                secondaryTypographyProps={{ component: 'div' }}
                 secondary={
                   <Stack direction="row" spacing={1} alignItems="center">
                     <Typography variant="caption" color="text.secondary">

--- a/web-frontend/src/hooks/useEventTeaserImages.ts
+++ b/web-frontend/src/hooks/useEventTeaserImages.ts
@@ -13,6 +13,7 @@ import { eventApiClient } from '@/services/eventApiClient';
 import type { components } from '@/types/generated/events-api.types';
 
 type TeaserImageUploadUrlRequest = components['schemas']['TeaserImageUploadUrlRequest'];
+type TeaserImageUpdateRequest = components['schemas']['TeaserImageUpdateRequest'];
 
 /**
  * 3-phase upload mutation.
@@ -40,6 +41,18 @@ export const useDeleteTeaserImage = (eventCode: string) => {
 
   return useMutation({
     mutationFn: (imageId: string) => eventApiClient.deleteTeaserImage(eventCode, imageId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['event', eventCode] });
+    },
+  });
+};
+
+export const useUpdateTeaserImagePosition = (eventCode: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ imageId, request }: { imageId: string; request: TeaserImageUpdateRequest }) =>
+      eventApiClient.updateTeaserImage(eventCode, imageId, request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['event', eventCode] });
     },

--- a/web-frontend/src/hooks/usePresentationSections.test.ts
+++ b/web-frontend/src/hooks/usePresentationSections.test.ts
@@ -148,8 +148,18 @@ describe('usePresentationSections', () => {
     const eventWithTeaser = {
       ...MOCK_EVENT,
       teaserImages: [
-        { id: 'img-1', imageUrl: 'https://cdn.batbern.ch/t1.jpg', displayOrder: 0 },
-        { id: 'img-2', imageUrl: 'https://cdn.batbern.ch/t2.jpg', displayOrder: 1 },
+        {
+          id: 'img-1',
+          imageUrl: 'https://cdn.batbern.ch/t1.jpg',
+          displayOrder: 0,
+          presentationPosition: 'AFTER_TOPIC_REVEAL' as const,
+        },
+        {
+          id: 'img-2',
+          imageUrl: 'https://cdn.batbern.ch/t2.jpg',
+          displayOrder: 1,
+          presentationPosition: 'AFTER_TOPIC_REVEAL' as const,
+        },
       ],
     } as PresentationEventDetail;
 
@@ -174,8 +184,18 @@ describe('usePresentationSections', () => {
     const eventWithTeaser = {
       ...MOCK_EVENT,
       teaserImages: [
-        { id: 'img-b', imageUrl: 'https://cdn.batbern.ch/b.jpg', displayOrder: 1 },
-        { id: 'img-a', imageUrl: 'https://cdn.batbern.ch/a.jpg', displayOrder: 0 },
+        {
+          id: 'img-b',
+          imageUrl: 'https://cdn.batbern.ch/b.jpg',
+          displayOrder: 1,
+          presentationPosition: 'AFTER_TOPIC_REVEAL' as const,
+        },
+        {
+          id: 'img-a',
+          imageUrl: 'https://cdn.batbern.ch/a.jpg',
+          displayOrder: 0,
+          presentationPosition: 'AFTER_TOPIC_REVEAL' as const,
+        },
       ],
     } as PresentationEventDetail;
 
@@ -183,6 +203,155 @@ describe('usePresentationSections', () => {
     const teaserSections = result.current.filter((s) => s.type === 'teaser-image');
     expect(teaserSections[0].imageUrl).toBe('https://cdn.batbern.ch/a.jpg');
     expect(teaserSections[1].imageUrl).toBe('https://cdn.batbern.ch/b.jpg');
+  });
+
+  test('places teaser image at AFTER_WELCOME between welcome and about', () => {
+    const eventWithTeaser = {
+      ...MOCK_EVENT,
+      teaserImages: [
+        {
+          id: 'img-w',
+          imageUrl: 'https://cdn.batbern.ch/welcome.jpg',
+          displayOrder: 0,
+          presentationPosition: 'AFTER_WELCOME' as const,
+        },
+      ],
+    } as PresentationEventDetail;
+
+    const { result } = renderHook(() => usePresentationSections(eventWithTeaser, []));
+    const types = result.current.map((s) => s.type);
+    const welcomeIdx = types.indexOf('welcome');
+    const aboutIdx = types.indexOf('about');
+
+    expect(types[welcomeIdx + 1]).toBe('teaser-image');
+    expect(aboutIdx).toBe(welcomeIdx + 2);
+  });
+
+  test('places teaser image at AFTER_COMMITTEE between committee and topic-reveal', () => {
+    const eventWithTeaser = {
+      ...MOCK_EVENT,
+      teaserImages: [
+        {
+          id: 'img-c',
+          imageUrl: 'https://cdn.batbern.ch/committee.jpg',
+          displayOrder: 0,
+          presentationPosition: 'AFTER_COMMITTEE' as const,
+        },
+      ],
+    } as PresentationEventDetail;
+
+    const { result } = renderHook(() => usePresentationSections(eventWithTeaser, []));
+    const types = result.current.map((s) => s.type);
+    const committeeIdx = types.indexOf('committee');
+    const topicIdx = types.indexOf('topic-reveal');
+
+    expect(types[committeeIdx + 1]).toBe('teaser-image');
+    expect(topicIdx).toBe(committeeIdx + 2);
+  });
+
+  test('places teaser image at AFTER_UPCOMING_EVENTS between upcoming-events and apero', () => {
+    const eventWithTeaser = {
+      ...MOCK_EVENT,
+      teaserImages: [
+        {
+          id: 'img-u',
+          imageUrl: 'https://cdn.batbern.ch/upcoming.jpg',
+          displayOrder: 0,
+          presentationPosition: 'AFTER_UPCOMING_EVENTS' as const,
+        },
+      ],
+    } as PresentationEventDetail;
+
+    const { result } = renderHook(() => usePresentationSections(eventWithTeaser, []));
+    const types = result.current.map((s) => s.type);
+    const upcomingIdx = types.indexOf('upcoming-events');
+    const aperoIdx = types.indexOf('apero');
+
+    expect(types[upcomingIdx + 1]).toBe('teaser-image');
+    expect(aperoIdx).toBe(upcomingIdx + 2);
+  });
+
+  test('handles mixed positions — each image at correct slot', () => {
+    const eventWithTeaser = {
+      ...MOCK_EVENT,
+      teaserImages: [
+        {
+          id: 'img-w',
+          imageUrl: 'https://cdn.batbern.ch/welcome.jpg',
+          displayOrder: 0,
+          presentationPosition: 'AFTER_WELCOME' as const,
+        },
+        {
+          id: 'img-t',
+          imageUrl: 'https://cdn.batbern.ch/topic.jpg',
+          displayOrder: 0,
+          presentationPosition: 'AFTER_TOPIC_REVEAL' as const,
+        },
+        {
+          id: 'img-u',
+          imageUrl: 'https://cdn.batbern.ch/upcoming.jpg',
+          displayOrder: 0,
+          presentationPosition: 'AFTER_UPCOMING_EVENTS' as const,
+        },
+      ],
+    } as PresentationEventDetail;
+
+    const { result } = renderHook(() => usePresentationSections(eventWithTeaser, []));
+    const types = result.current.map((s) => s.type);
+
+    // welcome → teaser → about → committee → topic-reveal → teaser → agenda-preview → upcoming-events → teaser → apero
+    expect(types[0]).toBe('welcome');
+    expect(types[1]).toBe('teaser-image'); // AFTER_WELCOME
+    expect(types[2]).toBe('about');
+    const topicIdx = types.indexOf('topic-reveal');
+    expect(types[topicIdx + 1]).toBe('teaser-image'); // AFTER_TOPIC_REVEAL
+    const upcomingIdx = types.indexOf('upcoming-events');
+    expect(types[upcomingIdx + 1]).toBe('teaser-image'); // AFTER_UPCOMING_EVENTS
+    expect(types[types.length - 1]).toBe('apero');
+  });
+
+  test('respects displayOrder within same position', () => {
+    const eventWithTeaser = {
+      ...MOCK_EVENT,
+      teaserImages: [
+        {
+          id: 'img-2',
+          imageUrl: 'https://cdn.batbern.ch/second.jpg',
+          displayOrder: 1,
+          presentationPosition: 'AFTER_WELCOME' as const,
+        },
+        {
+          id: 'img-1',
+          imageUrl: 'https://cdn.batbern.ch/first.jpg',
+          displayOrder: 0,
+          presentationPosition: 'AFTER_WELCOME' as const,
+        },
+      ],
+    } as PresentationEventDetail;
+
+    const { result } = renderHook(() => usePresentationSections(eventWithTeaser, []));
+    const teaserSections = result.current.filter((s) => s.type === 'teaser-image');
+    expect(teaserSections[0].imageUrl).toBe('https://cdn.batbern.ch/first.jpg');
+    expect(teaserSections[1].imageUrl).toBe('https://cdn.batbern.ch/second.jpg');
+  });
+
+  test('defaults missing presentationPosition to AFTER_TOPIC_REVEAL', () => {
+    const eventWithTeaser = {
+      ...MOCK_EVENT,
+      teaserImages: [
+        // presentationPosition intentionally omitted to test fallback
+        { id: 'img-x', imageUrl: 'https://cdn.batbern.ch/x.jpg', displayOrder: 0 },
+      ],
+    } as PresentationEventDetail;
+
+    const { result } = renderHook(() => usePresentationSections(eventWithTeaser, []));
+    const types = result.current.map((s) => s.type);
+    const topicIdx = types.indexOf('topic-reveal');
+    const agendaIdx = types.indexOf('agenda-preview');
+
+    // Should appear between topic-reveal and agenda-preview (default)
+    expect(types[topicIdx + 1]).toBe('teaser-image');
+    expect(agendaIdx).toBe(topicIdx + 2);
   });
 });
 

--- a/web-frontend/src/hooks/usePresentationSections.ts
+++ b/web-frontend/src/hooks/usePresentationSections.ts
@@ -14,6 +14,25 @@ import type { User } from '@/types/user.types';
 import type { components } from '@/types/generated/events-api.types';
 import type { PresentationSettings } from '@/services/presentationService';
 
+type TeaserImageItem = components['schemas']['TeaserImageItem'];
+
+function insertTeaserImages(
+  sections: PresentationSection[],
+  images: TeaserImageItem[],
+  position: string
+): void {
+  [...images]
+    .filter((img) => (img.presentationPosition ?? 'AFTER_TOPIC_REVEAL') === position)
+    .sort((a, b) => a.displayOrder - b.displayOrder)
+    .forEach((img) => {
+      sections.push({
+        type: 'teaser-image',
+        key: `teaser-image-${img.id}`,
+        imageUrl: img.imageUrl,
+      });
+    });
+}
+
 export type SectionType =
   | 'welcome'
   | 'about'
@@ -51,30 +70,23 @@ export function usePresentationSections(
     }
 
     const sections: PresentationSection[] = [];
+    const teaserImages = event.teaserImages ?? [];
 
     // §1 Welcome
     sections.push({ type: 'welcome', key: 'welcome' });
+    insertTeaserImages(sections, teaserImages, 'AFTER_WELCOME');
 
     // §2 About
     sections.push({ type: 'about', key: 'about' });
 
     // §3 Committee
     sections.push({ type: 'committee', key: 'committee' });
+    insertTeaserImages(sections, teaserImages, 'AFTER_COMMITTEE');
 
     // §4 Topic Reveal
     sections.push({ type: 'topic-reveal', key: 'topic-reveal' });
-
-    // §4.5 Teaser Images — one full-screen slide per image (Story 10.22 AC5)
-    const teaserImages = event.teaserImages ?? [];
-    [...teaserImages]
-      .sort((a, b) => a.displayOrder - b.displayOrder)
-      .forEach((img) => {
-        sections.push({
-          type: 'teaser-image',
-          key: `teaser-image-${img.id}`,
-          imageUrl: img.imageUrl,
-        });
-      });
+    // §4.5 Teaser Images at AFTER_TOPIC_REVEAL (Story 10.22 AC5; default position)
+    insertTeaserImages(sections, teaserImages, 'AFTER_TOPIC_REVEAL');
 
     // §5 Agenda Preview
     sections.push({ type: 'agenda-preview', key: 'agenda-preview' });
@@ -141,6 +153,7 @@ export function usePresentationSections(
 
     // Upcoming Events
     sections.push({ type: 'upcoming-events', key: 'upcoming-events' });
+    insertTeaserImages(sections, teaserImages, 'AFTER_UPCOMING_EVENTS');
 
     // Apéro
     sections.push({ type: 'apero', key: 'apero' });

--- a/web-frontend/src/services/eventApiClient.ts
+++ b/web-frontend/src/services/eventApiClient.ts
@@ -35,6 +35,7 @@ type TeaserImageItem = components['schemas']['TeaserImageItem'];
 type TeaserImageUploadUrlRequest = components['schemas']['TeaserImageUploadUrlRequest'];
 type TeaserImageUploadUrlResponse = components['schemas']['TeaserImageUploadUrlResponse'];
 type TeaserImageConfirmRequest = components['schemas']['TeaserImageConfirmRequest'];
+type TeaserImageUpdateRequest = components['schemas']['TeaserImageUpdateRequest'];
 
 // API base path for event endpoints
 const EVENT_API_PATH = '/events';
@@ -551,6 +552,22 @@ class EventApiClient {
     try {
       const response = await apiClient.post<TeaserImageItem>(
         `${EVENT_API_PATH}/${eventCode}/teaser-images/confirm`,
+        request
+      );
+      return response.data;
+    } catch (error) {
+      throw this.transformError(error);
+    }
+  }
+
+  async updateTeaserImage(
+    eventCode: string,
+    imageId: string,
+    request: TeaserImageUpdateRequest
+  ): Promise<TeaserImageItem> {
+    try {
+      const response = await apiClient.patch<TeaserImageItem>(
+        `${EVENT_API_PATH}/${eventCode}/teaser-images/${imageId}`,
         request
       );
       return response.data;

--- a/web-frontend/src/types/generated/events-api.types.ts
+++ b/web-frontend/src/types/generated/events-api.types.ts
@@ -2187,7 +2187,8 @@ export interface paths {
     delete: operations['deleteTeaserImage'];
     options?: never;
     head?: never;
-    patch?: never;
+    /** Update presentation position of a teaser image */
+    patch: operations['updateTeaserImage'];
     trace?: never;
   };
   '/admin/export/legacy': {
@@ -2479,6 +2480,15 @@ export interface components {
       photoId: string;
       s3Key: string;
     };
+    /**
+     * @description Controls which slide the image appears after in the moderator presentation.
+     * @enum {string}
+     */
+    TeaserImagePresentationPosition:
+      | 'AFTER_WELCOME'
+      | 'AFTER_COMMITTEE'
+      | 'AFTER_TOPIC_REVEAL'
+      | 'AFTER_UPCOMING_EVENTS';
     /** @description A single teaser image for the moderator presentation page. */
     TeaserImageItem: {
       /**
@@ -2497,6 +2507,10 @@ export interface components {
        * @example 0
        */
       displayOrder: number;
+      presentationPosition: components['schemas']['TeaserImagePresentationPosition'];
+    };
+    TeaserImageUpdateRequest: {
+      presentationPosition: components['schemas']['TeaserImagePresentationPosition'];
     };
     TeaserImageUploadUrlRequest: {
       /**
@@ -8631,6 +8645,43 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      /** @description Teaser image not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  updateTeaserImage: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @example BATbern57 */
+        eventCode: string;
+        imageId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TeaserImageUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description Teaser image updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['TeaserImageItem'];
+        };
       };
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];


### PR DESCRIPTION
## Summary

- Adds a `presentationPosition` field to each teaser image, letting the organizer choose where it appears in the moderator presentation
- Four positions: **After Welcome**, **After Committee**, **After Topic Reveal** (default — preserves existing behaviour), **After Upcoming Events**
- Multiple images can share the same position; they appear in `displayOrder` order at that slot

## Changes

**Backend**
- V81 migration: `presentation_position VARCHAR(30) NOT NULL DEFAULT 'AFTER_TOPIC_REVEAL'` with CHECK constraint
- New `PATCH /api/v1/events/{eventCode}/teaser-images/{imageId}` endpoint (ORGANIZER only)
- OpenAPI: `TeaserImagePresentationPosition` enum, `TeaserImageUpdateRequest` schema, extended `TeaserImageItem`
- TDD: unit + integration tests for new endpoint and field mapping

**Frontend**
- Position `<Select>` dropdown below each image thumbnail in the Teaser Images gallery (EventSettingsTab)
- `useUpdateTeaserImagePosition` mutation hook
- `usePresentationSections`: `insertTeaserImages()` helper called at 4 insertion points instead of one hardcoded slot
- i18n keys added to EN + DE locales

**Fix**
- `ListItemText` in notification rules: added `secondaryTypographyProps={{ component: 'div' }}` to fix invalid `<div>` inside `<p>` hydration warning

## Test plan

- [ ] Upload a teaser image → dropdown shows "Topic Reveal slide" by default
- [ ] Change to "Welcome slide" → PATCH 200 → image appears between welcome and about in `/present/{eventCode}`
- [ ] Change to "Upcoming Events slide" → image moves to end (before apéro)
- [ ] Two images at same position → both appear, sorted by displayOrder
- [ ] Backend tests: `EventTeaserImageServiceTest` + `EventTeaserImageControllerIntegrationTest` all pass
- [ ] Frontend: `usePresentationSections.test.ts` 21/21 pass, type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)