### PR TITLE
[F1 DRILL — DO NOT MERGE] deliberate Bruno failure to validate auto-rollback

### DIFF
--- a/bruno-tests/companies-api/zz-f1-deliberate-fail.bru
+++ b/bruno-tests/companies-api/zz-f1-deliberate-fail.bru
@@ -1,0 +1,32 @@
+meta {
+  name: F1 rollback drill — deliberate fail (DO NOT MERGE)
+  type: http
+  seq: 999
+}
+
+get {
+  url: {{baseUrl}}/companies
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{authToken}}
+}
+
+assert {
+  res.status: eq 999
+}
+
+tests {
+  test("F1 drill: deliberately asserts 999 to fail Bruno and trigger auto-rollback", function() {
+    expect(res.getStatus()).to.equal(999);
+  });
+}
+
+docs {
+  THROWAWAY — never merge to develop. Part of the F1 deliberate-fail rollback
+  exercise (plan §F1): makes the staging Bruno gate go red on a throwaway branch to
+  prove rollback-on-bruno-failure actually rolls ECS back to staging-stable.
+  Delete the branch after the drill.
+}


### PR DESCRIPTION
**Throwaway F1 deliberate-fail exercise (plan §F1). DO NOT MERGE — delete after the drill.**

Adds one Bruno test asserting GET /companies returns 999, so the now-blocking staging Bruno gate fails on this PR's deploy. Expected sequence:
1. deploy-to-staging deploys (no-op — same images as develop)
2. Bruno **fails** (deliberate)
3. `rollback-on-bruno-failure` fires (always-on, PR #674) and the PR #675-fixed rollback script **actually rolls ECS back to staging-stable** (EMS→1159, others→1158 — all verified good)

Draft so it can't merge. Will close + delete the branch once the rollback is confirmed.

Refs: docs/plans/bruno-staging-hardening.md PR #14 F1