### PR TITLE
feat: unconfirmed-attendee recovery — 4-day registration links + daily resend (registrations + Cognito sign-ups)

### DIFF
--- a/docs/architecture/06-backend-architecture.md
+++ b/docs/architecture/06-backend-architecture.md
@@ -695,6 +695,34 @@ The platform provides multi-channel notifications (email, WebSocket) with intell
 
 **See [Notification System](./06d-notification-system.md) for complete implementation details.**
 
+## Registration & Sign-up Confirmation Lifecycle
+
+Two distinct confirmation flows exist, with **different** token mechanics — a frequent source of confusion:
+
+| Flow | Token | Validity | Configurable? |
+| --- | --- | --- | --- |
+| **Event registration** confirmation (status `registered` → `confirmed`) | Our own signed JWT (`ConfirmationTokenService`) | **4 days** (`app.registration.confirmation-token-validity-hours`, default 96h) | ✅ yes — we issue it |
+| **Cognito account** confirmation (sign-up email verification) | Cognito's native sign-up code | **24h, fixed** | ❌ no — Cognito limitation |
+
+**Coupling invariant (registration):** `RegistrationCleanupService` deletes still-`registered` rows
+after `app.registration.cleanup-after-hours` (default 120h / 5 days). This window **must exceed** the
+confirmation-token validity, otherwise a still-valid 4-day link could point at an already-deleted row.
+The service enforces this defensively (`effectiveCleanupHours() = max(configured, tokenValidity + 24h)`)
+and warns at startup if misconfigured.
+
+**Daily auto-resend jobs** (both Spring `@Scheduled` + `@SchedulerLock`/ShedLock):
+
+- `RegistrationResendService` (event-management-service, 08:30) re-sends the registration-confirmation
+  email — with **fresh** JWTs — to attendees unconfirmed for `> after-hours` (default 48h), capped at
+  `max-attempts` (default 2) via `confirmation_resend_count` / `confirmation_resent_at` on `registrations`.
+- `CognitoConfirmationResendJob` (company-user-management-service, 08:15) re-sends a fresh Cognito
+  sign-up code to accounts unconfirmed within a bounded age window (stateless anti-spam, since
+  UNCONFIRMED users have no DB row) — see [06b §Unconfirmed Sign-up Resend Job](./06b-user-lifecycle-sync.md).
+  Requires `cognito-idp:ListUsers` + `cognito-idp:ResendConfirmationCode` on the CUMS task role.
+
+Together these close the "first confirmation email missed/expired → recovery dead-end → locked out"
+failure mode without manual admin intervention.
+
 ## Testing Strategy
 
 The BATbern backend uses Testcontainers PostgreSQL for all integration tests to ensure production parity. This approach catches PostgreSQL-specific issues (JSONB, functions, constraints) that would be missed with H2.

--- a/docs/architecture/06b-user-lifecycle-sync.md
+++ b/docs/architecture/06b-user-lifecycle-sync.md
@@ -628,6 +628,29 @@ follow-up if reuse appears).
 
 **Metrics**: Progress and results (`orphanedUsers`, `missingUsers`, duration, errors) are published via `UserSyncMetricsService`.
 
+### ✅ Unconfirmed Sign-up Resend Job — `CognitoConfirmationResendJob`
+
+`CognitoConfirmationResendJob` (company-user-management-service) runs daily and re-sends the Cognito
+sign-up confirmation code to accounts still in `UNCONFIRMED` status. It exists because Cognito's
+sign-up confirmation code is fixed at **24 hours** and is **not configurable** (only our own
+registration-confirmation token — in event-management-service — has a configurable window). An
+attendee whose first code expired before they clicked hits a recovery dead-end: re-registering
+reports "email already exists" and password-reset reports "user not registered". The nightly job
+hands them a fresh, valid code automatically (re-triggering the `CustomEmailSender_SignUp` Lambda)
+instead of requiring manual admin remediation.
+
+**Eligibility**: `UserStatus == UNCONFIRMED` **and** signup age within `[after-hours, after-hours +
+window-hours)` (defaults 48h / 48h). The bounded window is a **stateless** anti-spam guard —
+UNCONFIRMED users have no `user_profiles` row to record a resend count (PostConfirmation only creates
+one on confirmation), so the age window limits each account to a few nudges across daily runs, then
+leaves it alone.
+
+**Resend call**: `ResendConfirmationCode` keyed by the email alias (the SPA app client has no secret,
+so no `SecretHash` is required). Requires the `cognito-idp:ResendConfirmationCode` +
+`cognito-idp:ListUsers` IAM actions on the user-pool ARN (granted to the CUMS task role). Configurable
+via `cognito.resend.*` (`enabled`, `cron`, `after-hours`, `window-hours`). Confirmed accounts and
+accounts outside the window are skipped.
+
 ### ❌ No Compensation Logs
 **Reason**: No bidirectional sync means no partial failure scenarios requiring compensation.
 

--- a/docs/architecture/08-operations-security.md
+++ b/docs/architecture/08-operations-security.md
@@ -23,6 +23,11 @@ This document consolidates security implementation, performance standards, acces
 - **Token Storage**: Secure JWT storage with automatic refresh
 - **Session Management**: Cognito-based session management
 - **Password Policy**: Strong password requirements
+- **Unconfirmed sign-up recovery**: a daily `CognitoConfirmationResendJob` re-sends a fresh Cognito
+  confirmation code to accounts unconfirmed past a grace window (Cognito's sign-up code is fixed at
+  24h and not configurable). The CUMS task role is granted `cognito-idp:ListUsers` +
+  `cognito-idp:ResendConfirmationCode`, scoped to the user-pool ARN (the SPA client has no secret,
+  so no `SecretHash` is needed).
 
 ## Cost Optimizations (2026-03)
 

--- a/infrastructure/lib/stacks/company-management-stack.ts
+++ b/infrastructure/lib/stacks/company-management-stack.ts
@@ -163,6 +163,11 @@ export class CompanyManagementStack extends cdk.Stack {
     // AdminAddUserToGroup is intentionally NOT granted (Resolved Q#1, PM 2026-05-17): roles live in
     // PostgreSQL user_roles per ADR-001; no Cognito groups exist; granting the permission would be a useless
     // least-privilege violation. ADR-009 §Decision 3, PRD AR30, and PRD NFR5 are updated in the same commit.
+    // ListUsers + ResendConfirmationCode added for the daily unconfirmed-signup nudge
+    // (CognitoConfirmationResendJob) and the nightly reconciliation's missing-user scan
+    // (UserReconciliationService), which both page through the pool. ResendConfirmationCode is a
+    // non-admin API but is still IAM-scoped to this pool; the SPA client has no secret so no
+    // SecretHash is required.
     this.service.taskDefinition.taskRole.addToPrincipalPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: [
@@ -170,6 +175,8 @@ export class CompanyManagementStack extends cdk.Stack {
         'cognito-idp:AdminSetUserPassword',
         'cognito-idp:AdminInitiateAuth',
         'cognito-idp:AdminGetUser',
+        'cognito-idp:ListUsers',
+        'cognito-idp:ResendConfirmationCode',
       ],
       resources: [props.userPool.userPoolArn],
     }));

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/CognitoConfirmationResendJob.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/CognitoConfirmationResendJob.java
@@ -1,0 +1,171 @@
+package ch.batbern.companyuser.service;
+
+import ch.batbern.shared.utils.LoggingUtils;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.CognitoIdentityProviderException;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.InvalidParameterException;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.LimitExceededException;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersResponse;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ResendConfirmationCodeRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserStatusType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
+import software.amazon.awssdk.services.cognitoidentityprovider.paginators.ListUsersIterable;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Daily job that re-sends the Cognito sign-up confirmation code to accounts that registered but
+ * never confirmed, after a grace window (default 2 days). The fresh code re-triggers the
+ * CustomEmailSender Lambda ({@code CustomEmailSender_SignUp}), which delivers a new branded
+ * verification email.
+ *
+ * <p>Why this exists: Cognito's sign-up confirmation code is fixed at 24h and cannot be lengthened
+ * (only our own registration-confirmation token is configurable). Accounts whose first code expired
+ * hit a recovery dead-end — re-register reports "email already exists" and password-reset reports
+ * "user not registered" — leaving them permanently locked out without manual support. This nudge
+ * hands them a fresh, valid code automatically.
+ *
+ * <p>Stateless anti-spam: Cognito UNCONFIRMED users have no {@code user_profiles} row to track resend
+ * counts (the PostConfirmation trigger only creates one on confirmation), so this job only nudges
+ * accounts whose signup age is within {@code [after-hours, after-hours + window-hours)} — a bounded
+ * window so each account is nudged at most a few times across daily runs, then left alone.
+ *
+ * <p>Resend uses the email alias ({@code ResendConfirmationCode} resolves it). Confirmed accounts and
+ * accounts outside the window are skipped. ShedLock ensures a single ECS instance runs it.
+ */
+@Component
+@Slf4j
+public class CognitoConfirmationResendJob {
+
+    private static final int PAGE_SIZE = 60; // Cognito max page size
+
+    private final CognitoIdentityProviderClient cognitoClient;
+    private final String userPoolId;
+    private final String clientId;
+    private final boolean enabled;
+    private final long afterHours;
+    private final long windowHours;
+
+    public CognitoConfirmationResendJob(
+            CognitoIdentityProviderClient cognitoClient,
+            @Value("${aws.cognito.user-pool-id:}") String userPoolId,
+            @Value("${aws.cognito.client-id:}") String clientId,
+            @Value("${cognito.resend.enabled:true}") boolean enabled,
+            @Value("${cognito.resend.after-hours:48}") long afterHours,
+            @Value("${cognito.resend.window-hours:48}") long windowHours) {
+        this.cognitoClient = cognitoClient;
+        this.userPoolId = userPoolId;
+        this.clientId = clientId;
+        this.enabled = enabled;
+        this.afterHours = afterHours;
+        this.windowHours = windowHours;
+    }
+
+    @Scheduled(cron = "${cognito.resend.cron:0 15 8 * * *}")
+    @SchedulerLock(
+            name = "resendUnconfirmedCognitoSignups",
+            lockAtLeastFor = "PT1M",
+            lockAtMostFor = "PT15M"
+    )
+    public void resendUnconfirmedSignups() {
+        if (!enabled) {
+            log.debug("Cognito confirmation resend disabled; skipping scheduled execution");
+            return;
+        }
+        if (isBlank(userPoolId) || isBlank(clientId)) {
+            log.warn("Cognito confirmation resend skipped — aws.cognito.user-pool-id / client-id not configured");
+            return;
+        }
+
+        log.info("Starting scheduled Cognito confirmation resend for unconfirmed sign-ups");
+
+        Instant now = Instant.now();
+        // Eligible signup age is in [afterHours, afterHours + windowHours):
+        //   newest eligible signup time = now - afterHours        (older than the grace window)
+        //   oldest eligible signup time = now - (afterHours+window) (still within the bounded window)
+        Instant newestEligible = now.minus(afterHours, ChronoUnit.HOURS);
+        Instant oldestEligible = now.minus(afterHours + windowHours, ChronoUnit.HOURS);
+
+        int resent = 0;
+        int eligibleScanned = 0;
+        try {
+            ListUsersRequest request = ListUsersRequest.builder()
+                    .userPoolId(userPoolId)
+                    .limit(PAGE_SIZE)
+                    .build();
+            ListUsersIterable paginator = cognitoClient.listUsersPaginator(request);
+
+            for (ListUsersResponse page : paginator) {
+                for (UserType user : page.users()) {
+                    if (user.userStatus() != UserStatusType.UNCONFIRMED) {
+                        continue;
+                    }
+                    Instant created = user.userCreateDate();
+                    if (created == null
+                            || created.isAfter(newestEligible)   // too new — still inside grace window
+                            || created.isBefore(oldestEligible)) { // too old — past the bounded window
+                        continue;
+                    }
+                    eligibleScanned++;
+
+                    String email = extractEmail(user);
+                    if (isBlank(email)) {
+                        log.warn("Skipping resend for unconfirmed user {} — no email attribute", user.username());
+                        continue;
+                    }
+                    if (resendFor(email)) {
+                        resent++;
+                    }
+                }
+            }
+        } catch (CognitoIdentityProviderException e) {
+            log.error("Cognito confirmation resend scan failed: {}", e.getMessage());
+        }
+
+        log.info("Cognito confirmation resend complete: {} resent of {} unconfirmed-in-window",
+                resent, eligibleScanned);
+    }
+
+    private boolean resendFor(String email) {
+        try {
+            cognitoClient.resendConfirmationCode(ResendConfirmationCodeRequest.builder()
+                    .clientId(clientId)
+                    .username(email)
+                    .build());
+            log.info("Resent Cognito confirmation code to {}", LoggingUtils.maskEmail(email));
+            return true;
+        } catch (InvalidParameterException e) {
+            // Most commonly: the account was confirmed between scan and resend — benign, just skip.
+            log.debug("Skipping resend for {} — {}", LoggingUtils.maskEmail(email),
+                    e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : e.getMessage());
+            return false;
+        } catch (LimitExceededException e) {
+            log.warn("Rate limited resending confirmation to {} — will retry next run",
+                    LoggingUtils.maskEmail(email));
+            return false;
+        } catch (CognitoIdentityProviderException e) {
+            log.error("Failed to resend confirmation to {}: {}", LoggingUtils.maskEmail(email), e.getMessage());
+            return false;
+        }
+    }
+
+    private String extractEmail(UserType user) {
+        return user.attributes().stream()
+                .filter(attr -> "email".equals(attr.name()))
+                .map(AttributeType::value)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/services/company-user-management-service/src/main/resources/application.yml
+++ b/services/company-user-management-service/src/main/resources/application.yml
@@ -66,10 +66,22 @@ aws:
     domain: ${CLOUDFRONT_DOMAIN:https://cdn.batbern.ch}
   cognito:
     user-pool-id: ${COGNITO_USER_POOL_ID:}
+    client-id: ${COGNITO_CLIENT_ID:}
     region: ${AWS_REGION:eu-central-1}
   eventbridge:
     bus-name: ${EVENT_BUS_NAME:batbern-staging}
     source: ch.batbern.companyuser
+
+# Daily nudge for accounts that signed up but never confirmed their email.
+# Cognito's sign-up confirmation code is fixed at 24h (not configurable), so this re-sends a fresh
+# code to accounts unconfirmed for >= after-hours, bounded to a window so each account is nudged at
+# most a few times across daily runs (Cognito UNCONFIRMED users have no DB row for per-user state).
+cognito:
+  resend:
+    enabled: ${COGNITO_RESEND_ENABLED:true}
+    cron: "0 15 8 * * *"                          # daily 08:15 (distinct from 02:00 reconciliation)
+    after-hours: ${COGNITO_RESEND_AFTER_HOURS:48} # nudge once unconfirmed >= 2 days
+    window-hours: ${COGNITO_RESEND_WINDOW_HOURS:48} # only nudge within [after, after+window) of signup
 
 # Server Configuration
 server:

--- a/services/company-user-management-service/src/test/java/ch/batbern/companyuser/service/CognitoConfirmationResendJobTest.java
+++ b/services/company-user-management-service/src/test/java/ch/batbern/companyuser/service/CognitoConfirmationResendJobTest.java
@@ -1,0 +1,164 @@
+package ch.batbern.companyuser.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.InvalidParameterException;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersResponse;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ResendConfirmationCodeRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ResendConfirmationCodeResponse;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserStatusType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
+import software.amazon.awssdk.services.cognitoidentityprovider.paginators.ListUsersIterable;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for CognitoConfirmationResendJob (daily nudge for unconfirmed Cognito sign-ups).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CognitoConfirmationResendJob Tests")
+class CognitoConfirmationResendJobTest {
+
+    @Mock
+    private CognitoIdentityProviderClient cognitoClient;
+
+    private CognitoConfirmationResendJob job;
+
+    private static final String POOL = "eu-central-1_Test";
+    private static final String CLIENT = "test-client-id";
+
+    @BeforeEach
+    void setUp() {
+        // enabled, nudge after 48h, bounded window 48h -> eligible signup age in [48h, 96h)
+        job = new CognitoConfirmationResendJob(cognitoClient, POOL, CLIENT, true, 48, 48);
+    }
+
+    @Test
+    @DisplayName("Disabled: no Cognito interaction at all")
+    void disabled_noop() {
+        CognitoConfirmationResendJob disabled =
+                new CognitoConfirmationResendJob(cognitoClient, POOL, CLIENT, false, 48, 48);
+        disabled.resendUnconfirmedSignups();
+        verifyNoInteractions(cognitoClient);
+    }
+
+    @Test
+    @DisplayName("Missing client-id: safe no-op (no scan, no resend)")
+    void blankClientId_noop() {
+        CognitoConfirmationResendJob unconfigured =
+                new CognitoConfirmationResendJob(cognitoClient, POOL, "", true, 48, 48);
+        unconfigured.resendUnconfirmedSignups();
+        verifyNoInteractions(cognitoClient);
+    }
+
+    @Test
+    @DisplayName("Unconfirmed within window: fresh code resent via email alias + client-id")
+    void unconfirmedInWindow_resends() {
+        UserType u = user("sub-1", "stuck@example.ch", UserStatusType.UNCONFIRMED, hoursAgo(72));
+        ListUsersIterable pages = paginator(u);
+        when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(pages);
+        when(cognitoClient.resendConfirmationCode(any(ResendConfirmationCodeRequest.class)))
+                .thenReturn(ResendConfirmationCodeResponse.builder().build());
+
+        job.resendUnconfirmedSignups();
+
+        ArgumentCaptor<ResendConfirmationCodeRequest> captor =
+                ArgumentCaptor.forClass(ResendConfirmationCodeRequest.class);
+        verify(cognitoClient).resendConfirmationCode(captor.capture());
+        assertThat(captor.getValue().clientId()).isEqualTo(CLIENT);
+        assertThat(captor.getValue().username()).isEqualTo("stuck@example.ch");
+    }
+
+    @Test
+    @DisplayName("Confirmed accounts are never nudged")
+    void confirmed_skipped() {
+        UserType u = user("sub-2", "ok@example.ch", UserStatusType.CONFIRMED, hoursAgo(72));
+        ListUsersIterable pages = paginator(u);
+        when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(pages);
+
+        job.resendUnconfirmedSignups();
+
+        verify(cognitoClient, never()).resendConfirmationCode(any(ResendConfirmationCodeRequest.class));
+    }
+
+    @Test
+    @DisplayName("Unconfirmed but still inside the grace window (< after-hours) is not nudged yet")
+    void tooNew_skipped() {
+        UserType u = user("sub-3", "fresh@example.ch", UserStatusType.UNCONFIRMED, hoursAgo(12));
+        ListUsersIterable pages = paginator(u);
+        when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(pages);
+
+        job.resendUnconfirmedSignups();
+
+        verify(cognitoClient, never()).resendConfirmationCode(any(ResendConfirmationCodeRequest.class));
+    }
+
+    @Test
+    @DisplayName("Unconfirmed but past the bounded window is left alone")
+    void tooOld_skipped() {
+        UserType u = user("sub-4", "ancient@example.ch", UserStatusType.UNCONFIRMED, hoursAgo(200));
+        ListUsersIterable pages = paginator(u);
+        when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(pages);
+
+        job.resendUnconfirmedSignups();
+
+        verify(cognitoClient, never()).resendConfirmationCode(any(ResendConfirmationCodeRequest.class));
+    }
+
+    @Test
+    @DisplayName("A failing resend does not stop the rest of the batch")
+    void continuesOnError() {
+        UserType bad = user("sub-5", "bad@example.ch", UserStatusType.UNCONFIRMED, hoursAgo(60));
+        UserType good = user("sub-6", "good@example.ch", UserStatusType.UNCONFIRMED, hoursAgo(60));
+        ListUsersIterable pages = paginator(bad, good);
+        when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(pages);
+        when(cognitoClient.resendConfirmationCode(any(ResendConfirmationCodeRequest.class)))
+                .thenThrow(InvalidParameterException.builder().message("already confirmed").build())
+                .thenReturn(ResendConfirmationCodeResponse.builder().build());
+
+        job.resendUnconfirmedSignups();
+
+        // Both users attempted despite the first throwing
+        verify(cognitoClient, times(2)).resendConfirmationCode(any(ResendConfirmationCodeRequest.class));
+    }
+
+    // ---- helpers ----
+    private static Instant hoursAgo(long h) {
+        return Instant.now().minus(h, ChronoUnit.HOURS);
+    }
+
+    private UserType user(String username, String email, UserStatusType status, Instant created) {
+        return UserType.builder()
+                .username(username)
+                .userStatus(status)
+                .userCreateDate(created)
+                .attributes(AttributeType.builder().name("email").value(email).build())
+                .build();
+    }
+
+    private ListUsersIterable paginator(UserType... users) {
+        ListUsersIterable paginator = mock(ListUsersIterable.class);
+        ListUsersResponse response = ListUsersResponse.builder().users(users).build();
+        when(paginator.iterator()).thenReturn(List.of(response).iterator());
+        return paginator;
+    }
+}

--- a/services/event-management-service/src/main/java/ch/batbern/events/domain/Registration.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/domain/Registration.java
@@ -175,11 +175,27 @@ public class Registration {
     @Column(name = "updated_at")
     private Instant updatedAt;
 
+    /**
+     * Unconfirmed-resend job (link-validity hardening): timestamp of the most recent automated
+     * confirmation-email resend, and how many automated resends have been sent so far. Used by
+     * {@link ch.batbern.events.service.RegistrationResendService} to cap resends and enforce a gap
+     * between them. Null / 0 for registrations that were never auto-resent.
+     */
+    @Column(name = "confirmation_resent_at")
+    private Instant confirmationResentAt;
+
+    @Column(name = "confirmation_resend_count", nullable = false)
+    @Builder.Default
+    private Integer confirmationResendCount = 0;
+
     @PrePersist
     protected void onCreate() {
         // Story 10.12: auto-generate deregistration token if not set (covers test builders and legacy paths)
         if (deregistrationToken == null) {
             deregistrationToken = UUID.randomUUID();
+        }
+        if (confirmationResendCount == null) {
+            confirmationResendCount = 0;
         }
         createdAt = Instant.now();
         updatedAt = Instant.now();

--- a/services/event-management-service/src/main/java/ch/batbern/events/repository/RegistrationRepository.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/repository/RegistrationRepository.java
@@ -93,6 +93,33 @@ public interface RegistrationRepository
     List<Registration> findByStatusAndCreatedAtBefore(String status, Instant threshold);
 
     /**
+     * Find registrations eligible for an automated confirmation-email resend
+     * (used by {@code RegistrationResendService}).
+     *
+     * Eligible = still pending ("registered"), unconfirmed longer than the grace window
+     * ({@code createdAt <= eligibleBefore}), still within the active window
+     * ({@code createdAt > notExpiredAfter} — not already past the cleanup horizon), under the resend
+     * cap ({@code confirmationResendCount < maxAttempts}), and either never resent or last resent on
+     * or before {@code resentBefore} (enforces a minimum gap between resends).
+     *
+     * @param eligibleBefore registrations created at/after this instant are too new to nudge
+     * @param notExpiredAfter registrations created on/before this instant are effectively expired
+     * @param resentBefore   last-resend must be on/before this instant (or null)
+     * @param maxAttempts    resend cap
+     * @return matching registrations
+     */
+    @Query("SELECT r FROM Registration r WHERE r.status = 'registered' "
+            + "AND r.createdAt <= :eligibleBefore "
+            + "AND r.createdAt > :notExpiredAfter "
+            + "AND r.confirmationResendCount < :maxAttempts "
+            + "AND (r.confirmationResentAt IS NULL OR r.confirmationResentAt <= :resentBefore)")
+    List<Registration> findResendEligible(
+            @Param("eligibleBefore") Instant eligibleBefore,
+            @Param("notExpiredAfter") Instant notExpiredAfter,
+            @Param("resentBefore") Instant resentBefore,
+            @Param("maxAttempts") int maxAttempts);
+
+    /**
      * Count registrations by status
      * Used for cleanup statistics and monitoring
      *

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/ConfirmationTokenService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/ConfirmationTokenService.java
@@ -14,22 +14,38 @@ import java.util.UUID;
 /**
  * Service for generating and validating email confirmation and cancellation tokens.
  *
- * Generates short-lived JWT tokens (48h validity) for email-based registration confirmation and cancellation.
+ * Generates signed JWT tokens for email-based registration confirmation and cancellation.
  * Tokens contain registration details and cannot be forged without the secret key.
+ *
+ * Validity is configurable via {@code app.registration.confirmation-token-validity-hours}
+ * (default 4 days / 96 hours). It MUST stay below the registration cleanup window
+ * ({@code app.registration.cleanup-after-hours}) so a still-valid link always has a
+ * registration row to confirm — see {@link RegistrationCleanupService}.
  *
  * Security Features:
  * - JWT signature validation (HMAC-SHA256)
- * - Time-based expiry (48 hours)
+ * - Time-based expiry (configurable, default 4 days)
  * - Type validation (only "email-confirmation" or "registration-cancellation" tokens accepted)
  * - One-time use tracking (via confirmation timestamp or deletion in database)
  */
 @Service
 public class ConfirmationTokenService {
 
-    private final SecretKey signingKey;
-    private final long validityMs = 48 * 60 * 60 * 1000; // 48 hours
+    /**
+     * Default token validity: 4 days (96 hours). Widened from the original 48h so attendees
+     * have a longer window to click the confirmation link. MUST stay below the registration
+     * cleanup window so a still-valid link always has a row to confirm.
+     */
+    public static final long DEFAULT_VALIDITY_HOURS = 96;
 
-    public ConfirmationTokenService(@Value("${jwt.secret}") String secret) {
+    private final SecretKey signingKey;
+    private final long validityMs;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public ConfirmationTokenService(
+            @Value("${jwt.secret}") String secret,
+            @Value("${app.registration.confirmation-token-validity-hours:96}") long validityHours) {
+        this.validityMs = validityHours * 60L * 60L * 1000L;
         // Use provided secret or generate a secure random key for dev/test
         if (secret == null || secret.isEmpty() || "changeme".equals(secret)) {
             this.signingKey = Jwts.SIG.HS256.key().build();
@@ -41,11 +57,19 @@ public class ConfirmationTokenService {
     }
 
     /**
+     * Convenience constructor using the default 4-day validity. Intended for unit tests;
+     * production uses the {@code @Autowired} constructor with the configurable validity.
+     */
+    public ConfirmationTokenService(String secret) {
+        this(secret, DEFAULT_VALIDITY_HOURS);
+    }
+
+    /**
      * Generate confirmation token for registration.
      *
      * @param registrationId  UUID of the registration
      * @param eventCode       Event code (e.g., "BATbern57")
-     * @return JWT token string (valid for 48 hours)
+     * @return JWT token string (valid for the configured window, default 4 days)
      */
     public String generateConfirmationToken(UUID registrationId, String eventCode) {
         Date now = new Date();
@@ -110,7 +134,7 @@ public class ConfirmationTokenService {
      *
      * @param registrationId  UUID of the registration
      * @param eventCode       Event code (e.g., "BATbern57")
-     * @return JWT token string (valid for 48 hours)
+     * @return JWT token string (valid for the configured window, default 4 days)
      */
     public String generateCancellationToken(UUID registrationId, String eventCode) {
         Date now = new Date();

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/RegistrationCleanupService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/RegistrationCleanupService.java
@@ -2,9 +2,10 @@ package ch.batbern.events.service;
 
 import ch.batbern.events.domain.Registration;
 import ch.batbern.events.repository.RegistrationRepository;
-import lombok.RequiredArgsConstructor;
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,17 +19,58 @@ import java.util.List;
  * Story 4.1.5c: Automatic cleanup of registrations that were never email-confirmed
  *
  * Cleanup Rules:
- * - 'registered' status registrations > 48 hours old: Deleted (email confirmation not completed)
+ * - 'registered' status registrations older than the cleanup window are deleted (email
+ *   confirmation never completed). Window is configurable via
+ *   {@code app.registration.cleanup-after-hours} (default 120h / 5 days).
+ *
+ * INVARIANT: the cleanup window MUST exceed the confirmation-token validity
+ * ({@code app.registration.confirmation-token-validity-hours}, default 96h / 4 days) — otherwise a
+ * still-valid confirmation link could point at an already-deleted row. This service enforces the
+ * invariant defensively at runtime via {@link #effectiveCleanupHours()} (it never deletes a row
+ * whose link could still be valid) and warns at startup if the configured window is too small.
  *
  * Runs daily at 3 AM to minimize impact on production traffic
  * (Uses 3 AM to avoid collision with other scheduled jobs at 2 AM)
  */
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class RegistrationCleanupService {
 
+    /** Grace period kept between confirmation-link expiry and row deletion. */
+    private static final long CLEANUP_GRACE_HOURS = 24;
+
     private final RegistrationRepository registrationRepository;
+    private final long cleanupAfterHours;
+    private final long tokenValidityHours;
+
+    public RegistrationCleanupService(
+            RegistrationRepository registrationRepository,
+            @Value("${app.registration.cleanup-after-hours:120}") long cleanupAfterHours,
+            @Value("${app.registration.confirmation-token-validity-hours:96}") long tokenValidityHours) {
+        this.registrationRepository = registrationRepository;
+        this.cleanupAfterHours = cleanupAfterHours;
+        this.tokenValidityHours = tokenValidityHours;
+    }
+
+    /**
+     * Effective cleanup window in hours. Guarantees we never delete a registration whose
+     * confirmation link could still be valid, regardless of (mis)configuration:
+     * {@code max(configured cleanup, tokenValidity + grace)}.
+     */
+    long effectiveCleanupHours() {
+        return Math.max(cleanupAfterHours, tokenValidityHours + CLEANUP_GRACE_HOURS);
+    }
+
+    @PostConstruct
+    void verifyCleanupWindowInvariant() {
+        long minSafe = tokenValidityHours + CLEANUP_GRACE_HOURS;
+        if (cleanupAfterHours < minSafe) {
+            log.warn("Registration cleanup window ({}h) is below the safe minimum ({}h = token validity {}h "
+                    + "+ {}h grace); clamping to {}h so valid confirmation links are never orphaned. "
+                    + "Fix app.registration.cleanup-after-hours.",
+                    cleanupAfterHours, minSafe, tokenValidityHours, CLEANUP_GRACE_HOURS, effectiveCleanupHours());
+        }
+    }
 
     /**
      * Scheduled cleanup job - runs daily at 3 AM
@@ -59,24 +101,26 @@ public class RegistrationCleanupService {
     }
 
     /**
-     * Delete 'registered' status registrations older than 48 hours
-     * These are registrations where the user never clicked the email confirmation link
+     * Delete 'registered' status registrations older than the effective cleanup window.
+     * These are registrations where the user never clicked the email confirmation link.
      *
      * @param now Current timestamp
      * @return Number of registrations deleted
      */
     private int deleteUnconfirmedRegistrations(Instant now) {
-        Instant expiryThreshold = now.minus(48, ChronoUnit.HOURS);
+        long windowHours = effectiveCleanupHours();
+        Instant expiryThreshold = now.minus(windowHours, ChronoUnit.HOURS);
 
         List<Registration> unconfirmedRegistrations = registrationRepository
                 .findByStatusAndCreatedAtBefore("registered", expiryThreshold);
 
         if (unconfirmedRegistrations.isEmpty()) {
-            log.info("No unconfirmed registrations found older than 48 hours");
+            log.info("No unconfirmed registrations found older than {} hours", windowHours);
             return 0;
         }
 
-        log.info("Found {} unconfirmed registrations older than 48 hours", unconfirmedRegistrations.size());
+        log.info("Found {} unconfirmed registrations older than {} hours",
+                unconfirmedRegistrations.size(), windowHours);
 
         int deleted = 0;
         for (Registration registration : unconfirmedRegistrations) {
@@ -119,7 +163,7 @@ public class RegistrationCleanupService {
      */
     public CleanupStatistics getCleanupStatistics() {
         Instant now = Instant.now();
-        Instant expiryThreshold = now.minus(48, ChronoUnit.HOURS);
+        Instant expiryThreshold = now.minus(effectiveCleanupHours(), ChronoUnit.HOURS);
 
         long registeredCount = registrationRepository.countByStatus("registered");
         long confirmedCount = registrationRepository.countByStatus("confirmed");

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/RegistrationResendService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/RegistrationResendService.java
@@ -1,0 +1,163 @@
+package ch.batbern.events.service;
+
+import ch.batbern.events.client.UserApiClient;
+import ch.batbern.events.domain.Event;
+import ch.batbern.events.domain.Registration;
+import ch.batbern.events.dto.generated.users.UserResponse;
+import ch.batbern.events.repository.EventRepository;
+import ch.batbern.events.repository.RegistrationRepository;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Daily job that re-sends the registration-confirmation email to attendees who registered but
+ * never confirmed, after a grace window (default 2 days). Complements {@link RegistrationCleanupService}:
+ * cleanup eventually deletes never-confirmed rows; this job nudges the attendee with a fresh
+ * confirmation link first, so a missed/expired first email is recoverable without manual support.
+ *
+ * <p>Anti-spam / idempotency: each registration carries {@code confirmation_resend_count} and
+ * {@code confirmation_resent_at}. A registration is auto-resent at most {@code max-attempts} times
+ * (default 2), with at least {@code after-hours} between resends, so a daily run never floods inboxes.
+ *
+ * <p>Each resend regenerates fresh confirmation + cancellation JWTs (mirroring the organizer
+ * resend endpoint) so the new email always carries a link valid for the full configured window.
+ *
+ * <p>Runs daily at 08:30 (after speaker reminders at 08:00, before deadline reminders at 09:00).
+ * Cleanup runs earlier at 03:00, so rows past the cleanup horizon are already gone by the time this
+ * job scans; the {@code notExpiredAfter} bound is a defensive second guard.
+ */
+@Service
+@Slf4j
+public class RegistrationResendService {
+
+    private final RegistrationRepository registrationRepository;
+    private final EventRepository eventRepository;
+    private final ConfirmationTokenService confirmationTokenService;
+    private final RegistrationEmailService registrationEmailService;
+    private final UserApiClient userApiClient;
+
+    private final boolean enabled;
+    private final long afterHours;
+    private final int maxAttempts;
+    private final long cleanupAfterHours;
+    private final String appBaseUrl;
+
+    public RegistrationResendService(
+            RegistrationRepository registrationRepository,
+            EventRepository eventRepository,
+            ConfirmationTokenService confirmationTokenService,
+            RegistrationEmailService registrationEmailService,
+            UserApiClient userApiClient,
+            @Value("${app.registration.resend.enabled:true}") boolean enabled,
+            @Value("${app.registration.resend.after-hours:48}") long afterHours,
+            @Value("${app.registration.resend.max-attempts:2}") int maxAttempts,
+            @Value("${app.registration.cleanup-after-hours:120}") long cleanupAfterHours,
+            @Value("${app.base-url:https://batbern.ch}") String appBaseUrl) {
+        this.registrationRepository = registrationRepository;
+        this.eventRepository = eventRepository;
+        this.confirmationTokenService = confirmationTokenService;
+        this.registrationEmailService = registrationEmailService;
+        this.userApiClient = userApiClient;
+        this.enabled = enabled;
+        this.afterHours = afterHours;
+        this.maxAttempts = maxAttempts;
+        this.cleanupAfterHours = cleanupAfterHours;
+        this.appBaseUrl = appBaseUrl;
+    }
+
+    /**
+     * Scheduled resend job. ShedLock ensures a single ECS instance runs it.
+     */
+    @Scheduled(cron = "${app.registration.resend.cron:0 30 8 * * *}")
+    @SchedulerLock(
+            name = "resendUnconfirmedRegistrations",
+            lockAtLeastFor = "PT1M",
+            lockAtMostFor = "PT15M"
+    )
+    public void resendUnconfirmedRegistrations() {
+        if (!enabled) {
+            log.debug("Registration confirmation resend disabled; skipping scheduled execution");
+            return;
+        }
+        log.info("Starting scheduled resend of unconfirmed registration confirmations");
+
+        Instant now = Instant.now();
+        Instant eligibleBefore = now.minus(afterHours, ChronoUnit.HOURS);          // unconfirmed > grace window
+        Instant notExpiredAfter = now.minus(cleanupAfterHours, ChronoUnit.HOURS);  // still within active window
+        Instant resentBefore = now.minus(afterHours, ChronoUnit.HOURS);            // >= grace since last resend
+
+        List<Registration> eligible = registrationRepository.findResendEligible(
+                eligibleBefore, notExpiredAfter, resentBefore, maxAttempts);
+
+        if (eligible.isEmpty()) {
+            log.info("No unconfirmed registrations eligible for confirmation resend");
+            return;
+        }
+        log.info("Found {} unconfirmed registration(s) eligible for confirmation resend", eligible.size());
+
+        int sent = 0;
+        for (Registration registration : eligible) {
+            try {
+                if (resendFor(registration, now)) {
+                    sent++;
+                }
+            } catch (Exception e) {
+                // Don't let one failure stop the batch
+                log.error("Failed to resend confirmation for registration {}",
+                        registration.getRegistrationCode(), e);
+            }
+        }
+        log.info("Confirmation resend complete: {} of {} processed", sent, eligible.size());
+    }
+
+    private boolean resendFor(Registration registration, Instant now) {
+        Event event = eventRepository.findById(registration.getEventId()).orElse(null);
+        if (event == null) {
+            log.warn("Skipping resend for {} — event {} not found",
+                    registration.getRegistrationCode(), registration.getEventId());
+            return false;
+        }
+
+        UserResponse userProfile = userApiClient.getUserByUsername(registration.getAttendeeUsername());
+        if (userProfile == null || userProfile.getEmail() == null || userProfile.getEmail().isBlank()) {
+            log.warn("Skipping resend for {} — no resolvable email for attendee {}",
+                    registration.getRegistrationCode(), registration.getAttendeeUsername());
+            return false;
+        }
+
+        String confirmationToken = confirmationTokenService.generateConfirmationToken(
+                registration.getId(), event.getEventCode());
+        String cancellationToken = confirmationTokenService.generateCancellationToken(
+                registration.getId(), event.getEventCode());
+        String deregistrationUrl = registration.getDeregistrationToken() != null
+                ? appBaseUrl + "/deregister?token=" + registration.getDeregistrationToken()
+                : null;
+
+        registrationEmailService.sendRegistrationConfirmation(
+                registration,
+                userProfile,
+                event,
+                confirmationToken,
+                cancellationToken,
+                deregistrationUrl,
+                Locale.GERMAN);
+
+        int previous = registration.getConfirmationResendCount() == null
+                ? 0 : registration.getConfirmationResendCount();
+        registration.setConfirmationResentAt(now);
+        registration.setConfirmationResendCount(previous + 1);
+        registrationRepository.save(registration);
+
+        log.info("Resent confirmation email for registration {} (auto-resend attempt {} of {})",
+                registration.getRegistrationCode(), previous + 1, maxAttempts);
+        return true;
+    }
+}

--- a/services/event-management-service/src/main/resources/application.yml
+++ b/services/event-management-service/src/main/resources/application.yml
@@ -93,6 +93,18 @@ app:
     # on Accept/Decline, which would otherwise fan out to every organizer.
     calendar-organizer-email: ${EMAIL_CALENDAR_ORGANIZER:calendar@batbern.ch}
     reply-to: ${EMAIL_REPLY_TO:replies@batbern.ch}
+  # Registration confirmation lifecycle (link validity + cleanup + auto-resend).
+  # INVARIANT: cleanup-after-hours > confirmation-token-validity-hours, so a still-valid
+  # confirmation link always has a registration row to confirm (a longer link is useless
+  # if the row was already deleted). Enforced by RegistrationCleanupService at startup.
+  registration:
+    confirmation-token-validity-hours: ${REG_CONFIRMATION_TOKEN_VALIDITY_HOURS:96}   # 4 days
+    cleanup-after-hours: ${REG_CLEANUP_AFTER_HOURS:120}                               # 5 days
+    resend:
+      enabled: ${REG_RESEND_ENABLED:true}
+      cron: "0 30 8 * * *"                       # daily 08:30 (after speaker reminders, before deadline reminders)
+      after-hours: ${REG_RESEND_AFTER_HOURS:48}  # resend once a registration is >2 days unconfirmed
+      max-attempts: ${REG_RESEND_MAX_ATTEMPTS:2} # at most this many auto-resends per registration
 
 # Story 10.29: Newsletter send tuning (canary mode)
 newsletter:

--- a/services/event-management-service/src/main/resources/db/migration/V106__add_registration_resend_tracking.sql
+++ b/services/event-management-service/src/main/resources/db/migration/V106__add_registration_resend_tracking.sql
@@ -1,0 +1,22 @@
+-- V106__add_registration_resend_tracking.sql
+-- Feature: unconfirmed-registration auto-resend (link-validity hardening).
+--
+-- Adds bookkeeping columns used by RegistrationResendService — a daily job that re-sends the
+-- registration-confirmation email to attendees who registered but never clicked the confirmation
+-- link. The columns cap how many times a single registration is auto-resent and enforce a minimum
+-- gap between resends, so a daily run never floods inboxes.
+--
+--   confirmation_resent_at    — timestamp of the most recent automated resend (NULL = never resent)
+--   confirmation_resend_count — number of automated resends so far (default 0)
+--
+-- Backward compatible: both columns are nullable / defaulted, so existing rows are unaffected.
+-- Tuning lives in application.yml under app.registration.resend.*.
+
+ALTER TABLE registrations
+    ADD COLUMN IF NOT EXISTS confirmation_resent_at    TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS confirmation_resend_count INTEGER NOT NULL DEFAULT 0;
+
+-- Speeds up the daily resend scan: only still-pending ('registered') rows are ever eligible.
+CREATE INDEX IF NOT EXISTS idx_registrations_pending_resend
+    ON registrations (created_at)
+    WHERE status = 'registered';

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/ConfirmationTokenServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/ConfirmationTokenServiceTest.java
@@ -196,9 +196,9 @@ class ConfirmationTokenServiceTest {
     }
 
     @Test
-    @DisplayName("Should have 48-hour expiry period")
-    void should_have48HourExpiry_when_tokenGenerated() {
-        // Arrange
+    @DisplayName("Should default to 4-day (96h) expiry period")
+    void should_have4DayExpiry_byDefault() {
+        // Arrange — the single-arg convenience constructor uses DEFAULT_VALIDITY_HOURS (96h)
         UUID registrationId = UUID.randomUUID();
         String eventCode = "BATbern57";
 
@@ -206,13 +206,42 @@ class ConfirmationTokenServiceTest {
         String token = tokenService.generateConfirmationToken(registrationId, eventCode);
         Claims claims = tokenService.validateConfirmationToken(token);
 
-        // Assert
-        long issuedAt = claims.getIssuedAt().getTime();
-        long expiry = claims.getExpiration().getTime();
-        long validityMs = expiry - issuedAt;
-
-        // Should be 48 hours (in milliseconds)
-        long expectedValidityMs = 48 * 60 * 60 * 1000;
+        // Assert — 4 days (96 hours) in milliseconds
+        long validityMs = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
+        long expectedValidityMs = 96L * 60 * 60 * 1000;
         assertThat(validityMs).isEqualTo(expectedValidityMs);
+    }
+
+    @Test
+    @DisplayName("Should honor configured validity hours for confirmation tokens")
+    void should_useConfiguredValidity_when_validityHoursProvided() {
+        // Arrange — explicit non-default validity (72h)
+        ConfirmationTokenService customService =
+                new ConfirmationTokenService("test-secret-key-for-jwt-token-signing-minimum-256-bits", 72);
+        UUID registrationId = UUID.randomUUID();
+
+        // Act
+        Claims claims = customService.validateConfirmationToken(
+                customService.generateConfirmationToken(registrationId, "BATbern57"));
+
+        // Assert
+        long validityMs = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
+        assertThat(validityMs).isEqualTo(72L * 60 * 60 * 1000);
+    }
+
+    @Test
+    @DisplayName("Cancellation token should share the configured validity window")
+    void should_useConfiguredValidity_forCancellationToken() {
+        // Arrange — issued together with the confirmation token in the same email,
+        // so it must share the (default 4-day) window.
+        UUID registrationId = UUID.randomUUID();
+
+        // Act
+        Claims claims = tokenService.validateCancellationToken(
+                tokenService.generateCancellationToken(registrationId, "BATbern57"));
+
+        // Assert
+        long validityMs = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
+        assertThat(validityMs).isEqualTo(96L * 60 * 60 * 1000);
     }
 }

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/RegistrationCleanupServiceIntegrationTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/RegistrationCleanupServiceIntegrationTest.java
@@ -95,10 +95,10 @@ class RegistrationCleanupServiceIntegrationTest extends AbstractIntegrationTest 
     }
 
     @Test
-    @DisplayName("Should delete unconfirmed registrations older than 48 hours")
+    @DisplayName("Should delete unconfirmed registrations older than the cleanup window (default 5 days)")
     void shouldDeleteOldUnconfirmedRegistrations() {
-        // Arrange - Create registration 49 hours ago (should be deleted)
-        Instant expiredTime = Instant.now().minus(49, ChronoUnit.HOURS);
+        // Arrange - Create registration 6 days ago (older than the 5-day cleanup window → deleted)
+        Instant expiredTime = Instant.now().minus(6, ChronoUnit.DAYS);
         Registration oldUnconfirmed = createAndSaveRegistration(
                 "REG-OLD-001",
                 "registered",
@@ -117,7 +117,7 @@ class RegistrationCleanupServiceIntegrationTest extends AbstractIntegrationTest 
     @Test
     @DisplayName("Should NOT delete recent unconfirmed registrations")
     void shouldNotDeleteRecentUnconfirmedRegistrations() {
-        // Arrange - Create registration 47 hours ago (should NOT be deleted)
+        // Arrange - Create registration 47 hours ago (well within the 5-day cleanup window → kept)
         Instant recentTime = Instant.now().minus(47, ChronoUnit.HOURS);
         Registration recentUnconfirmed = createAndSaveRegistration(
                 "REG-RECENT-001",
@@ -160,7 +160,7 @@ class RegistrationCleanupServiceIntegrationTest extends AbstractIntegrationTest 
     @Disabled("TODO: Fix test isolation issue - cleanup service not deleting in multi-entity scenarios due to JPA/transaction management complexity")
     void shouldHandleMixedScenario() {
         // Arrange
-        Instant oldTime = Instant.now().minus(49, ChronoUnit.HOURS);
+        Instant oldTime = Instant.now().minus(6, ChronoUnit.DAYS);
         Instant recentTime = Instant.now().minus(47, ChronoUnit.HOURS);
 
         // Create various registrations
@@ -198,7 +198,7 @@ class RegistrationCleanupServiceIntegrationTest extends AbstractIntegrationTest 
     @Disabled("TODO: Fix test isolation issue - cleanup service not deleting in multi-entity scenarios due to JPA/transaction management complexity")
     void shouldReturnAccurateStatistics() {
         // Arrange
-        Instant oldTime = Instant.now().minus(49, ChronoUnit.HOURS);
+        Instant oldTime = Instant.now().minus(6, ChronoUnit.DAYS);
         Instant recentTime = Instant.now().minus(47, ChronoUnit.HOURS);
 
         createAndSaveRegistration("REG-OLD-001", "registered", oldTime);
@@ -236,7 +236,7 @@ class RegistrationCleanupServiceIntegrationTest extends AbstractIntegrationTest 
     @DisplayName("Manual trigger should work same as scheduled job")
     void shouldWorkViaManualTrigger() {
         // Arrange
-        Instant oldTime = Instant.now().minus(49, ChronoUnit.HOURS);
+        Instant oldTime = Instant.now().minus(6, ChronoUnit.DAYS);
         createAndSaveRegistration("REG-MANUAL-001", "registered", oldTime);
 
         // Act

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/RegistrationCleanupServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/RegistrationCleanupServiceTest.java
@@ -2,10 +2,11 @@ package ch.batbern.events.service;
 
 import ch.batbern.events.domain.Registration;
 import ch.batbern.events.repository.RegistrationRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -34,8 +35,13 @@ class RegistrationCleanupServiceTest {
     @Mock
     private RegistrationRepository registrationRepository;
 
-    @InjectMocks
     private RegistrationCleanupService cleanupService;
+
+    @BeforeEach
+    void setUp() {
+        // Default production config: 4-day token validity (96h), 5-day cleanup window (120h).
+        cleanupService = new RegistrationCleanupService(registrationRepository, 120, 96);
+    }
 
     @Test
     @DisplayName("Should delete unconfirmed registrations older than 48 hours")
@@ -157,6 +163,38 @@ class RegistrationCleanupServiceTest {
 
         // Assert
         verify(registrationRepository).findByStatusAndCreatedAtBefore(eq("registered"), any(Instant.class));
+    }
+
+    @Test
+    @DisplayName("Effective cleanup window is the larger of configured window and (token validity + grace)")
+    void effectiveCleanupHours_takesSafeMaximum() {
+        // Configured 120h vs token-validity 96h + 24h grace = 120h -> 120h
+        RegistrationCleanupService svc = new RegistrationCleanupService(registrationRepository, 120, 96);
+        assertThat(svc.effectiveCleanupHours()).isEqualTo(120);
+    }
+
+    @Test
+    @DisplayName("Cleanup window shorter than token validity is clamped so valid links are never orphaned")
+    void effectiveCleanupHours_clampsWhenBelowTokenValidity() {
+        // Misconfig: delete after 48h but link valid 96h -> clamp to 96 + 24 = 120h
+        RegistrationCleanupService svc = new RegistrationCleanupService(registrationRepository, 48, 96);
+        assertThat(svc.effectiveCleanupHours()).isEqualTo(120);
+    }
+
+    @Test
+    @DisplayName("Deletion threshold reflects the effective cleanup window, not the legacy 48h")
+    void deletesUsingEffectiveWindow() {
+        RegistrationCleanupService svc = new RegistrationCleanupService(registrationRepository, 120, 96);
+        when(registrationRepository.findByStatusAndCreatedAtBefore(eq("registered"), any(Instant.class)))
+                .thenReturn(Collections.emptyList());
+
+        svc.cleanupUnconfirmedRegistrations();
+
+        ArgumentCaptor<Instant> captor = ArgumentCaptor.forClass(Instant.class);
+        verify(registrationRepository).findByStatusAndCreatedAtBefore(eq("registered"), captor.capture());
+        // Threshold should be ~120h ago (allow a small clock delta around the boundary)
+        assertThat(captor.getValue()).isBeforeOrEqualTo(Instant.now().minus(119, ChronoUnit.HOURS));
+        assertThat(captor.getValue()).isAfter(Instant.now().minus(122, ChronoUnit.HOURS));
     }
 
     // Helper method to create test registrations

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/RegistrationResendServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/RegistrationResendServiceTest.java
@@ -1,0 +1,171 @@
+package ch.batbern.events.service;
+
+import ch.batbern.events.client.UserApiClient;
+import ch.batbern.events.domain.Event;
+import ch.batbern.events.domain.Registration;
+import ch.batbern.events.dto.generated.users.UserResponse;
+import ch.batbern.events.repository.EventRepository;
+import ch.batbern.events.repository.RegistrationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for RegistrationResendService (unconfirmed-registration auto-resend job).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RegistrationResendService Tests")
+class RegistrationResendServiceTest {
+
+    @Mock
+    private RegistrationRepository registrationRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private ConfirmationTokenService confirmationTokenService;
+
+    @Mock
+    private RegistrationEmailService registrationEmailService;
+
+    @Mock
+    private UserApiClient userApiClient;
+
+    private RegistrationResendService service;
+
+    @BeforeEach
+    void setUp() {
+        // enabled, resend after 48h, max 2 attempts, cleanup 120h, base url
+        service = new RegistrationResendService(
+                registrationRepository, eventRepository, confirmationTokenService,
+                registrationEmailService, userApiClient,
+                true, 48, 2, 120, "https://batbern.ch");
+    }
+
+    @Test
+    @DisplayName("Disabled: skips entirely without scanning the repository")
+    void disabled_skips() {
+        RegistrationResendService disabled = new RegistrationResendService(
+                registrationRepository, eventRepository, confirmationTokenService,
+                registrationEmailService, userApiClient,
+                false, 48, 2, 120, "https://batbern.ch");
+
+        disabled.resendUnconfirmedRegistrations();
+
+        verifyNoInteractions(registrationRepository, registrationEmailService, userApiClient);
+    }
+
+    @Test
+    @DisplayName("No eligible registrations: nothing sent, nothing saved")
+    void noEligible_doesNothing() {
+        when(registrationRepository.findResendEligible(any(), any(), any(), anyInt()))
+                .thenReturn(List.of());
+
+        service.resendUnconfirmedRegistrations();
+
+        verify(registrationEmailService, never())
+                .sendRegistrationConfirmation(any(), any(), any(), any(), any(), any(), any());
+        verify(registrationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Eligible registration: fresh tokens generated, email sent, resend tracked")
+    void eligible_resendsAndTracks() {
+        Registration reg = registration("BATbern59-reg-A", 0);
+        Event event = mock(Event.class);
+        when(event.getEventCode()).thenReturn("BATbern59");
+        UserResponse user = mock(UserResponse.class);
+        when(user.getEmail()).thenReturn("attendee@example.ch");
+
+        when(registrationRepository.findResendEligible(any(), any(), any(), eq(2)))
+                .thenReturn(List.of(reg));
+        when(eventRepository.findById(reg.getEventId())).thenReturn(Optional.of(event));
+        when(userApiClient.getUserByUsername("test.user")).thenReturn(user);
+        when(confirmationTokenService.generateConfirmationToken(reg.getId(), "BATbern59")).thenReturn("ctoken");
+        when(confirmationTokenService.generateCancellationToken(reg.getId(), "BATbern59")).thenReturn("xtoken");
+
+        service.resendUnconfirmedRegistrations();
+
+        verify(registrationEmailService).sendRegistrationConfirmation(
+                eq(reg), eq(user), eq(event), eq("ctoken"), eq("xtoken"), any(), any());
+        verify(registrationRepository).save(reg);
+        assertThat(reg.getConfirmationResendCount()).isEqualTo(1);
+        assertThat(reg.getConfirmationResentAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Attendee without a resolvable email is skipped (no send, no tracking)")
+    void noEmail_skips() {
+        Registration reg = registration("BATbern59-reg-B", 0);
+        Event event = mock(Event.class);
+        UserResponse user = mock(UserResponse.class);
+        when(user.getEmail()).thenReturn(null);
+
+        when(registrationRepository.findResendEligible(any(), any(), any(), anyInt()))
+                .thenReturn(List.of(reg));
+        when(eventRepository.findById(reg.getEventId())).thenReturn(Optional.of(event));
+        when(userApiClient.getUserByUsername("test.user")).thenReturn(user);
+
+        service.resendUnconfirmedRegistrations();
+
+        verify(registrationEmailService, never())
+                .sendRegistrationConfirmation(any(), any(), any(), any(), any(), any(), any());
+        verify(registrationRepository, never()).save(any());
+        assertThat(reg.getConfirmationResendCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("A failing registration does not stop the rest of the batch")
+    void continuesOnError() {
+        Registration bad = registration("BATbern59-reg-BAD", 0);
+        Registration good = registration("BATbern59-reg-GOOD", 0);
+        Event event = mock(Event.class);
+        when(event.getEventCode()).thenReturn("BATbern59");
+        UserResponse user = mock(UserResponse.class);
+        when(user.getEmail()).thenReturn("ok@example.ch");
+
+        when(registrationRepository.findResendEligible(any(), any(), any(), anyInt()))
+                .thenReturn(List.of(bad, good));
+        when(eventRepository.findById(bad.getEventId())).thenThrow(new RuntimeException("boom"));
+        when(eventRepository.findById(good.getEventId())).thenReturn(Optional.of(event));
+        when(userApiClient.getUserByUsername("test.user")).thenReturn(user);
+
+        service.resendUnconfirmedRegistrations();
+
+        // The good registration is still processed despite the earlier failure
+        verify(registrationRepository).save(good);
+        assertThat(good.getConfirmationResendCount()).isEqualTo(1);
+    }
+
+    private Registration registration(String code, int resendCount) {
+        return Registration.builder()
+                .id(UUID.randomUUID())
+                .registrationCode(code)
+                .eventId(UUID.randomUUID())
+                .attendeeUsername("test.user")
+                .status("registered")
+                .deregistrationToken(UUID.randomUUID())
+                .confirmationResendCount(resendCount)
+                .createdAt(Instant.now().minusSeconds(3L * 24 * 3600))
+                .build();
+    }
+}


### PR DESCRIPTION
## Why

Triggered by a support case (an attendee who registered but could never confirm) and the batch of **19 stuck `UNCONFIRMED` accounts** found alongside it. Root cause was **not** a broken link or a dead Lambda — the CustomEmailSender Lambda works and the link/confirm code is correct. The real failure mode is **expiry + a recovery dead-end**: a confirmation code/link expires, and then every recovery path dead-ends (`re-register → "email already exists"`, `reset password → "not registered"`), with no obvious "resend". This PR closes that dead-end systematically.

## What ships

**1. Registration confirmation links valid for 4 days (was 48h)** — `ConfirmationTokenService` validity is now configurable (`app.registration.confirmation-token-validity-hours`, default **96h**), applied to both confirmation and cancellation tokens.

**2. Cleanup window decoupled + made safe** — `RegistrationCleanupService` now deletes still-`registered` rows after `app.registration.cleanup-after-hours` (default **120h / 5 days**) and **defensively clamps** to `max(configured, tokenValidity + 24h)`, so a still-valid 4-day link can never point at an already-deleted row. (This coupling is the subtle part: lengthening the link without lengthening cleanup would have made the longer link useless.)

**3. Daily resend for unconfirmed *registrations*** — new `RegistrationResendService` (`@Scheduled` 08:30 + ShedLock) re-sends the confirmation email (with **fresh** tokens) to attendees unconfirmed for `> 2 days`, capped at **2** attempts via new `confirmation_resend_count` / `confirmation_resent_at` columns (**migration V106**).

**4. Daily resend for unconfirmed *Cognito sign-ups*** — new `CognitoConfirmationResendJob` in company-user-management-service (`@Scheduled` 08:15 + ShedLock) re-sends a fresh Cognito code (`ResendConfirmationCode` → `CustomEmailSender_SignUp`) to `UNCONFIRMED` accounts within a bounded signup-age window. IAM: CUMS task role granted `cognito-idp:ListUsers` + `cognito-idp:ResendConfirmationCode` (pool-scoped; SPA client has no secret).

## ⚠️ One decision needed (the bedtime question)

> *"Can we increase the link validity to 4 days?"*

- **Event-registration link → yes, done** (our own JWT, fully configurable).
- **Cognito account-confirmation link → not natively possible.** Cognito's sign-up confirmation code is **fixed at 24h** and has no configurability knob (only `tempPasswordValidity` is configurable). Achieving a true 4-day window there would require a **custom-token rework** (issue our own token, store it, custom verify endpoint calling `AdminConfirmSignUp`) — a meaningful auth-flow change I did **not** want to land unilaterally overnight.

**The daily Cognito resend job (#4) is the shipped mitigation** — instead of one 24h code, unconfirmed accounts get a fresh code automatically after the grace window. **Question for you:** is the resend-based mitigation enough, or do you want me to scope the custom-token rework for true 4-day Cognito validity?

## Config knobs (all defaulted; override via env)

| Key | Default | Meaning |
|---|---|---|
| `app.registration.confirmation-token-validity-hours` | 96 | registration link validity (4 days) |
| `app.registration.cleanup-after-hours` | 120 | delete unconfirmed registrations after (5 days) |
| `app.registration.resend.after-hours` / `.max-attempts` | 48 / 2 | resend a registration after 2 days, ≤2× |
| `cognito.resend.after-hours` / `.window-hours` | 48 / 48 | nudge an unconfirmed sign-up after 2 days, within a bounded window |
| `*.resend.enabled` | true | kill-switches for both jobs |

## Testing

- New/updated unit tests: `ConfirmationTokenServiceTest`, `RegistrationCleanupServiceTest`, `RegistrationResendServiceTest`, `CognitoConfirmationResendJobTest`.
- Updated integration test `RegistrationCleanupServiceIntegrationTest` to the new 5-day window.
- Full module suites green (event-management + company-user-management, Testcontainers — validates the V106 Flyway migration).

## Deploy notes

- **Not deployed.** These introduce **outbound-email** jobs, so they should ramp under your review. Merging to `develop` auto-deploys to staging(=production); the jobs are `@Scheduled` and fire daily at 08:15 / 08:30 — they begin emailing real unconfirmed users on the first scheduled run after deploy. Flip `*.resend.enabled=false` to hold them.
- The IAM grant is a **CDK/infra change** → needs a CDK deploy for the Cognito resend job to have permission (until then it logs and no-ops safely on AccessDenied).
- No real comms were sent during development (tests use mocked email/Cognito clients).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
