### PR TITLE
fix: allow Cloudflare Turnstile domain in Content Security Policy

### DIFF
--- a/api-gateway/src/main/java/ch/batbern/gateway/security/SecurityHeadersFilter.java
+++ b/api-gateway/src/main/java/ch/batbern/gateway/security/SecurityHeadersFilter.java
@@ -84,8 +84,9 @@ public class SecurityHeadersFilter implements Filter {
         // Default source - only from same origin
         csp.append("default-src 'self'; ");
 
-        // Script sources - self and inline (for React apps)
-        csp.append("script-src 'self' 'unsafe-inline' 'unsafe-eval'; ");
+        // Script sources - self and inline (for React apps) + Cloudflare Turnstile
+        csp.append("script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com; ");
+        csp.append("script-src-elem 'self' 'unsafe-inline' https://challenges.cloudflare.com; ");
 
         // Style sources - self and inline (for Material-UI)
         csp.append("style-src 'self' 'unsafe-inline'; ");
@@ -96,11 +97,11 @@ public class SecurityHeadersFilter implements Filter {
         // Font sources - self and data URIs
         csp.append("font-src 'self' data:; ");
 
-        // Connect sources (for API calls) - self, AWS Cognito, and CloudFront CDN
-        csp.append("connect-src 'self' https://cognito-idp.eu-central-1.amazonaws.com https://*.cloudfront.net https://cdn.batbern.ch https://cdn.staging.batbern.ch; ");
+        // Connect sources (for API calls) - self, AWS Cognito, CloudFront CDN, and Cloudflare Turnstile
+        csp.append("connect-src 'self' https://cognito-idp.eu-central-1.amazonaws.com https://*.cloudfront.net https://cdn.batbern.ch https://cdn.staging.batbern.ch https://challenges.cloudflare.com; ");
 
-        // Frame sources - allow Google Maps embeds on public pages
-        csp.append("frame-src 'self' https://maps.google.com https://www.google.com; ");
+        // Frame sources - allow Google Maps embeds and Cloudflare Turnstile
+        csp.append("frame-src 'self' https://maps.google.com https://www.google.com https://challenges.cloudflare.com; ");
 
         // Object sources - none (prevent Flash/Java/ActiveX)
         csp.append("object-src 'none'; ");

--- a/api-gateway/src/main/java/ch/batbern/gateway/security/SecurityHeadersHandler.java
+++ b/api-gateway/src/main/java/ch/batbern/gateway/security/SecurityHeadersHandler.java
@@ -51,8 +51,9 @@ public class SecurityHeadersHandler {
         // Default source
         csp.append("default-src 'self'; ");
 
-        // Script sources
-        csp.append("script-src 'self' 'unsafe-inline'; ");
+        // Script sources + Cloudflare Turnstile
+        csp.append("script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; ");
+        csp.append("script-src-elem 'self' 'unsafe-inline' https://challenges.cloudflare.com; ");
 
         // Style sources
         csp.append("style-src 'self' 'unsafe-inline'; ");
@@ -60,18 +61,18 @@ public class SecurityHeadersHandler {
         // Image sources
         csp.append("img-src 'self' data: https:; ");
 
-        // Connect sources (for API calls)
+        // Connect sources (for API calls) + Cloudflare Turnstile
         if (isLocalhost(request)) {
-            csp.append("connect-src 'self' http://localhost:* https://api.batbern.ch; ");
+            csp.append("connect-src 'self' http://localhost:* https://api.batbern.ch https://challenges.cloudflare.com; ");
         } else {
-            csp.append("connect-src 'self' https://api.batbern.ch; ");
+            csp.append("connect-src 'self' https://api.batbern.ch https://challenges.cloudflare.com; ");
         }
 
         // Font sources
         csp.append("font-src 'self'; ");
 
-        // Frame sources - allow Google Maps embeds on public pages
-        csp.append("frame-src 'self' https://maps.google.com https://www.google.com; ");
+        // Frame sources - allow Google Maps embeds and Cloudflare Turnstile
+        csp.append("frame-src 'self' https://maps.google.com https://www.google.com https://challenges.cloudflare.com; ");
 
         // Object sources
         csp.append("object-src 'none'; ");

--- a/infrastructure/lib/stacks/frontend-stack.ts
+++ b/infrastructure/lib/stacks/frontend-stack.ts
@@ -160,13 +160,14 @@ function handler(event) {
         contentSecurityPolicy: {
           contentSecurityPolicy:
             "default-src 'self'; " +
-            "script-src 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://cdn.tiny.cloud; " +
+            "script-src 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://cdn.tiny.cloud https://challenges.cloudflare.com; " +
+            "script-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.tiny.cloud https://challenges.cloudflare.com; " +
             "worker-src 'self' blob: https://cdn.jsdelivr.net; " +
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.tiny.cloud https://cdn.jsdelivr.net; " +
             "img-src 'self' data: https:; " +
             "font-src 'self' data: https://fonts.gstatic.com https://assets.unicorn.studio https://cdn.tiny.cloud; " +
-            "connect-src 'self' blob: https://*.amazonaws.com https://*.amazoncognito.com https://*.cloudfront.net https://fonts.googleapis.com https://fonts.gstatic.com https://storage.googleapis.com https://api.staging.batbern.ch https://api.batbern.ch https://cdn.tiny.cloud https://cdn.jsdelivr.net; " +
-            "frame-src 'self' https://maps.google.com https://www.google.com; " +
+            "connect-src 'self' blob: https://*.amazonaws.com https://*.amazoncognito.com https://*.cloudfront.net https://fonts.googleapis.com https://fonts.gstatic.com https://storage.googleapis.com https://api.staging.batbern.ch https://api.batbern.ch https://cdn.tiny.cloud https://cdn.jsdelivr.net https://challenges.cloudflare.com; " +
+            "frame-src 'self' https://maps.google.com https://www.google.com https://challenges.cloudflare.com; " +
             "object-src 'none'; " +
             "base-uri 'self'; " +
             "form-action 'self'; " +

--- a/infrastructure/lib/stacks/frontend-stack.ts
+++ b/infrastructure/lib/stacks/frontend-stack.ts
@@ -161,7 +161,7 @@ function handler(event) {
           contentSecurityPolicy:
             "default-src 'self'; " +
             "script-src 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://cdn.tiny.cloud https://challenges.cloudflare.com; " +
-            "script-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.tiny.cloud https://challenges.cloudflare.com; " +
+            "script-src-elem 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://cdn.tiny.cloud https://challenges.cloudflare.com; " +
             "worker-src 'self' blob: https://cdn.jsdelivr.net; " +
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.tiny.cloud https://cdn.jsdelivr.net; " +
             "img-src 'self' data: https:; " +


### PR DESCRIPTION
Fixes #614

Adds `https://challenges.cloudflare.com` to `script-src`, `script-src-elem`, `frame-src`, and `connect-src` in the CloudFront response headers policy and API Gateway security headers.

> **Note:** Requires a CDK infrastructure deploy to take effect in production.

Generated with [Claude Code](https://claude.ai/code)