### PR TITLE
[F1 DRILL #3 — DO NOT MERGE] confirm full auto-rollback across all services

### DIFF
--- a/bruno-tests/companies-api/zz-f1-deliberate-fail.bru
+++ b/bruno-tests/companies-api/zz-f1-deliberate-fail.bru
@@ -1,0 +1,31 @@
+meta {
+  name: F1 rollback drill #3 — deliberate fail (DO NOT MERGE)
+  type: http
+  seq: 999
+}
+
+get {
+  url: {{baseUrl}}/companies
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{authToken}}
+}
+
+assert {
+  res.status: eq 999
+}
+
+tests {
+  test("F1 drill #3: deliberately asserts 999 to fail Bruno and trigger full auto-rollback", function() {
+    expect(res.getStatus()).to.equal(999);
+  });
+}
+
+docs {
+  THROWAWAY — never merge. Final F1 re-run after all 3 rollback fixes (#675 service-name,
+  #679 register-from-temp-file, #681 counter set-e trap). Confirms the auto-rollback now
+  COMPLETES across all 5 services and the rollback job exits 0. Delete the branch after.
+}


### PR DESCRIPTION
**Throwaway final F1 re-run (plan §F1). DO NOT MERGE — delete after.** After all 3 rollback fixes (#675 service-name, #679 register-from-temp-file, #681 counter set-e trap). Deliberately fails Bruno (GET /companies asserts 999) to confirm the auto-rollback now **completes across all 5 services** and the `rollback-on-bruno-failure` job **exits 0**. Draft so it can't merge.

Refs: docs/plans/bruno-staging-hardening.md PR #14 F1