### PR TITLE
docs: align documentation with code changes from issues #560, #572, #577

### DIFF
--- a/docs/architecture/06-backend-architecture.md
+++ b/docs/architecture/06-backend-architecture.md
@@ -72,6 +72,16 @@ The following endpoints are accessible without any token at the domain-service l
 | `POST /api/v1/events/{code}/registrations` | Attendee registration creation |
 | `POST /api/v1/events/{code}/registrations/confirm` | Registration confirmation |
 
+**VPC-Internal Endpoints (no JWT required):**
+
+Some endpoints are designed for cross-service communication within the VPC only. These are protected by `VpcInternalAuthorizationManager` (which validates the request originates from within the VPC) rather than JWT-based role checks. Example:
+
+| Pattern | Service | Notes |
+|---|---|---|
+| `GET /api/v1/users/by-company` | Company-User Management | Used by partner-coordination-service to fetch contacts without requiring an organizer JWT |
+
+This pattern avoids the need to forward end-user JWTs for internal service-to-service calls that don't require user-level authorization.
+
 Role-gated endpoints (e.g. `POST /api/v1/events`, organizer-only mutations) are enforced at the **API Gateway** layer before requests reach domain services.
 
 ```java
@@ -602,6 +612,38 @@ public class RoleManagementService {
     }
 }
 ```
+
+## Newsletter Async Processing
+
+The newsletter send system uses an asynchronous fire-and-forget pattern to handle large recipient lists without blocking the API or exhausting thread pools:
+
+- **Trigger**: `POST /api/v1/events/{code}/newsletter/send` returns `202 Accepted` immediately
+- **Processing**: `@Async` method sends emails sequentially with SES rate limiting (~70ms/email to stay within SES quotas)
+- **Progress tracking**: `newsletter_send_status` table tracks state (`PENDING` → `IN_PROGRESS` → `COMPLETED` / `PARTIAL` / `FAILED`), with `sent_count` and `total_count` for progress polling
+- **Duplicate prevention**: A second send attempt while `IN_PROGRESS` returns `409 Conflict`
+- **Retry**: Dedicated retry endpoint to re-send only failed recipients from a previous partial/failed send
+- **Orphan recovery**: On service startup, any stuck `IN_PROGRESS` records (from a crash mid-send) are reset to `FAILED` for manual retry
+
+## Email Forwarding (Serverless)
+
+Inbound email forwarding for platform mailboxes (ok@, info@, events@, partner@, support@, batbernNN@batbern.ch) is handled entirely serverlessly:
+
+```
+SES Receipt Rule → S3 (raw email) → Lambda (email-forwarder)
+                                          ├─ address-resolver: maps inbox → recipients via role/registration APIs
+                                          ├─ sender-auth: validates sender
+                                          ├─ email-rewriter: rewrites From/Reply-To headers
+                                          └─ SES sendRawEmail → forwarded to resolved recipients
+```
+
+- **Environment isolation**: Staging uses `replies@staging.batbern.ch`; production uses `replies@batbern.ch` (separate MX records and SES receipt rules)
+- **Outbound sender**: Staging uses `noreply@berner-architekten-treffen.ch` (verified SES domain); production uses `noreply@batbern.ch`
+- **Sender exclusion**: The original sender is excluded from forwarding recipients to prevent bounce loops
+- **Admin configuration**: Organizers can manage forwarding rules via Admin Settings UI
+
+## Auto-Enrollment on Event Creation
+
+When a new event is created, an `EventCreatedEvent` listener automatically enrolls all active organizers and partner contacts as stakeholders. A manual quick-action button is also available for idempotent re-enrollment (`POST` endpoint returns success even if already enrolled).
 
 ## Real-time Notifications and Escalation
 

--- a/docs/architecture/06a-workflow-state-machines.md
+++ b/docs/architecture/06a-workflow-state-machines.md
@@ -495,6 +495,25 @@ public class EventTaskService implements ApplicationListener<EventWorkflowTransi
     }
 
     /**
+     * Delete a task (ORGANIZER only).
+     * Default template tasks cannot be deleted — throws IllegalStateException (HTTP 400).
+     * Custom tasks are permanently removed.
+     */
+    @Transactional
+    public void deleteTask(UUID taskId, String deletedBy) {
+        EventTask task = eventTaskRepository.findById(taskId)
+            .orElseThrow(() -> new EntityNotFoundException("Task not found: " + taskId));
+
+        if (task.getTemplateId() != null && taskTemplateRepository.findById(task.getTemplateId())
+                .map(TaskTemplate::isDefault).orElse(false)) {
+            throw new IllegalStateException("Cannot delete default template task");
+        }
+
+        eventTaskRepository.delete(task);
+        log.info("Task '{}' deleted by {}", task.getTaskName(), deletedBy);
+    }
+
+    /**
      * Get tasks for organizer
      */
     public List<EventTask> getTasksForOrganizer(String username) {
@@ -513,6 +532,8 @@ Organizers see tasks grouped by status:
 **Critical tasks filter:** `getCriticalTasksForOrganizer()` returns only tasks that are overdue or due within the next 3 days. This is separate from the status-based grouping above.
 
 **Task reassignment:** `reassignTask(taskId, newOrganizerUsername)` allows changing the assigned organizer on any open task.
+
+**Task deletion:** `DELETE /api/v1/events/{code}/tasks/{taskId}` (ORGANIZER only). Default template tasks cannot be deleted — throws `IllegalStateException` (HTTP 400). Custom tasks are permanently removed. The frontend shows a red delete `IconButton` on Kanban cards with a confirmation dialog.
 
 **Task creation idempotency:** Calling `createTasksForEvent` twice for the same template/event pair does not create duplicate tasks. The creation guard prevents duplicates even if a workflow transition event is replayed.
 
@@ -667,6 +688,8 @@ public class QualityReviewService {
 - `submission_version` — version counter for resubmissions
 
 ## Overflow Management & Voting System
+
+> **Scope Note (2026-01-24):** Overflow Management (Story 5.6) was **removed from MVP scope**. Manual speaker selection by organizers is sufficient for launch. Democratic voting on overflow speakers is deferred to Phase 2+ backlog. The design below is retained as a reference for the future implementation.
 
 ```java
 @Service

--- a/docs/architecture/08-operations-security.md
+++ b/docs/architecture/08-operations-security.md
@@ -7,7 +7,9 @@ This document consolidates security implementation, performance standards, acces
 ### Frontend Security
 - **CSP Headers**: Strict content security policy with CloudFront CDN support
   - `connect-src`: Allows connections to self, AWS Cognito, CloudFront CDN (`*.cloudfront.net`), and branded CDN domain (`cdn.batbern.ch`)
-  - Configured in `SecurityHeadersFilter.java` for API Gateway
+  - `frame-src`: Allows Google Maps embeds (`https://www.google.com/maps/`)
+  - Configured in `SecurityHeadersFilter.java` (API Gateway) and `SecurityHeadersHandler.java`
+- **COEP/CORP**: Cross-Origin-Embedder-Policy (COEP) header **removed** to allow third-party embeds (Google Maps). Cross-Origin-Resource-Policy (CORP) relaxed from `same-origin` to `cross-origin` for CDN asset delivery.
 - **XSS Prevention**: Input sanitization and output encoding
 - **Secure Storage**: Encrypted localStorage for sensitive data
 
@@ -20,6 +22,18 @@ This document consolidates security implementation, performance standards, acces
 - **Token Storage**: Secure JWT storage with automatic refresh
 - **Session Management**: Cognito-based session management
 - **Password Policy**: Strong password requirements
+
+## Cost Optimizations (2026-03)
+
+The following cost optimizations were applied to the production (staging) environment:
+
+| Change | Savings | Rationale |
+|--------|---------|-----------|
+| **Container Insights V2 disabled** | ~$48/month | Not justified for current low traffic volume |
+| **RDS backup retention reduced** 14 → 7 days | ~$4/month | 7 days sufficient for a low-traffic community platform |
+| **Bastion auto-stop on tunnel close** | ~$2/month | `start-db-tunnel.sh` now automatically stops the bastion EC2 instance when the SSH tunnel is closed |
+
+**`isProd` bug fix (2026-03-22):** The `cluster-stack.ts` and `incident-management-stack.ts` stacks were incorrectly using `envName === 'production'` to determine production behavior. Since the consolidated environment uses `envName: 'staging'` but serves production traffic, this was changed to use `config.isProduction` (which is `true`). This ensures production-grade behavior (alerts, scaling) is correctly applied.
 
 ## Performance Benchmarks and SLAs
 

--- a/docs/prd/epic-5-enhanced-organizer-workflows.md
+++ b/docs/prd/epic-5-enhanced-organizer-workflows.md
@@ -2,7 +2,7 @@
 
 **Status:** ✅ **COMPLETE** - MVP Ready (8/8 stories, 100%)
 
-**Last Updated:** 2026-01-24
+**Last Updated:** 2026-03-23
 **Completed:** 2026-01-24
 
 **Workflow Redesign (2025-12-19):** Epic 5 has been redesigned from a linear 16-step workflow to a parallel workflow architecture with 8 event states, per-speaker workflows, and configurable task management. This reflects the actual implementation reality discovered during Stories 5.1-5.4.
@@ -1287,3 +1287,30 @@ As an **organizer**, I want to coordinate partner meetings scheduled on same day
 - Partner Coordination Service: Step 16 (partner meetings) - extends Story 2.7
 - Frontend: React organizer dashboard with workflow interface
 - Infrastructure: AWS SES integration for newsletters (Story 5.12)
+
+---
+
+## Post-MVP Enhancements (2026-03)
+
+The following enhancements were delivered after Epic 5 was marked complete, extending the event management and organizer workflow capabilities:
+
+### Newsletter Improvements
+- **Subscriber management page** — Paginated, searchable, sortable list of newsletter subscribers with unsubscribe/resubscribe/delete actions. Backend sort migration from in-memory to database-driven sorting.
+- **Async newsletter send** — Fixed critical P0 thread-pool overflow bug (~2890/3000 emails lost). Replaced synchronous send with `@Async` fire-and-forget pattern, progress polling, SES rate limiting (70ms/email), status tracking (`PENDING` → `IN_PROGRESS` → `COMPLETED` / `PARTIAL` / `FAILED`), duplicate prevention (409), and retry endpoint for partial failures.
+
+### Task System Enhancements
+- **Task deletion** — `DELETE /api/v1/events/{code}/tasks/{taskId}` (ORGANIZER only). Default template tasks cannot be deleted. Red delete IconButton on Kanban cards with confirmation dialog.
+
+### Event Management Enhancements
+- **Global teaser images** — Teaser images can now be uploaded without being linked to a specific event (`event_code` nullable in V90 migration). GlobalImagesTab in admin UI supports multilingual metadata (10 locales). Presentation pages merge global images with event-specific ones.
+- **Auto-enrollment** — Organizers and partners are automatically enrolled as stakeholders when a new event is created (`EventCreatedEvent` listener). Quick-action button available for manual idempotent re-enrollment.
+- **Session materials deletion** — Delete button added for uploaded session materials (speaker presentations).
+
+### Public Website Enhancements
+- **Structural session filtering** — Break, lunch, and networking sessions are filtered out of public SessionCards grid.
+- **Post-event materials** — Materials download block shown in POST_EVENT and ARCHIVE phases via presigned URLs.
+- **Registration CTA visibility** — Register button hidden for COMING_SOON, POST_EVENT, and ARCHIVE phases.
+
+### Email Infrastructure
+- **SES email forwarding** — Serverless forwarding for 6 platform inboxes via SES receipt rules + Lambda. See [Backend Architecture: Email Forwarding](../architecture/06-backend-architecture.md#email-forwarding-serverless).
+- **Environment-specific email routing** — Staging and production use separate SES domains and reply-to addresses.

--- a/docs/prd/epic-8-partner-coordination.md
+++ b/docs/prd/epic-8-partner-coordination.md
@@ -1,6 +1,7 @@
 # Epic 8: Partner Coordination
 
 **Status:** ✅ **COMPLETE** — Stories 8.0–8.4 done (deployed to staging 2026-02-22; Story 8.4 Partner Notes added 2026-02-23)
+**Last Updated:** 2026-03-23
 
 **Simplified (2026-02-21):** Epic 8 was originally scoped with QuickSight, Microsoft Graph, materialized views, and tier-based voting. These were cut as massively over-engineered for a community of ~5–10 partners and ~3 events/year. The three stories below reflect what was actually decided and built.
 
@@ -145,17 +146,27 @@ As an **organizer**, I want to manage the Spring and Autumn partner meetings, so
 - Meeting list: all past and upcoming meetings with status (invite sent / not sent)
 - Organizer-only access (partners do not interact with this screen)
 
-**What was cut:**
+**Post-MVP Enhancements (2026-03):**
+- **Meeting edit/delete** — `EditMeetingDialog` UI, `DELETE` endpoint sends `METHOD:CANCEL` ICS to all attendees
+- **Inline iCal** — Calendar invites sent with `Content-Disposition: inline` for better client compatibility
+- **Session-based VEVENT times** — Meeting VEVENT times derived from linked session start/end times; event-code prefix in SUMMARY
+- **Collapsible meeting cards** — UI shows time and agenda in collapsible partner meeting cards
+- **iCal RSVP tracking** — V9 migration adds `partner_meeting_rsvps` table. Inbound email router parses `METHOD:REPLY` ICS responses. `PartnerMeetingRsvpPanel` UI shows RSVP status per partner with auto-refresh. Endpoints:
+  - `POST /api/v1/partner-meetings/{meetingId}/rsvps` — Upsert RSVP from parsed iCal reply
+  - `GET  /api/v1/partner-meetings/{meetingId}/rsvps` — List RSVPs for a meeting
+  - `GET  /api/v1/partner-meetings/{meetingId}/rsvps/summary` — Grouped RSVP summary (accepted/declined/tentative)
+
+**What was cut (original scope):**
 - Microsoft Graph / Outlook API integration — standard ICS works with any calendar app
 - Automated Spring/Autumn scheduling — date comes from the BATbern event
-- RSVP tracking (attending / not attending / tentative)
+- ~~RSVP tracking (attending / not attending / tentative)~~ — **now implemented** via iCal REPLY parsing (2026-03)
 - Automated reminder emails
 - Attendance prediction
-- Cancellation and rescheduling handling
+- ~~Cancellation and rescheduling handling~~ — **delete with METHOD:CANCEL now implemented** (2026-03)
 - Pre-meeting pack compilation, material distribution
 - Post-meeting follow-up email
 - EventBridge scheduled rules
-- `meeting_rsvps` and `meeting_materials` tables
+- ~~`meeting_rsvps` and `meeting_materials` tables~~ — `partner_meeting_rsvps` **now implemented** (V9 migration, 2026-03); `meeting_materials` still cut
 
 **Architecture:**
 ```
@@ -177,6 +188,8 @@ PartnerMeetingController (202 Accepted immediately)
 - `GET  /api/v1/partner-meetings/{meetingId}` (ORGANIZER)
 - `PATCH /api/v1/partner-meetings/{meetingId}` — agenda or notes update (ORGANIZER)
 - `POST /api/v1/partner-meetings/{meetingId}/send-invite` → 202 Accepted (ORGANIZER)
+- `PUT  /api/v1/partner-meetings/{meetingId}` — Edit meeting (ORGANIZER)
+- `DELETE /api/v1/partner-meetings/{meetingId}` — Delete meeting + send METHOD:CANCEL ICS (ORGANIZER)
 
 **Performance targets:** Meeting list P95 < 3s | Invite 202 response < 200ms (async send)
 
@@ -218,12 +231,12 @@ As an **organizer**, I want to record and manage private notes about a partner c
 | Microsoft Graph / Outlook calendar integration | Standard ICS (RFC 5545) works everywhere |
 | Tier-based vote weighting + influence cap algorithm | 5–10 partners; simple count is fair |
 | Drag-and-drop topic ranking (react-beautiful-dnd) | Sort by vote count is enough |
-| RSVP tracking | Not needed |
+| ~~RSVP tracking~~ | **Now implemented** (2026-03) — iCal REPLY parsing + `partner_meeting_rsvps` table |
 | Automated Spring/Autumn scheduling | Date comes from the BATbern event |
 | EventBridge scheduled rules | Not needed |
 | Automated reminder emails, attendance prediction | Not needed |
 | Pre-meeting pack, material distribution | Not needed |
-| `meeting_rsvps` + `meeting_materials` tables | Not needed |
+| ~~`meeting_rsvps`~~ + `meeting_materials` tables | `partner_meeting_rsvps` **now implemented** (2026-03); `meeting_materials` still cut |
 | Mobile-responsive analytics layout | Desktop only for partner portal |
 | Department breakdown, comparative analytics | No department data tracked; anonymized comparison not needed |
 | Individual attendee tracking | Not allowed (GDPR) |

--- a/docs/user-guide/features/file-uploads.md
+++ b/docs/user-guide/features/file-uploads.md
@@ -6,6 +6,8 @@ The BATbern file upload system provides secure, direct-to-S3 file handling for:
 
 - **Company Logos** - Brand images for partner directories and event materials
 - **Speaker Materials** - Presentation slides, handouts, and supporting documents
+- **Event Photos** - Multi-file photo uploads with parallel presigned URL generation
+- **Event Teaser Images** - Global or event-specific teaser images with multilingual metadata
 - **Event Assets** - Venue maps, promotional images, sponsor materials `[PLANNED]`
 
 The system uses **presigned S3 URLs** to enable secure, direct browser-to-cloud uploads without proxying files through the backend, ensuring:
@@ -142,6 +144,11 @@ sequenceDiagram
    - Speaker status updates to "Material Submitted"
    - Notification sent to speaker confirming receipt
    - File available for organizer review and attendee distribution
+
+7. **Deleting Materials**
+   - Click the delete button next to an uploaded material file
+   - Confirm deletion in the dialog
+   - File is removed from S3 and the session record is updated
 
 ### Supported File Formats
 

--- a/docs/user-guide/features/notifications.md
+++ b/docs/user-guide/features/notifications.md
@@ -14,7 +14,7 @@ The system is designed to reduce manual monitoring while preventing information 
 
 | Channel | Status | Details |
 |---------|--------|---------|
-| Transactional Email | ✅ `[IMPLEMENTED]` | Speaker invitations, deadline reminders, registration confirmations, partner calendar invites |
+| Transactional Email | ✅ `[IMPLEMENTED]` | Speaker invitations, deadline reminders, registration confirmations, partner calendar invites, email forwarding & distribution lists |
 | In-App Notification Center | 🔨 `[IN PROGRESS]` | Notification feed with mark-as-read, delete, and full-page view |
 | Notification Preferences & Rules | 📋 `[PLANNED]` | Per-event settings, quiet hours, digest scheduling, escalation configuration |
 
@@ -49,6 +49,19 @@ RFC 5545 `.ics` calendar invites delivered via email to partners. Each file cont
 ### Task Deadline Reminders (Epic 5)
 
 Organizers receive email reminders for tasks approaching their due dates. Timing is controlled by the task template's trigger configuration (e.g., 1 day before deadline). See [Task System](../workflow/task-system.md).
+
+### Email Forwarding & Distribution Lists (2026-03)
+
+The platform provides serverless email forwarding for 6 inboxes: `ok@`, `info@`, `events@`, `partner@`, `support@`, and `batbernNN@batbern.ch`. Emails received at these addresses are automatically forwarded to the appropriate recipients based on their role or event registration status:
+
+- **Dynamic recipient resolution** — Lambda resolves recipients via role-based and registration-based API calls
+- **Sender exclusion** — Original sender is excluded from forwarding to prevent bounce loops
+- **Environment isolation** — Staging uses `replies@staging.batbern.ch` with `noreply@berner-architekten-treffen.ch`; production uses `replies@batbern.ch` with `noreply@batbern.ch`
+- **Admin configuration** — Organizers manage forwarding rules via Admin Settings UI
+
+### Partner Meeting iCal RSVP Parsing (2026-03)
+
+When partners reply to calendar invites (Accept / Decline / Tentative), the platform's inbound email handler automatically parses `METHOD:REPLY` ICS attachments and updates the RSVP status in the `partner_meeting_rsvps` table. Organizers see RSVP status in the Partner Meeting management UI.
 
 ---
 


### PR DESCRIPTION
- 06-backend-architecture: add VPC-internal endpoints pattern, newsletter
  async processing, email forwarding Lambda architecture, auto-enrollment
- 06a-workflow-state-machines: mark overflow voting as deferred (Story 5.6),
  add task deletion capability and documentation
- 08-operations-security: update CSP headers (frame-src for Google Maps),
  document COEP removal, add cost optimizations section, isProd bug fix
- epic-5 PRD: add post-MVP enhancements section (newsletter improvements,
  task deletion, global teaser images, auto-enrollment, session materials
  deletion, structural session filtering, email forwarding)
- epic-8 PRD: add meeting edit/delete, iCal RSVP tracking, update
  cut-features table to reflect re-implemented capabilities
- file-uploads user guide: add multi-file photo uploads, teaser images,
  session materials deletion
- notifications user guide: add email forwarding & distribution lists,
  iCal RSVP parsing, update implementation status table

Closes #560, Closes #572, Closes #577

https://claude.ai/code/session_01QJExkXPR8MG89621Bu39Kk