### PR TITLE
docs: update user-guide for email, public event times, and CC forwarding fixes (#613)

### DIFF
--- a/docs/user-guide/appendix/changelog.md
+++ b/docs/user-guide/appendix/changelog.md
@@ -8,8 +8,8 @@ Version history and release notes for the BATbern platform. Releases follow [Sem
 - **MINOR**: New features (backward compatible)
 - **PATCH**: Bug fixes and minor improvements
 
-**Current Version**: v1.2.1
-**Last Updated**: 2026-02-27
+**Current Version**: v1.2.2
+**Last Updated**: 2026-04-07
 
 ---
 
@@ -52,6 +52,19 @@ Each release includes:
 ---
 
 ## v1.2.x - Current Release
+
+### v1.2.2 - Email & Public Event Page Fixes `[2026-04-07]`
+
+**Type**: Patch Release
+
+**Bug Fixes**:
+- ✅ Registration confirmation emails and ICS calendar attachments now use the correct, resolved event start and end times (previously used placeholder/incorrect values)
+- ✅ Email forwarding Lambda now correctly forwards CC addresses as mailing-list recipients, and recognises all `batbernNN@batbern.ch` address variants
+- ✅ Public event page now shows resolved start **and** end times (not just the event date)
+- ✅ Newsletter subscriber list: registered-user icon corrected; subscriber display names improved for readability
+- ✅ TypeScript 7 compatibility: deprecated `baseUrl`-only `tsconfig.json` options resolved; removed stale lucide icon imports
+
+---
 
 ### v1.2.1 - Speaker JWT Magic Link Authentication `[2026-02-23]`
 
@@ -447,7 +460,8 @@ Each release includes:
 
 | Version | Status | Support End Date |
 |---------|--------|------------------|
-| v1.2.1 | **Current** | Until v1.3.0 release |
+| v1.2.2 | **Current** | Until v1.3.0 release |
+| v1.2.1 | Security fixes only | Until v1.3.0 release |
 | v1.2.0 | Security fixes only | Until v1.3.0 release |
 | v1.1.x | Security fixes only | 2026-05-01 |
 | v0.9.x | Unsupported | Ended 2026-01-01 |

--- a/docs/user-guide/entity-management/events.md
+++ b/docs/user-guide/entity-management/events.md
@@ -179,7 +179,7 @@ See [Workflow System](../workflow/README.md) for complete workflow documentation
 **Event Date & Time**:
 - Primary conference date and time
 - Used for countdown timers
-- Displayed on event landing pages
+- Displayed on event landing pages — the resolved start **and** end times are shown on the public event page so that prospective attendees see the full duration at a glance
 
 **Registration Window**:
 - **Registration Opens**: When public can register

--- a/docs/user-guide/features/notifications.md
+++ b/docs/user-guide/features/notifications.md
@@ -40,7 +40,7 @@ Three-tier escalation triggered automatically before the content submission dead
 
 ### Registration Confirmation Emails (Epic 4)
 
-Sent automatically when an attendee completes event registration. Includes event details and a QR code for day-of check-in.
+Sent automatically when an attendee completes event registration. Includes event details (including the event's start and end times), a QR code for day-of check-in, and an `.ics` calendar attachment so attendees can add the event to their calendar with accurate times.
 
 ### Partner Calendar Invites (Epic 8)
 
@@ -56,6 +56,8 @@ The platform provides serverless email forwarding for 6 inboxes: `ok@`, `info@`,
 
 - **Dynamic recipient resolution** — Lambda resolves recipients via role-based and registration-based API calls
 - **Sender exclusion** — Original sender is excluded from forwarding to prevent bounce loops
+- **CC address forwarding** — CC recipients on inbound emails are recognised as mailing-list addresses and resolved through the same recipient-resolution pipeline; they are forwarded alongside the primary recipients
+- **All mailing list variants recognised** — All `batbernNN@batbern.ch` series addresses (e.g. `batbern44@batbern.ch`) are detected and handled correctly, not only the latest series
 - **Environment isolation** — Staging uses `replies@staging.batbern.ch` with `noreply@berner-architekten-treffen.ch`; production uses `replies@batbern.ch` with `noreply@batbern.ch`
 - **Admin configuration** — Organizers manage forwarding rules via Admin Settings UI
 


### PR DESCRIPTION
Resolves doc drift flagged in #613.

Updates three user-guide docs to reflect changes shipped in the week of 2026-04-06:

- `notifications.md`: registration emails now include correct event start/end times; CC forwarding and all mailing list variants documented
- `events.md`: public event page shows resolved start and end times
- `changelog.md`: v1.2.2 patch entry covering all six commits

Generated with [Claude Code](https://claude.ai/code)