### PR TITLE
fix(gateway): preserve path encoding and upstream Cache-Control headers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,6 +358,46 @@ make setup-test-users ENV=development     # development
 
 **CI/CD:** `deploy-staging.yml` gets tokens for all roles from GitHub secrets (`STAGING_ORGANIZER_*`, `STAGING_SPEAKER_*`, `STAGING_PARTNER_*`). Falls back to `STAGING_TEST_USER_*` for organizer.
 
+### Bruno `.bru` File Syntax — Comments Go in `docs { }`, NOT `#`
+
+**CRITICAL — common Claude mistake.** Bruno's `.bru` grammar does NOT support free-floating `#` comments at the top level (between blocks). When the parser sees a `#` line outside a recognised block, it prints `Warning: Skipping invalid file ...` and **silently skips the entire file** — the request never runs, but `bru run` exits 0 if every other file passed. This makes the failure invisible in CI: a "PASS" summary can hide cleanup hooks that never executed.
+
+```bruno
+# ❌ Wrong — parser skips this file with a Warning
+meta {
+  name: Pretest cleanup
+  type: http
+  seq: 0
+}
+
+# Audit-pass addition: unconditional pretest cleanup.
+# Runs BEFORE every other test in this collection.
+
+post { ... }
+```
+
+```bruno
+# ✅ Correct — prose lives in a docs { } block at the end of the file
+meta {
+  name: Pretest cleanup
+  type: http
+  seq: 0
+}
+
+post { ... }
+
+tests { ... }
+
+docs {
+  Audit-pass addition: unconditional pretest cleanup.
+  Runs BEFORE every other test in this collection.
+}
+```
+
+The only blocks Bruno's parser accepts at file scope are: `meta`, `docs`, `settings`, `headers`, `body:*`, `auth:*`, `params:*`, `query`, `tests`, `assert`, `script:pre-request`, `script:post-response`, `vars:*`, `metadata`, and the HTTP verb blocks (`get`, `post`, `put`, etc.). Anything else — including `#`-prefixed comments — fails the parse.
+
+**Detection:** grep CI output for `Skipping invalid file` after any Bruno run. A clean run should have zero such warnings.
+
 ## Critical Development Standards
 
 ### Type Sharing

--- a/api-gateway/src/main/java/ch/batbern/gateway/routing/DomainRouter.java
+++ b/api-gateway/src/main/java/ch/batbern/gateway/routing/DomainRouter.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -151,10 +152,16 @@ public class DomainRouter {
         cleaned.remove("Referrer-Policy");
         cleaned.remove("Permissions-Policy");
 
-        // Remove cache control headers that will be added by SecurityHeadersFilter
-        cleaned.remove("Cache-Control");
-        cleaned.remove("Pragma");
-        cleaned.remove("Expires");
+        // NOTE: Cache-Control/Pragma/Expires intentionally NOT stripped here.
+        // The previous "will be added by SecurityHeadersFilter" comment was wrong —
+        // SecurityHeadersHandler exists but is never wired in as an interceptor, so
+        // stripping these headers caused Spring Security's default
+        // `no-cache, no-store, max-age=0, must-revalidate` to apply to every response,
+        // overriding the controller's explicit `cachePublic + 24h` directive on
+        // `/api/v1/public/users/*` (caught by Bruno test users-api/20). Controllers
+        // (e.g. PublicUserController) set Cache-Control explicitly when they want
+        // a caching directive; when they don't, Spring Security's default still
+        // applies — which is the correct behaviour for authenticated endpoints.
 
         // Remove transfer-encoding to prevent chunked encoding issues
         // Spring will set Content-Length automatically
@@ -202,21 +209,33 @@ public class DomainRouter {
                 // Get target service URL
                 String serviceUrl = getServiceUrl(targetService);
 
-                // Build URI using UriComponentsBuilder to properly handle query parameters
-                // This prevents double-encoding and URI template variable expansion issues
-                UriComponentsBuilder uriBuilder = UriComponentsBuilder
-                        .fromUriString(serviceUrl + requestUri);
-
-                // Add query parameters from request (already decoded by servlet container)
-                // UriComponentsBuilder will encode them properly
-                request.getParameterMap().forEach((key, values) -> {
-                    for (String value : values) {
-                        uriBuilder.queryParam(key, value);
-                    }
-                });
-
-                // build() encodes the parameters, toUri() creates the URI object
-                URI targetUri = uriBuilder.build().toUri();
+                // Construct target URI preserving the path's original wire encoding.
+                // getRequestURI() returns the URL-encoded path (e.g. `%40` for `@`);
+                // UriComponentsBuilder.fromUriString(...).build() defaults to encoded=false
+                // and re-encodes percent signs (`%40` → `%2540`), which Spring Security's
+                // StrictHttpFirewall on the downstream service then rejects as
+                // "potentially malicious String '%25'" (caught by Bruno test
+                // users-api/17-delete-additional-email).
+                //
+                // Path: keep getRequestURI() bytes verbatim.
+                // Query params: getParameterMap() returns DECODED values, so we still need
+                // UriComponentsBuilder's RFC 3986 query encoding (verified by the JSON-in-
+                // query-string test below).
+                Map<String, String[]> params = request.getParameterMap();
+                String encodedQuery = null;
+                if (!params.isEmpty()) {
+                    UriComponentsBuilder queryBuilder = UriComponentsBuilder.newInstance();
+                    params.forEach((key, values) -> {
+                        for (String value : values) {
+                            queryBuilder.queryParam(key, value);
+                        }
+                    });
+                    // .encode() converts decoded queryParam values into their RFC 3986
+                    // wire form ({ → %7B, " → %22, etc.) so the assembled URI parses.
+                    encodedQuery = queryBuilder.build().encode().getQuery();
+                }
+                URI targetUri = URI.create(serviceUrl + requestUri
+                        + (encodedQuery != null ? "?" + encodedQuery : ""));
 
                 // Copy headers from original request (excluding Host header)
                 HttpHeaders headers = new HttpHeaders();

--- a/api-gateway/src/test/java/ch/batbern/gateway/routing/DomainRouterTest.java
+++ b/api-gateway/src/test/java/ch/batbern/gateway/routing/DomainRouterTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -481,5 +482,71 @@ class DomainRouterTest {
 
         // Then: root path "/" is preserved as-is (length == 1, not stripped)
         assertThat(uriCaptor.getValue().getPath()).isEqualTo("/");
+    }
+
+    // Regression test for the double-encoding bug caught by Bruno
+    // users-api/17-delete-additional-email. The DELETE path embeds a URL-encoded
+    // email (`bruno-test-<ts>%40e2e.batbern.invalid`); a previous build() default
+    // re-encoded the `%` as `%25`, producing `%2540` upstream which Spring
+    // Security's StrictHttpFirewall rejects ("potentially malicious String '%25'").
+    @Test
+    @DisplayName("should_preservePathEncoding_when_pathContainsPercentEncodedAtSign")
+    void should_preservePathEncoding_when_pathContainsPercentEncodedAtSign() {
+        // Given
+        String targetService = "company-user-management-service";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/v1/users/me/additional-emails/bruno-test-1234%40e2e.batbern.invalid");
+        request.setMethod("DELETE");
+
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        when(restTemplate.exchange(
+            uriCaptor.capture(),
+            any(),
+            any(),
+            eq(byte[].class)
+        )).thenReturn(ResponseEntity.noContent().build());
+
+        // When
+        domainRouter.routeRequest(targetService, request).join();
+
+        // Then: the gateway must forward `%40` verbatim, not double-encode to `%2540`
+        String rawPath = uriCaptor.getValue().getRawPath();
+        assertThat(rawPath).contains("%40");
+        assertThat(rawPath).doesNotContain("%2540");
+        assertThat(uriCaptor.getValue().toString())
+                .isEqualTo("http://localhost:8085/api/v1/users/me/additional-emails/bruno-test-1234%40e2e.batbern.invalid");
+    }
+
+    // Regression test for the Cache-Control stripping bug caught by Bruno
+    // users-api/20-public-user-by-username. The gateway previously stripped
+    // upstream Cache-Control headers referencing a `SecurityHeadersFilter` that
+    // doesn't exist; PublicUserController's `cachePublic + 24h` directive was
+    // dropped and replaced by Spring Security's `no-cache, no-store, ...` default.
+    @Test
+    @DisplayName("should_preserveUpstreamCacheControl_when_responseCarriesPublicCachingHeader")
+    void should_preserveUpstreamCacheControl_when_responseCarriesPublicCachingHeader() {
+        // Given
+        String targetService = "company-user-management-service";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/v1/public/users/jane.smith");
+        request.setMethod("GET");
+
+        HttpHeaders upstreamHeaders = new HttpHeaders();
+        upstreamHeaders.set("Cache-Control", "public, max-age=86400");
+        when(restTemplate.exchange(
+            any(URI.class),
+            any(),
+            any(),
+            eq(byte[].class)
+        )).thenReturn(ResponseEntity.ok()
+                .headers(upstreamHeaders)
+                .body("{\"username\":\"jane.smith\"}".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+
+        // When
+        ResponseEntity<byte[]> response = domainRouter.routeRequest(targetService, request).join();
+
+        // Then: gateway must forward the upstream Cache-Control unchanged.
+        assertThat(response.getHeaders().getFirst("Cache-Control"))
+                .isEqualTo("public, max-age=86400");
     }
 }


### PR DESCRIPTION
## Summary
- Gateway forwarded `%40` → `%2540` (double-encoded), tripping Spring Security's `StrictHttpFirewall` on every downstream service. Now the path is forwarded verbatim from `getRequestURI()`; query params still get RFC-3986 encoding via `UriComponentsBuilder.newInstance().queryParam(...).build().encode()`.
- Gateway stripped upstream `Cache-Control`/`Pragma`/`Expires` citing a `SecurityHeadersFilter` that is never wired in. `PublicUserController`'s explicit `cachePublic + 24h` directive was silently replaced by Spring Security's `no-cache, no-store, max-age=0, must-revalidate` default. Now upstream cache directives pass through; Spring Security's default still applies when the controller doesn't set one (correct for authenticated endpoints).
- Adds `CLAUDE.md` guardrail: Bruno `.bru` files must put prose in a `docs { }` block — free-floating `#` comments cause Bruno's parser to silently drop the file with a warning, exit 0, and hide broken/missing tests behind a green CI. This guardrail explains the foot-gun that masked the gateway bugs for weeks.

Both gateway bugs caught by the `users-api` Bruno collection during PR 5 prep. They cannot land in PR 5 because they affect every Bruno collection and every downstream service.

## Test plan
- [x] `./gradlew :api-gateway:test --tests "ch.batbern.gateway.routing.DomainRouterTest"` — 30/30 green, including 2 new regressions (`should_preservePathEncoding_when_pathContainsPercentEncodedAtSign`, `should_preserveUpstreamCacheControl_when_responseCarriesPublicCachingHeader`).
- [x] Local `users-api` Bruno collection — 35/35 requests, 46/46 assertions (was 4 failures).
- [ ] CI runs `staging` Bruno collections post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)