### PR TITLE
fix(newsletter+speakers): correct event start time and prefer company displayName

### DIFF
--- a/docs/api/events-api.openapi.yml
+++ b/docs/api/events-api.openapi.yml
@@ -7132,9 +7132,17 @@ components:
           maxLength: 100
         company:
           type: string
-          description: Speaker's company name (from User.companyId)
+          description: Speaker's company identifier/slug (from User.companyId). Stable key used for logo lookup — NOT for display.
           example: GoogleZH
           maxLength: 12
+        companyDisplayName:
+          type: string
+          description: |
+            Human-readable company name (companies.display_name, falling back to
+            companies.name, then the company slug). Prefer this over `company` for
+            display. Null when the speaker has no associated company.
+          example: Google Zürich
+          maxLength: 255
         profilePictureUrl:
           type: string
           format: uri
@@ -8529,7 +8537,14 @@ components:
         company:
           type: string
           nullable: true
-          description: Company or organization of the speaker
+          description: Company identifier/slug of the speaker (from User.companyId). Stable key — NOT for display.
+          example: TechCorpAG
+        companyDisplayName:
+          type: string
+          nullable: true
+          description: |
+            Human-readable company name (companies.display_name, falling back to
+            companies.name, then the slug). Prefer this over `company` for display.
           example: Tech Corp AG
         expertise:
           type: string

--- a/services/event-management-service/src/main/java/ch/batbern/events/client/UserApiClient.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/client/UserApiClient.java
@@ -13,6 +13,7 @@ import ch.batbern.events.exception.UserServiceException;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Client interface for communicating with the User Management Service API.
@@ -125,6 +126,19 @@ public interface UserApiClient {
      * @throws UserServiceException if API communication fails (5xx, timeout, network error)
      */
     List<CompanyBasicDto> getAllCompanies();
+
+    /**
+     * Resolve a map of company slug → human-readable display name.
+     *
+     * <p>The value is {@code displayName} when set, falling back to the company {@code name},
+     * then the slug itself — mirroring the {@code COALESCE(display_name, name, company_id)}
+     * resolution used by the cross-service portrait projection. Cached (15&nbsp;min) so callers
+     * enriching many speakers incur at most one upstream call per TTL.
+     *
+     * @return immutable map keyed by company slug ({@code User.companyId}); never null
+     * @throws UserServiceException if API communication fails (5xx, timeout, network error)
+     */
+    Map<String, String> getCompanyDisplayNames();
 
     // Story 11.C.2 (AR13/AR14): canonical speaker-provisioning + profile-patch operations.
 

--- a/services/event-management-service/src/main/java/ch/batbern/events/client/impl/UserApiClientImpl.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/client/impl/UserApiClientImpl.java
@@ -856,6 +856,27 @@ public class UserApiClientImpl implements UserApiClient {
     }
 
     /**
+     * Resolve company slug → display name, cached for 15 min in {@code userApiCache}.
+     * Mirrors {@code COALESCE(display_name, name, company_id)}: prefer displayName, then
+     * the company name, then (at the call site, via {@code getOrDefault}) the slug itself.
+     */
+    @Override
+    @Cacheable(value = "userApiCache", key = "'companyDisplayNames'")
+    public java.util.Map<String, String> getCompanyDisplayNames() {
+        java.util.Map<String, String> bySlug = new java.util.HashMap<>();
+        for (CompanyBasicDto company : getAllCompanies()) {
+            if (company.getName() == null) {
+                continue;
+            }
+            String display = (company.getDisplayName() != null && !company.getDisplayName().isBlank())
+                    ? company.getDisplayName()
+                    : company.getName();
+            bySlug.put(company.getName(), display);
+        }
+        return bySlug;
+    }
+
+    /**
      * Create HTTP headers with JWT token propagated from SecurityContext.
      *
      * Extracts the JWT token from the current security context and adds it

--- a/services/event-management-service/src/main/java/ch/batbern/events/controller/EventController.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/controller/EventController.java
@@ -485,8 +485,9 @@ public class EventController {
                     sm.put("presentationTitle", null);
                     sm.put("isConfirmed", su.isConfirmed());
                     sm.put("profilePictureUrl", portrait != null ? portrait.getProfilePictureUrl() : null);
-                    sm.put("company",          portrait != null ? portrait.getCompanyId() : null);
-                    sm.put("companyLogoUrl",   portrait != null ? portrait.getCompanyLogoUrl() : null);
+                    sm.put("company",            portrait != null ? portrait.getCompanyId() : null);
+                    sm.put("companyDisplayName", portrait != null ? portrait.getCompanyDisplayName() : null);
+                    sm.put("companyLogoUrl",     portrait != null ? portrait.getCompanyLogoUrl() : null);
                     sm.put("bio", null); // Only needed on detail page
                     return sm;
                 })

--- a/services/event-management-service/src/main/java/ch/batbern/events/dto/SessionSpeakerResponse.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/dto/SessionSpeakerResponse.java
@@ -25,7 +25,8 @@ public class SessionSpeakerResponse {
     private String username;
     private String firstName;
     private String lastName;
-    private String company;
+    private String company; // company identifier/slug (User.companyId) — stable key, not for display
+    private String companyDisplayName; // human-readable name (displayName ?? name ?? slug); prefer for display
     private String profilePictureUrl;
     private String bio;
 

--- a/services/event-management-service/src/main/java/ch/batbern/events/dto/SpeakerPoolResponse.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/dto/SpeakerPoolResponse.java
@@ -17,7 +17,8 @@ public class SpeakerPoolResponse {
     private UUID id;
     private UUID eventId;
     private String speakerName;
-    private String company;
+    private String company; // company identifier/slug (User.companyId) — stable key, not for display
+    private String companyDisplayName; // human-readable name (displayName ?? name ?? slug); prefer for display
     private String expertise;
     private String assignedOrganizerId;
     private String status;
@@ -233,6 +234,14 @@ public class SpeakerPoolResponse {
 
     public void setCompany(String company) {
         this.company = company;
+    }
+
+    public String getCompanyDisplayName() {
+        return companyDisplayName;
+    }
+
+    public void setCompanyDisplayName(String companyDisplayName) {
+        this.companyDisplayName = companyDisplayName;
     }
 
     public String getExpertise() {

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/NewsletterEmailService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/NewsletterEmailService.java
@@ -859,7 +859,11 @@ public class NewsletterEmailService {
                         if (name.isBlank()) {
                             name = sp.getUsername();
                         }
-                        String company = sp.getCompany() != null ? sp.getCompany().trim() : "";
+                        // Prefer the human-readable display name; fall back to the slug.
+                        String company = sp.getCompanyDisplayName() != null
+                                && !sp.getCompanyDisplayName().isBlank()
+                                ? sp.getCompanyDisplayName().trim()
+                                : (sp.getCompany() != null ? sp.getCompany().trim() : "");
                         return company.isBlank() ? name : name + ", " + company;
                     })
                     .collect(Collectors.joining("; "));

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/NewsletterEmailService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/NewsletterEmailService.java
@@ -972,7 +972,12 @@ public class NewsletterEmailService {
     }
 
     private String formatEventTime(Event event, boolean isDe) {
-        return isDe ? "ab 16:00 Uhr" : "from 4:00 PM";
+        // Resolve the real start time (sessions → event-type config → fallback) via the
+        // shared EventTimeResolver — the same source as the registration email and the
+        // .ics attachment. Previously hardcoded to 16:00, which mis-stated every event
+        // whose actual start differs (e.g. afternoon events at 13:00 — BATbern59 incident).
+        String startTime = eventTimeResolver.formatStartTime(event);
+        return isDe ? "ab " + startTime + " Uhr" : "from " + startTime;
     }
 
     private String computeFinalStatus(int sentCount, int failedCount) {

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/PrimarySpeakerResolver.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/PrimarySpeakerResolver.java
@@ -166,6 +166,8 @@ public class PrimarySpeakerResolver {
         }
         if (p.companyName() != null && !p.companyName().isBlank()) {
             response.setCompany(p.companyName());
+            response.setCompanyDisplayName(
+                    userApiClient.getCompanyDisplayNames().getOrDefault(p.companyName(), p.companyName()));
         }
     }
 

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/SessionUserService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/SessionUserService.java
@@ -256,7 +256,8 @@ public class SessionUserService {
                 .username(user.getId())
                 .firstName(user.getFirstName())
                 .lastName(user.getLastName())
-                .company(user.getCompanyId()) // companyId is the company name per Story 1.16.2
+                .company(user.getCompanyId()) // companyId is the company name (slug) per Story 1.16.2
+                .companyDisplayName(resolveCompanyDisplayName(user.getCompanyId()))
                 .profilePictureUrl(user.getProfilePictureUrl() != null ? user.getProfilePictureUrl().toString() : null)
                 .bio(user.getBio())
                 .speakerRole(sessionUser.getSpeakerRole())
@@ -264,6 +265,17 @@ public class SessionUserService {
                 .presentationTitle(null)
                 .isConfirmed(sessionUser.isConfirmed())
                 .build();
+    }
+
+    /**
+     * Resolve a company slug to its human-readable display name (displayName ?? name ?? slug)
+     * via the cached company map. Returns {@code null} when the speaker has no company.
+     */
+    private String resolveCompanyDisplayName(String companySlug) {
+        if (companySlug == null || companySlug.isBlank()) {
+            return null;
+        }
+        return userApiClient.getCompanyDisplayNames().getOrDefault(companySlug, companySlug);
     }
 
 }

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/SpeakerPoolService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/SpeakerPoolService.java
@@ -204,6 +204,9 @@ public class SpeakerPoolService {
             }
         }
 
+        // Cached (15 min) slug → display-name map; one lookup serves every row in this page.
+        final Map<String, String> companyDisplayNames = userApiClient.getCompanyDisplayNames();
+
         return speakers.stream()
                 .map(speaker -> {
                     Session session = speaker.getSessionId() != null
@@ -224,6 +227,11 @@ public class SpeakerPoolService {
                             UserResponse user = userByUsername.get(primary.getUsername());
                             applySessionIdentityOverlay(response, primary, user);
                         }
+                    }
+                    // Resolve the company slug to its human-readable display name for the UI.
+                    if (response.getCompany() != null && !response.getCompany().isBlank()) {
+                        response.setCompanyDisplayName(companyDisplayNames
+                                .getOrDefault(response.getCompany(), response.getCompany()));
                     }
                     // Enrich with material info if session exists
                     if (speaker.getSessionId() != null) {

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/NewsletterEmailServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/NewsletterEmailServiceTest.java
@@ -199,6 +199,43 @@ class NewsletterEmailServiceTest {
         assertThat(vars.get("registrationLink")).isEqualTo("https://batbern.ch/register/BATbern58");
     }
 
+    // ── buildVariables: eventTime ─────────────────────────────────────────────
+    // Regression for the BATbern59 incident: the newsletter showed a hardcoded
+    // "16:00" instead of the event's real start time (13:00, resolved from the
+    // published agenda / afternoon event-type config). eventTime MUST come from
+    // EventTimeResolver — the same source used by the registration email and the
+    // .ics attachment — never a literal.
+
+    @Test
+    @DisplayName("buildVariables: eventTime is resolved from EventTimeResolver, not hardcoded (DE)")
+    void buildVariables_eventTime_de_usesResolverStartTime() {
+        when(eventTimeResolver.formatStartTime(testEvent)).thenReturn("13:00");
+
+        Map<String, String> vars = newsletterEmailService.buildVariables(testEvent, "de", false, "");
+
+        assertThat(vars.get("eventTime")).isEqualTo("ab 13:00 Uhr");
+    }
+
+    @Test
+    @DisplayName("buildVariables: eventTime is resolved from EventTimeResolver, not hardcoded (EN)")
+    void buildVariables_eventTime_en_usesResolverStartTime() {
+        when(eventTimeResolver.formatStartTime(testEvent)).thenReturn("13:00");
+
+        Map<String, String> vars = newsletterEmailService.buildVariables(testEvent, "en", false, "");
+
+        assertThat(vars.get("eventTime")).isEqualTo("from 13:00");
+    }
+
+    @Test
+    @DisplayName("buildVariables: eventTime never falls back to the old hardcoded 16:00")
+    void buildVariables_eventTime_doesNotHardcodeSixteenHundred() {
+        when(eventTimeResolver.formatStartTime(testEvent)).thenReturn("13:00");
+
+        Map<String, String> vars = newsletterEmailService.buildVariables(testEvent, "de", false, "");
+
+        assertThat(vars.get("eventTime")).doesNotContain("16:00").doesNotContain("4:00 PM");
+    }
+
     // ── buildVariables: currentYear ───────────────────────────────────────────
 
     @Test

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/NewsletterEmailServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/NewsletterEmailServiceTest.java
@@ -302,6 +302,58 @@ class NewsletterEmailServiceTest {
         assertThat(result).containsOnlyOnce("</tr></tbody>");
     }
 
+    @Test
+    @DisplayName("buildSpeakersSection: renders companyDisplayName, not the slug, when present")
+    void buildSpeakersSection_prefersCompanyDisplayName() {
+        testEvent.setWorkflowState(ch.batbern.shared.types.EventWorkflowState.AGENDA_PUBLISHED);
+
+        Session session = new Session();
+        session.setSessionType("presentation");
+        session.setTitle("Agentic AI in Swisscom");
+
+        SessionSpeakerResponse sp = SessionSpeakerResponse.builder()
+                .username("anna.meier")
+                .firstName("Anna")
+                .lastName("Meier")
+                .company("swisscomZH")                 // slug — must NOT be shown
+                .companyDisplayName("Swisscom (Schweiz) AG") // display name — must be shown
+                .build();
+
+        when(sessionRepository.findByEventIdWithSpeakers(testEvent.getId()))
+                .thenReturn(List.of(session));
+        when(sessionUserService.getSessionSpeakers(any())).thenReturn(List.of(sp));
+
+        String result = newsletterEmailService.buildSpeakersSection(testEvent, true);
+
+        assertThat(result).contains("Anna Meier, Swisscom (Schweiz) AG");
+        assertThat(result).doesNotContain("swisscomZH");
+    }
+
+    @Test
+    @DisplayName("buildSpeakersSection: falls back to slug when companyDisplayName is absent")
+    void buildSpeakersSection_fallsBackToSlugWhenNoDisplayName() {
+        testEvent.setWorkflowState(ch.batbern.shared.types.EventWorkflowState.AGENDA_PUBLISHED);
+
+        Session session = new Session();
+        session.setSessionType("presentation");
+        session.setTitle("Zero Trust");
+
+        SessionSpeakerResponse sp = SessionSpeakerResponse.builder()
+                .username("bob.huber")
+                .firstName("Bob")
+                .lastName("Huber")
+                .company("postfinance")
+                .build(); // no companyDisplayName
+
+        when(sessionRepository.findByEventIdWithSpeakers(testEvent.getId()))
+                .thenReturn(List.of(session));
+        when(sessionUserService.getSessionSpeakers(any())).thenReturn(List.of(sp));
+
+        String result = newsletterEmailService.buildSpeakersSection(testEvent, true);
+
+        assertThat(result).contains("Bob Huber, postfinance");
+    }
+
     // ── templateKey: custom key routing ──────────────────────────────────────
 
     @Test

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/PrimarySpeakerResolverTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/PrimarySpeakerResolverTest.java
@@ -242,4 +242,77 @@ class PrimarySpeakerResolverTest {
             assertThat(resolver.resolveEmail(pool)).isEmpty();
         }
     }
+
+    @Nested
+    @DisplayName("applyOverlay(SpeakerPoolResponse, SpeakerPool)")
+    class ApplyOverlay {
+
+        @Test
+        @DisplayName("sets both the company slug and the resolved companyDisplayName")
+        void shouldSetCompanyAndDisplayName() {
+            UUID sessionId = UUID.randomUUID();
+            SpeakerPool pool = SpeakerPool.builder()
+                    .id(UUID.randomUUID())
+                    .sessionId(sessionId)
+                    .build();
+            SessionUser primary = SessionUser.builder()
+                    .id(UUID.randomUUID())
+                    .session(Session.builder().id(sessionId).build())
+                    .username("nissim.buchs.3")
+                    .speakerRole(SessionUser.SpeakerRole.PRIMARY_SPEAKER)
+                    .build();
+            UserResponse user = new UserResponse();
+            user.setId("nissim.buchs.3");
+            user.setFirstName("Nissim");
+            user.setLastName("Buchs");
+            user.setCompanyId("ELCA");
+
+            when(sessionUserRepository.findBySessionIdAndSpeakerRole(
+                    sessionId, SessionUser.SpeakerRole.PRIMARY_SPEAKER))
+                    .thenReturn(Optional.of(primary));
+            when(userApiClient.getUserByUsername("nissim.buchs.3")).thenReturn(user);
+            when(userApiClient.getCompanyDisplayNames())
+                    .thenReturn(java.util.Map.of("ELCA", "ELCA Informatique SA"));
+
+            ch.batbern.events.dto.SpeakerPoolResponse response =
+                    new ch.batbern.events.dto.SpeakerPoolResponse();
+            resolver.applyOverlay(response, pool);
+
+            assertThat(response.getCompany()).isEqualTo("ELCA");
+            assertThat(response.getCompanyDisplayName()).isEqualTo("ELCA Informatique SA");
+        }
+
+        @Test
+        @DisplayName("falls back to the slug as displayName when the slug is unknown")
+        void shouldFallBackToSlug_whenUnknown() {
+            UUID sessionId = UUID.randomUUID();
+            SpeakerPool pool = SpeakerPool.builder()
+                    .id(UUID.randomUUID())
+                    .sessionId(sessionId)
+                    .build();
+            SessionUser primary = SessionUser.builder()
+                    .id(UUID.randomUUID())
+                    .session(Session.builder().id(sessionId).build())
+                    .username("jane.doe")
+                    .speakerRole(SessionUser.SpeakerRole.PRIMARY_SPEAKER)
+                    .build();
+            UserResponse user = new UserResponse();
+            user.setId("jane.doe");
+            user.setFirstName("Jane");
+            user.setLastName("Doe");
+            user.setCompanyId("UnknownCo");
+
+            when(sessionUserRepository.findBySessionIdAndSpeakerRole(
+                    sessionId, SessionUser.SpeakerRole.PRIMARY_SPEAKER))
+                    .thenReturn(Optional.of(primary));
+            when(userApiClient.getUserByUsername("jane.doe")).thenReturn(user);
+            when(userApiClient.getCompanyDisplayNames()).thenReturn(java.util.Map.of());
+
+            ch.batbern.events.dto.SpeakerPoolResponse response =
+                    new ch.batbern.events.dto.SpeakerPoolResponse();
+            resolver.applyOverlay(response, pool);
+
+            assertThat(response.getCompanyDisplayName()).isEqualTo("UnknownCo");
+        }
+    }
 }

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/SessionUserServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/SessionUserServiceTest.java
@@ -125,6 +125,39 @@ class SessionUserServiceTest {
     }
 
     @Test
+    void should_resolveCompanyDisplayName_when_companyHasDisplayName() {
+        // Given: the company slug resolves to a human-readable display name
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(testSession));
+        when(userApiClient.getUserByUsername(username)).thenReturn(testUser);
+        when(userApiClient.getCompanyDisplayNames())
+                .thenReturn(java.util.Map.of("GoogleZH", "Google Zürich"));
+        when(sessionUserRepository.existsBySessionIdAndUsername(sessionId, username)).thenReturn(false);
+        when(sessionUserRepository.save(any(SessionUser.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        SessionSpeakerResponse response = sessionUserService.assignSpeakerToSession(
+                sessionId, username, SpeakerRole.PRIMARY_SPEAKER, null);
+
+        // Then: slug retained as the stable key, display name resolved for the UI
+        assertThat(response.getCompany()).isEqualTo("GoogleZH");
+        assertThat(response.getCompanyDisplayName()).isEqualTo("Google Zürich");
+    }
+
+    @Test
+    void should_fallBackToSlug_when_companyHasNoDisplayName() {
+        // Given: the company slug is absent from the display-name map
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(testSession));
+        when(userApiClient.getUserByUsername(username)).thenReturn(testUser);
+        when(userApiClient.getCompanyDisplayNames()).thenReturn(java.util.Map.of());
+        when(sessionUserRepository.existsBySessionIdAndUsername(sessionId, username)).thenReturn(false);
+        when(sessionUserRepository.save(any(SessionUser.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        SessionSpeakerResponse response = sessionUserService.assignSpeakerToSession(
+                sessionId, username, SpeakerRole.PRIMARY_SPEAKER, null);
+
+        assertThat(response.getCompanyDisplayName()).isEqualTo("GoogleZH");
+    }
+
+    @Test
     void should_throwException_when_sessionNotFound() {
         // Given: Session does not exist
         when(sessionRepository.findById(sessionId)).thenReturn(Optional.empty());

--- a/web-frontend/src/components/public/Event/SpeakerDisplay.tsx
+++ b/web-frontend/src/components/public/Event/SpeakerDisplay.tsx
@@ -55,6 +55,10 @@ export const SpeakerDisplay = ({
 
   const logoUrl = speaker.companyLogoUrl ?? company?.logo?.url;
 
+  // Prefer the human-readable display name; fall back to the slug. `speaker.company`
+  // (the slug) stays the stable key for logo lookup above — only the label changes.
+  const companyLabel = speaker.companyDisplayName ?? speaker.company;
+
   // Size mappings
   const sizeClasses = {
     small: {
@@ -118,7 +122,7 @@ export const SpeakerDisplay = ({
         {speaker.company && (
           <div className={`${sizes.company} text-zinc-400 flex items-center gap-1.5`}>
             <Building2 className="h-3 w-3 flex-shrink-0" />
-            <span className="truncate">{speaker.company}</span>
+            <span className="truncate">{companyLabel}</span>
           </div>
         )}
       </div>
@@ -131,7 +135,7 @@ export const SpeakerDisplay = ({
           {logoUrl ? (
             <img
               src={logoUrl}
-              alt={`${speaker.company} logo`}
+              alt={`${companyLabel} logo`}
               className={`${sizes.logoImage} object-contain`}
               width={128}
               height={64}

--- a/web-frontend/src/components/public/Event/SpeakerGrid.tsx
+++ b/web-frontend/src/components/public/Event/SpeakerGrid.tsx
@@ -15,6 +15,7 @@ interface SpeakerWithSession {
   firstName: string;
   lastName: string;
   company?: string;
+  companyDisplayName?: string;
   profilePictureUrl?: string;
   sessionTitle: string;
   sessionDescription?: string;
@@ -46,6 +47,7 @@ export const SpeakerGrid = ({ sessions }: SpeakerGridProps) => {
               firstName: speaker.firstName,
               lastName: speaker.lastName,
               company: speaker.company,
+              companyDisplayName: speaker.companyDisplayName,
               profilePictureUrl: speaker.profilePictureUrl,
               sessionTitle: speaker.presentationTitle || session.title,
               sessionDescription: session.description,
@@ -80,6 +82,7 @@ export const SpeakerGrid = ({ sessions }: SpeakerGridProps) => {
                   firstName: speaker.firstName,
                   lastName: speaker.lastName,
                   company: speaker.company,
+                  companyDisplayName: speaker.companyDisplayName,
                   profilePictureUrl: speaker.profilePictureUrl,
                   bio: speaker.bio,
                   speakerRole:

--- a/web-frontend/src/components/public/Event/__tests__/SpeakerDisplay.test.tsx
+++ b/web-frontend/src/components/public/Event/__tests__/SpeakerDisplay.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * SpeakerDisplay — company label rendering
+ *
+ * Regression for the company-name bug: the public event page must show the
+ * company's human-readable displayName, never the raw slug. The slug stays the
+ * key for logo lookup (useCompany), so we mock that hook out here.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import type { SessionSpeaker } from '@/types/event.types';
+
+// Mock the data hooks — this test is about the company label, not logos/portraits.
+vi.mock('@/hooks/useCompany/useCompany', () => ({
+  useCompany: () => ({ data: undefined }),
+}));
+vi.mock('@/hooks/useUserPortrait', () => ({
+  useUserPortrait: () => ({ data: undefined }),
+}));
+vi.mock('react-intersection-observer', () => ({
+  useInView: () => ({ ref: vi.fn(), inView: false }),
+}));
+
+import { SpeakerDisplay } from '../SpeakerDisplay';
+
+const baseSpeaker: SessionSpeaker = {
+  username: 'anna.meier',
+  firstName: 'Anna',
+  lastName: 'Meier',
+  speakerRole: 'PRIMARY_SPEAKER',
+  isConfirmed: true,
+};
+
+describe('SpeakerDisplay — company label', () => {
+  test('should_renderCompanyDisplayName_when_present', () => {
+    render(
+      <SpeakerDisplay
+        speaker={{
+          ...baseSpeaker,
+          company: 'swisscomZH',
+          companyDisplayName: 'Swisscom (Schweiz) AG',
+        }}
+      />
+    );
+
+    expect(screen.getByText('Swisscom (Schweiz) AG')).toBeInTheDocument();
+    expect(screen.queryByText('swisscomZH')).not.toBeInTheDocument();
+  });
+
+  test('should_fallBackToSlug_when_companyDisplayNameMissing', () => {
+    render(<SpeakerDisplay speaker={{ ...baseSpeaker, company: 'postfinance' }} />);
+
+    expect(screen.getByText('postfinance')).toBeInTheDocument();
+  });
+});

--- a/web-frontend/src/pages/presentation/SpeakerCard.tsx
+++ b/web-frontend/src/pages/presentation/SpeakerCard.tsx
@@ -88,7 +88,7 @@ export function SpeakerCard({ speaker }: SpeakerCardProps): JSX.Element {
         {logoUrl && (
           <img
             src={logoUrl}
-            alt={speaker.company ?? ''}
+            alt={speaker.companyDisplayName ?? speaker.company ?? ''}
             style={{
               height: '2.5vw',
               maxWidth: '9.375vw',

--- a/web-frontend/src/pages/public/ArchiveEventDetailPage.tsx
+++ b/web-frontend/src/pages/public/ArchiveEventDetailPage.tsx
@@ -15,7 +15,7 @@ import { EventDescriptionSection } from '@/components/public/Event/EventDescript
 import { InfiniteMarquee } from '@/components/public/Testimonials/InfiniteMarquee';
 import { eventApiClient } from '@/services/eventApiClient';
 import { useEventPhotos } from '@/hooks/useEventPhotos';
-import type { EventDetailUI, SessionUI, SpeakerUI } from '@/types/event.types';
+import type { EventDetailUI, SessionUI, SessionSpeaker } from '@/types/event.types';
 
 export default function ArchiveEventDetailPage() {
   const { eventCode } = useParams<{ eventCode: string }>();
@@ -79,16 +79,19 @@ export default function ArchiveEventDetailPage() {
     return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
   };
 
-  // Collect all unique speakers (cast to SpeakerUI for extended properties)
-  const allSpeakers =
+  // Derive the speaker's display name from the API fields (firstName/lastName),
+  // falling back to the username. The API does not send a `fullName` field.
+  const speakerFullName = (s: SessionSpeaker) =>
+    [s.firstName, s.lastName].filter(Boolean).join(' ').trim() || s.username || 'Unknown';
+
+  // Collect all unique speakers across sessions, de-duplicated by username
+  // (the public event API returns SessionSpeaker objects keyed by username).
+  const allSpeakers: SessionSpeaker[] =
     (event?.sessions as SessionUI[] | undefined)
       ?.flatMap((session) => session.speakers || [])
       .filter(
-        (speaker, index, arr) =>
-          arr.findIndex((s) => (s as SpeakerUI).speakerId === (speaker as SpeakerUI).speakerId) ===
-          index
-      )
-      .map((speaker) => speaker as SpeakerUI) || [];
+        (speaker, index, arr) => arr.findIndex((s) => s.username === speaker.username) === index
+      ) || [];
 
   // SEO metadata
   const pageUrl = `${window.location.origin}/archive/${eventCode}`;
@@ -126,11 +129,11 @@ export default function ArchiveEventDetailPage() {
           allSpeakers.length > 0
             ? allSpeakers.map((speaker) => ({
                 '@type': 'Person',
-                name: speaker.fullName,
-                ...(speaker.companyName && {
+                name: speakerFullName(speaker),
+                ...((speaker.companyDisplayName ?? speaker.company) && {
                   affiliation: {
                     '@type': 'Organization',
-                    name: speaker.companyName,
+                    name: speaker.companyDisplayName ?? speaker.company,
                   },
                 }),
               }))
@@ -249,13 +252,13 @@ export default function ArchiveEventDetailPage() {
                       {session.speakers && session.speakers.length > 0 && (
                         <div className="mb-3">
                           <div className="text-sm text-muted-foreground">
-                            {(session.speakers as SpeakerUI[]).map((speaker, idx) => (
-                              <span key={speaker.speakerId}>
-                                <span className="font-medium">{speaker.fullName}</span>
-                                {speaker.companyName && (
+                            {(session.speakers ?? []).map((speaker, idx) => (
+                              <span key={speaker.username}>
+                                <span className="font-medium">{speakerFullName(speaker)}</span>
+                                {(speaker.companyDisplayName ?? speaker.company) && (
                                   <span className="text-muted-foreground">
                                     {' '}
-                                    ({speaker.companyName})
+                                    ({speaker.companyDisplayName ?? speaker.company})
                                   </span>
                                 )}
                                 {idx < session.speakers!.length - 1 && ', '}
@@ -296,25 +299,25 @@ export default function ArchiveEventDetailPage() {
                 </h2>
                 <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                   {allSpeakers.map((speaker) => (
-                    <div key={speaker.speakerId} className="text-center">
-                      {speaker.photoUrl ? (
+                    <div key={speaker.username} className="text-center">
+                      {speaker.profilePictureUrl ? (
                         <img
-                          src={speaker.photoUrl}
-                          alt={speaker.fullName}
+                          src={speaker.profilePictureUrl}
+                          alt={speakerFullName(speaker)}
                           className="w-24 h-24 rounded-full mx-auto mb-3 object-cover"
                         />
                       ) : (
                         <div className="w-24 h-24 rounded-full bg-muted mx-auto mb-3 flex items-center justify-center">
                           <span className="text-2xl font-medium text-muted-foreground">
-                            {getInitials(speaker.fullName || '')}
+                            {getInitials(speakerFullName(speaker))}
                           </span>
                         </div>
                       )}
-                      <div className="font-medium text-foreground">
-                        {speaker.fullName || 'Unknown'}
-                      </div>
-                      {speaker.companyName && (
-                        <div className="text-sm text-muted-foreground">{speaker.companyName}</div>
+                      <div className="font-medium text-foreground">{speakerFullName(speaker)}</div>
+                      {(speaker.companyDisplayName ?? speaker.company) && (
+                        <div className="text-sm text-muted-foreground">
+                          {speaker.companyDisplayName ?? speaker.company}
+                        </div>
                       )}
                     </div>
                   ))}

--- a/web-frontend/src/pages/public/__tests__/ArchiveEventDetailPage.test.tsx
+++ b/web-frontend/src/pages/public/__tests__/ArchiveEventDetailPage.test.tsx
@@ -86,10 +86,12 @@ describe('ArchiveEventDetailPage Component', () => {
         endTime: '18:30',
         speakers: [
           {
-            speakerId: 'sp1',
-            fullName: 'John Doe',
-            companyName: 'TechCorp',
-            photoUrl: 'https://cdn.batbern.ch/speakers/john.jpg',
+            username: 'john.doe',
+            firstName: 'John',
+            lastName: 'Doe',
+            company: 'tcorp-zh', // slug — must NOT be shown
+            companyDisplayName: 'TechCorp', // display name — must be shown
+            profilePictureUrl: 'https://cdn.batbern.ch/speakers/john.jpg',
           },
         ],
         presentationUrl: 'https://cdn.batbern.ch/2024/presentations/serverless.pdf',
@@ -103,15 +105,19 @@ describe('ArchiveEventDetailPage Component', () => {
         endTime: '19:05',
         speakers: [
           {
-            speakerId: 'sp2',
-            fullName: 'Jane Smith',
-            companyName: 'CloudInc',
-            photoUrl: 'https://cdn.batbern.ch/speakers/jane.jpg',
+            username: 'jane.smith',
+            firstName: 'Jane',
+            lastName: 'Smith',
+            company: 'cloud-zh',
+            companyDisplayName: 'CloudInc',
+            profilePictureUrl: 'https://cdn.batbern.ch/speakers/jane.jpg',
           },
           {
-            speakerId: 'sp3',
-            fullName: 'Bob Wilson',
-            companyName: 'StartupXYZ',
+            username: 'bob.wilson',
+            firstName: 'Bob',
+            lastName: 'Wilson',
+            company: 'startup-zh',
+            companyDisplayName: 'StartupXYZ',
           },
         ],
         presentationUrl: 'https://cdn.batbern.ch/2024/presentations/kubernetes.pdf',
@@ -125,10 +131,12 @@ describe('ArchiveEventDetailPage Component', () => {
         endTime: '19:40',
         speakers: [
           {
-            speakerId: 'sp4',
-            fullName: 'Alice Johnson',
-            companyName: 'DevCo',
-            photoUrl: 'https://cdn.batbern.ch/speakers/alice.jpg',
+            username: 'alice.johnson',
+            firstName: 'Alice',
+            lastName: 'Johnson',
+            company: 'devco-zh',
+            companyDisplayName: 'DevCo',
+            profilePictureUrl: 'https://cdn.batbern.ch/speakers/alice.jpg',
           },
         ],
       },
@@ -140,9 +148,11 @@ describe('ArchiveEventDetailPage Component', () => {
         endTime: '20:15',
         speakers: [
           {
-            speakerId: 'sp5',
-            fullName: 'Charlie Brown',
-            companyName: 'FinTech Solutions',
+            username: 'charlie.brown',
+            firstName: 'Charlie',
+            lastName: 'Brown',
+            company: 'fintech-zh',
+            companyDisplayName: 'FinTech Solutions',
           },
         ],
         presentationUrl: 'https://cdn.batbern.ch/2024/presentations/api-gateway.pdf',
@@ -357,6 +367,9 @@ describe('ArchiveEventDetailPage Component', () => {
         expect(screen.getAllByText(/DevCo/i).length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText(/FinTech Solutions/i).length).toBeGreaterThanOrEqual(1);
       });
+      // The displayName is shown, never the raw company slug.
+      expect(screen.queryByText(/tcorp-zh/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/cloud-zh/i)).not.toBeInTheDocument();
     });
 
     test('should_displaySessionTime_when_provided', async () => {

--- a/web-frontend/src/types/event.types.ts
+++ b/web-frontend/src/types/event.types.ts
@@ -41,7 +41,8 @@ export interface SpeakerUI extends Speaker {
   // Archive browsing fields (Story 4.2)
   speakerId?: string; // UUID identifier for speaker
   fullName?: string; // Computed full name (firstName + lastName)
-  companyName?: string; // Speaker's company name
+  companyName?: string; // Speaker's company name (legacy frontend-only field; prefer companyDisplayName)
+  companyDisplayName?: string; // Human-readable company name (displayName ?? name); prefer over `company` slug
   photoUrl?: string; // Speaker's photo URL (alias for profilePictureUrl)
 }
 

--- a/web-frontend/src/types/generated/events-api.types.ts
+++ b/web-frontend/src/types/generated/events-api.types.ts
@@ -3467,10 +3467,17 @@ export interface components {
        */
       lastName: string;
       /**
-       * @description Speaker's company name (from User.companyId)
+       * @description Speaker's company identifier/slug (from User.companyId). Stable key used for logo lookup — NOT for display.
        * @example GoogleZH
        */
       company?: string;
+      /**
+       * @description Human-readable company name (companies.display_name, falling back to
+       *     companies.name, then the company slug). Prefer this over `company` for
+       *     display. Null when the speaker has no associated company.
+       * @example Google Zürich
+       */
+      companyDisplayName?: string;
       /**
        * Format: uri
        * @description Speaker's profile picture URL (from User entity)
@@ -4574,10 +4581,16 @@ export interface components {
        */
       speakerName: string;
       /**
-       * @description Company or organization of the speaker
-       * @example Tech Corp AG
+       * @description Company identifier/slug of the speaker (from User.companyId). Stable key — NOT for display.
+       * @example TechCorpAG
        */
       company?: string | null;
+      /**
+       * @description Human-readable company name (companies.display_name, falling back to
+       *     companies.name, then the slug). Prefer this over `company` for display.
+       * @example Tech Corp AG
+       */
+      companyDisplayName?: string | null;
       /**
        * @description Areas of expertise
        * @example Cloud Architecture, Kubernetes, DevOps


### PR DESCRIPTION
Two independent production bugs in newsletter & speaker rendering, fixed in one branch.

## 1. Newsletter event start time was hardcoded `16:00` — commit `18d86a06`

`NewsletterEmailService.formatEventTime()` returned a hardcoded `"ab 16:00 Uhr"` / `"from 4:00 PM"` for every event, ignoring its `event` argument. Triggered by the BATbern59 newsletter going out showing `16:00` when the real start was `13:00` (verified against staging: afternoon event, `agenda_published`, earliest session at 11:00 UTC = 13:00 Europe/Zurich).

Route `formatEventTime` through the shared `EventTimeResolver` — the same source already used by the registration email and the `.ics` attachment (sessions → event-type config → 16:00 fallback). DE now renders `ab 13:00 Uhr`; EN renders `from 13:00` (24h, matching the rest of the system). The underlying event data was correct; this was purely a rendering bug.

Adds 3 regression tests pinning `eventTime` to the resolver output.

## 2. Speaker company rendered as slug, not displayName — commit `d4e00d80`

Every speaker render path used `User.companyId` (the company slug like `bkw` or `swisscomZH`) instead of the company's human-readable display name. So the newsletter speaker table, the public event page, the archive, and the organizer speaker pool all showed `swisscomZH` rather than `Swisscom (Schweiz) AG`.

Adds a resolved `companyDisplayName` (`displayName ?? name ?? slug`) to the `SessionSpeaker` and `SpeakerPoolResponse` schemas. The slug remains the stable key the frontend uses for logo lookup; only the displayed label changes.

Resolution mechanism:
- `EventController` batch path already loaded `companyDisplayName` via the `user_portraits` projection (`LEFT JOIN companies` + `COALESCE`) — just exposes it now.
- `SessionUserService`, `PrimarySpeakerResolver`, and the `SpeakerPoolService` bulk overlay resolve via a new cached `UserApiClient.getCompanyDisplayNames()` (slug→display map, reuses `userApiCache`, 15-min TTL — one upstream call per cache window, no N+1).

Frontend renders `companyDisplayName ?? company` at every speaker company site: `SpeakerDisplay` (public event page), `SpeakerCard` (presentation), and the archive event detail page (3 sites including JSON-LD).

### Pre-existing archive bug repaired in passing

`ArchiveEventDetailPage` was reading `speaker.fullName` / `companyName` / `speakerId` / `photoUrl` — **fields the API never returns** (verified against `api.batbern.ch`: live speakers only carry `firstName` / `lastName` / `company` / `username` / `profilePictureUrl`). In production this meant the archive showed `"Unknown"` names, no company, no photos, and the `speakerId` dedup collapsed every session to a single speaker. The test masked the bug by mocking the fictional shape.

Switched the section to the real `SessionSpeaker` fields (`username` key/dedup, `firstName`+`lastName` name, `profilePictureUrl` photo, `companyDisplayName ?? company`) and updated the test to the real shape with distinct slug-vs-displayName assertions.

## Verification

- Full `event-management-service` suite green (unit + integration via Testcontainers PostgreSQL).
- Frontend type-check ✅, lint ✅, 260 tests green across the touched areas (public Event, presentation, public pages — including `SessionCards` / `EventProgram` / `PresentationPage` which consume the changed components).
- 6 new backend tests + 3 new frontend tests pin the displayName-preference behaviour and the resolver routing.

## Notes for review / deploy

- Newsletter-time fix corrects future sends only — the BATbern59 newsletter already reached subscribers showing 16:00. Sending a correction is a separate operational decision.
- `companyDisplayName` is currently `null` on the live API (verified) and will populate once this deploys.
- Eyeball the archive page on staging after deploy: names/photos/dedup should now look right alongside the company displayName.

🤖 Generated with [Claude Code](https://claude.com/claude-code)