### PR TITLE
fix(ci): Bruno runner aborts on first ((var++)) under set -e

### DIFF
--- a/scripts/ci/run-bruno-tests.sh
+++ b/scripts/ci/run-bruno-tests.sh
@@ -246,7 +246,13 @@ for collection in "${collections[@]}"; do
 
     if [ ! -d "$collection_path" ]; then
         echo -e "${YELLOW}⚠ Skipping:${NC} $collection (directory not found)"
-        ((skipped++))
+        # Use $((...)) form rather than ((var++)). With `set -e` (line 20),
+        # `((var++))` returns the PRE-increment value as the arithmetic
+        # result — if that value is 0 (first success/fail/skip in the run),
+        # bash treats it as a falsy command and aborts the script BEFORE the
+        # summary block prints. We hit this on the first all-green Bruno CI
+        # run after 11.F.1 fixed the role-token plumbing.
+        skipped=$((skipped + 1))
         continue
     fi
 
@@ -268,7 +274,7 @@ for collection in "${collections[@]}"; do
     # Use -r for recursive execution of all tests in the folder
     if (cd bruno-tests && bru run "$collection" -r --env "$ENVIRONMENT" --output "../results-${collection}.json" 2>&1); then
         echo -e "${GREEN}✓ PASS${NC}: $collection tests passed"
-        ((passed++))
+        passed=$((passed + 1))
 
         # Display summary if results file exists
         results_file="results-${collection}.json"
@@ -289,7 +295,7 @@ for collection in "${collections[@]}"; do
         fi
     else
         echo -e "${RED}✗ FAIL${NC}: $collection tests failed"
-        ((failed++))
+        failed=$((failed + 1))
 
         # Try to show error details
         results_file="results-${collection}.json"


### PR DESCRIPTION
## Summary

`scripts/ci/run-bruno-tests.sh` uses `((passed++))` / `((failed++))` / `((skipped++))` to bump per-collection counters. With `set -e` active (line 20), `((expr))` aborts the script whenever the arithmetic result is `0` — and `((var++))` returns the **pre**-increment value. So on the **very first** successful collection (when `passed=0`), the script prints `✓ PASS: …` then aborts with exit code 1 before the summary block can print.

GitHub Actions then records the Bruno step as `outcome=failure` → `tag-stable-on-success` (gated on `outputs.outcome == 'success'`) gets skipped → `staging-stable` never gets promoted, even on a fully clean Bruno run.

## Reproduction

[Run 26413771521 → Bruno step](https://github.com/nissimbuchs/BATbern2/actions/runs/26413771521/job/77765110352):

```
admin-cleanup-api 9/9 ✓ PASS  (15/15 assertions)
✓ PASS: admin-cleanup-api tests passed       ← line 270
##[error]Process completed with exit code 1.  ← ((passed++)) aborted via set -e
# Summary block never printed.
Bruno step outcome: failure                   ← workflow reads step outcome
```

## Why now

This was invisible while admin-cleanup-api had 3/9 real failures — the FAIL branch's `((failed++))` has the identical bug, but exit-1 was the *intended* outcome there. PR #667 (11.F.1) fixed the role-token plumbing so the auth-matrix tests finally get proper 403s and the collection went all-green for the first time.

## Fix

Replace `((var++))` with `var=$((var + 1))` in all three counter sites. Assignment never triggers `set -e` regardless of the right-hand value. Added a one-paragraph comment at the `skipped` site so future maintainers don't reintroduce the pattern.

## Test plan
- [x] `bash -n scripts/ci/run-bruno-tests.sh` — syntax clean.
- [ ] Next post-deploy Bruno run on develop should now correctly report `outcome=success` and fire `tag-stable-on-success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)