### PR TITLE
fix(admin): load TinyMCE from static script instead of ESM imports

### DIFF
--- a/web-frontend/src/components/organizer/Admin/EmailTemplateEditModal.test.tsx
+++ b/web-frontend/src/components/organizer/Admin/EmailTemplateEditModal.test.tsx
@@ -34,16 +34,6 @@ vi.mock('@monaco-editor/react', () => ({
   ),
 }));
 
-// TinyMCE — mock self-hosted imports (no DOM in jsdom)
-vi.mock('tinymce/tinymce', () => ({}));
-vi.mock('tinymce/models/dom/model', () => ({}));
-vi.mock('tinymce/themes/silver/theme', () => ({}));
-vi.mock('tinymce/icons/default/icons', () => ({}));
-vi.mock('tinymce/plugins/code', () => ({}));
-vi.mock('tinymce/plugins/table', () => ({}));
-vi.mock('tinymce/plugins/lists', () => ({}));
-vi.mock('tinymce/plugins/link', () => ({}));
-
 // TinyMCE React wrapper — replace with a simple textarea for tests
 vi.mock('@tinymce/tinymce-react', () => ({
   Editor: ({ value, onEditorChange }: { value?: string; onEditorChange?: (v: string) => void }) => (

--- a/web-frontend/src/components/organizer/Admin/EmailTemplateEditModal.tsx
+++ b/web-frontend/src/components/organizer/Admin/EmailTemplateEditModal.tsx
@@ -12,16 +12,6 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Editor from '@monaco-editor/react';
-// Self-hosted TinyMCE: import core engine before the React wrapper
-// so the wrapper uses the local bundle instead of TinyMCE Cloud.
-import 'tinymce/tinymce';
-import 'tinymce/models/dom/model';
-import 'tinymce/themes/silver/theme';
-import 'tinymce/icons/default/icons';
-import 'tinymce/plugins/code';
-import 'tinymce/plugins/table';
-import 'tinymce/plugins/lists';
-import 'tinymce/plugins/link';
 import { Editor as TinyMCEEditor } from '@tinymce/tinymce-react';
 import {
   Alert,
@@ -294,6 +284,7 @@ export const EmailTemplateEditModal: React.FC<Props> = ({
         ) : (
           <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
             <TinyMCEEditor
+              tinymceScriptSrc="/tinymce/tinymce.min.js"
               initialValue={htmlBody}
               onEditorChange={(val: string) => {
                 tinymceContentRef.current = val;

--- a/web-frontend/vite.config.ts
+++ b/web-frontend/vite.config.ts
@@ -137,10 +137,17 @@ export default defineConfig({
         enabled: false, // Disable PWA in development for faster builds
       },
     }),
-    // Self-hosted TinyMCE assets (skins, icons, models, plugins)
-    // Required because TinyMCE Cloud restricts the 'code' plugin to paid tiers.
+    // Self-hosted TinyMCE assets (core JS, skins, icons, models, plugins, themes).
+    // The core script is loaded at runtime via <Editor tinymceScriptSrc="/tinymce/tinymce.min.js" />
+    // instead of ESM side-effect imports, because Vite's production bundler may reorder
+    // the TinyMCE IIFEs within a chunk so that plugins execute before the core sets
+    // window.tinymce, causing "ReferenceError: Can't find variable: tinymce".
     viteStaticCopy({
       targets: [
+        {
+          src: 'node_modules/tinymce/tinymce.min.js',
+          dest: 'tinymce',
+        },
         {
           src: 'node_modules/tinymce/skins',
           dest: 'tinymce',
@@ -245,7 +252,6 @@ export default defineConfig({
         manualChunks(id) {
           if (!id.includes('node_modules')) return undefined;
           if (id.includes('@emotion') || id.includes('@mui')) return 'vendor-mui';
-          if (id.includes('tinymce')) return 'vendor-tinymce';
           return 'vendor';
         },
         // Asset file naming for better caching


### PR DESCRIPTION
## Summary

- **Fix** `ReferenceError: Can't find variable: tinymce` that crashed the admin page when opening any email template editor (layout or content mode)
- **Root cause**: Vite's production bundler reordered TinyMCE IIFE modules within the `vendor-tinymce` chunk so plugins executed before the core set `window.tinymce`
- **Solution**: Use `@tinymce/tinymce-react`'s `tinymceScriptSrc` prop to load TinyMCE from a static copy at runtime, bypassing Vite's bundler entirely

### Changes
- Remove all `import 'tinymce/...'` side-effect imports from `EmailTemplateEditModal.tsx`
- Add `tinymceScriptSrc="/tinymce/tinymce.min.js"` to `<Editor>` component
- Copy `tinymce.min.js` to public dir via `vite-plugin-static-copy` in `vite.config.ts`
- Remove now-unnecessary `vendor-tinymce` manual chunk from Rollup config
- Remove stale tinymce module mocks from test file

## Test plan

- [ ] Deploy to production and verify `/organizer/admin` loads without error
- [ ] Open Email Templates tab → edit a layout template → Monaco editor renders
- [ ] Open Email Templates tab → edit a content template → TinyMCE WYSIWYG renders
- [ ] Verify TinyMCE toolbar works (bold, italic, code view, tables, links)
- [ ] All other admin tabs (Event Types, Import Data, Task Templates, etc.) still work
- [ ] `npx vitest run` passes for EmailTemplateEditModal and EmailTemplatesTab tests

Fixes #620

https://claude.ai/code/session_01WULXEVhjqURX7YnR5tAJiv