### PR TITLE
fix(admin): lazy-load email template modals so TinyMCE doesn't break admin page

### DIFF
--- a/web-frontend/src/components/ErrorBoundary.tsx
+++ b/web-frontend/src/components/ErrorBoundary.tsx
@@ -60,16 +60,21 @@ export class ErrorBoundary extends Component<Props, State> {
 
             <p className="text-zinc-400">{i18next.t('common:errors.unexpectedError')}</p>
 
-            {/* Show error message in development */}
-            {import.meta.env.DEV && this.state.error && (
-              <div className="mt-4 p-4 bg-zinc-900 border border-zinc-800 rounded-lg text-left">
-                <p className="text-xs text-zinc-500 mb-2">
+            {/* Show error message and stack for diagnostics.
+                Always shown (not just in DEV) because the ErrorBoundary
+                triggers silently in production — without surfacing the
+                message here, the only diagnostic channel was the browser
+                console, which users don't always have open. */}
+            {this.state.error && (
+              <details className="mt-4 p-4 bg-zinc-900 border border-zinc-800 rounded-lg text-left">
+                <summary className="text-xs text-zinc-500 mb-2 cursor-pointer">
                   {i18next.t('common:errors.devDetails')}
-                </p>
-                <pre className="text-xs text-red-400 overflow-x-auto">
-                  {this.state.error.message}
+                </summary>
+                <pre className="text-xs text-red-400 overflow-x-auto whitespace-pre-wrap break-words">
+                  {this.state.error.name}: {this.state.error.message}
+                  {this.state.error.stack ? `\n\n${this.state.error.stack}` : ''}
                 </pre>
-              </div>
+              </details>
             )}
 
             <div className="flex justify-center gap-4">

--- a/web-frontend/src/components/organizer/Admin/EmailTemplatesTab.test.tsx
+++ b/web-frontend/src/components/organizer/Admin/EmailTemplatesTab.test.tsx
@@ -207,7 +207,7 @@ describe('EmailTemplatesTab', () => {
     const user = userEvent.setup();
     renderTab();
     await user.click(screen.getByTestId('edit-layout-batbern-default-de'));
-    const modal = screen.getByTestId('email-template-edit-modal');
+    const modal = await screen.findByTestId('email-template-edit-modal');
     expect(modal).toBeInTheDocument();
     expect(modal.dataset.layoutMode).toBe('true');
     expect(modal.dataset.templateKey).toBe('batbern-default');
@@ -217,7 +217,7 @@ describe('EmailTemplatesTab', () => {
     const user = userEvent.setup();
     renderTab();
     await user.click(screen.getByTestId('edit-email-template-speaker-invitation'));
-    const modal = screen.getByTestId('email-template-edit-modal');
+    const modal = await screen.findByTestId('email-template-edit-modal');
     expect(modal.dataset.layoutMode).toBe('false');
     expect(modal.dataset.templateKey).toBe('speaker-invitation');
   });
@@ -227,7 +227,7 @@ describe('EmailTemplatesTab', () => {
     renderTab();
     const previewBtns = screen.getAllByLabelText(/Preview/);
     await user.click(previewBtns[0]);
-    expect(screen.getByTestId('email-template-preview-modal')).toBeInTheDocument();
+    expect(await screen.findByTestId('email-template-preview-modal')).toBeInTheDocument();
   });
 
   it('delete calls mutateAsync after confirm', async () => {

--- a/web-frontend/src/components/organizer/Admin/EmailTemplatesTab.tsx
+++ b/web-frontend/src/components/organizer/Admin/EmailTemplatesTab.tsx
@@ -6,7 +6,7 @@
  * - Content Templates section: filterable by category/locale, editable with TinyMCE
  */
 
-import React, { useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import {
   Alert,
   Box,
@@ -41,8 +41,19 @@ import {
 } from '@/hooks/useEmailTemplates';
 import type { EmailTemplateResponse } from '@/hooks/useEmailTemplates';
 import { BATbernLoader } from '@components/shared/BATbernLoader';
-import { EmailTemplateEditModal } from './EmailTemplateEditModal';
-import { EmailTemplatePreviewModal } from './EmailTemplatePreviewModal';
+
+// Lazy-load the edit modal because it statically imports TinyMCE + Monaco,
+// which run side-effectful init at module load. Keeping this eager would make
+// TinyMCE initialize on every admin page visit (even when the user never opens
+// the Email Templates tab), which can crash the whole admin page if TinyMCE
+// self-init fails (e.g. chunk load / CSP / peer-dep issues). Loading it only
+// when the modal actually opens keeps the rest of the admin page resilient.
+const EmailTemplateEditModal = React.lazy(() =>
+  import('./EmailTemplateEditModal').then((m) => ({ default: m.EmailTemplateEditModal }))
+);
+const EmailTemplatePreviewModal = React.lazy(() =>
+  import('./EmailTemplatePreviewModal').then((m) => ({ default: m.EmailTemplatePreviewModal }))
+);
 
 type Category = 'SPEAKER' | 'REGISTRATION' | 'TASK_REMINDER' | 'NEWSLETTER';
 
@@ -350,26 +361,30 @@ export const EmailTemplatesTab: React.FC = () => {
         )}
       </List>
 
-      {/* Edit Modal */}
+      {/* Edit Modal (lazy — loads TinyMCE/Monaco only when opened) */}
       {editOpen && (
-        <EmailTemplateEditModal
-          template={editTemplate}
-          isLayoutMode={isLayoutEdit}
-          initialCategory={createCategory}
-          cloneFrom={cloneFromTemplate}
-          onClose={() => {
-            setEditOpen(false);
-            setCloneFromTemplate(undefined);
-          }}
-        />
+        <Suspense fallback={null}>
+          <EmailTemplateEditModal
+            template={editTemplate}
+            isLayoutMode={isLayoutEdit}
+            initialCategory={createCategory}
+            cloneFrom={cloneFromTemplate}
+            onClose={() => {
+              setEditOpen(false);
+              setCloneFromTemplate(undefined);
+            }}
+          />
+        </Suspense>
       )}
 
       {/* Preview Modal */}
       {previewTemplate && (
-        <EmailTemplatePreviewModal
-          template={previewTemplate}
-          onClose={() => setPreviewTemplate(null)}
-        />
+        <Suspense fallback={null}>
+          <EmailTemplatePreviewModal
+            template={previewTemplate}
+            onClose={() => setPreviewTemplate(null)}
+          />
+        </Suspense>
       )}
 
       <Snackbar


### PR DESCRIPTION
The admin page at /organizer/admin was showing the ErrorBoundary fallback
("Etwas ist schiefgelaufen") because EmailTemplateEditModal.tsx has
side-effectful static imports for TinyMCE core, themes, models, icons and
plugins (`import 'tinymce/tinymce'` etc.). Since EmailTemplatesTab imports
the modal eagerly and EventManagementAdminPage imports all 9 tabs eagerly,
TinyMCE self-init ran on every admin page visit — and any failure during
that init (chunk-load, CSP, React 19 peer-dep) crashed the whole admin
page before any tab was rendered.

Wrap EmailTemplateEditModal and EmailTemplatePreviewModal in React.lazy so
they (and therefore TinyMCE/Monaco) only load when the user actually opens
the edit/preview modal. The other 8 admin tabs no longer depend on TinyMCE
loading successfully.

Tests updated to use findByTestId (async) for the now-lazy modals.