### PR TITLE
fix(public-ui): lighter dark cards, mobile filter stays open, missing i18n [no-doc]

### DIFF
--- a/web-frontend/public/locales/de/common.json
+++ b/web-frontend/public/locales/de/common.json
@@ -562,6 +562,11 @@
     "detail": {
       "backToArchive": "← Zurück zum Archiv",
       "photos": "Fotos"
+    },
+    "sort": {
+      "newest": "Neueste zuerst",
+      "oldest": "Älteste zuerst",
+      "mostAttended": "Meistbesucht"
     }
   },
   "notifications": {

--- a/web-frontend/public/locales/de/events.json
+++ b/web-frontend/public/locales/de/events.json
@@ -815,7 +815,8 @@
       "confirmed": "Bestätigt",
       "registered": "Angemeldet",
       "waitlist": "Warteliste",
-      "cancelled": "Storniert"
+      "cancelled": "Storniert",
+      "attended": "Teilgenommen"
     }
   },
   "capacity": {

--- a/web-frontend/public/locales/en/common.json
+++ b/web-frontend/public/locales/en/common.json
@@ -597,6 +597,11 @@
     "detail": {
       "backToArchive": "← Back to Archive",
       "photos": "Photos"
+    },
+    "sort": {
+      "newest": "Newest first",
+      "oldest": "Oldest first",
+      "mostAttended": "Most attended"
     }
   },
   "notifications": {

--- a/web-frontend/public/locales/en/events.json
+++ b/web-frontend/public/locales/en/events.json
@@ -815,7 +815,8 @@
       "confirmed": "Confirmed",
       "registered": "Registered",
       "waitlist": "Waitlist",
-      "cancelled": "Cancelled"
+      "cancelled": "Cancelled",
+      "attended": "Attended"
     }
   },
   "capacity": {

--- a/web-frontend/public/locales/es/common.json
+++ b/web-frontend/public/locales/es/common.json
@@ -560,6 +560,11 @@
     "detail": {
       "backToArchive": "← Volver al archivo",
       "photos": "Photos"
+    },
+    "sort": {
+      "newest": "Más recientes",
+      "oldest": "Más antiguos",
+      "mostAttended": "Más asistidos"
     }
   },
   "notifications": {

--- a/web-frontend/public/locales/es/events.json
+++ b/web-frontend/public/locales/es/events.json
@@ -791,7 +791,8 @@
       "confirmed": "[MISSING] Confirmed",
       "registered": "[MISSING] Registered",
       "waitlist": "[MISSING] Waitlist",
-      "cancelled": "[MISSING] Cancelled"
+      "cancelled": "[MISSING] Cancelled",
+      "attended": "Participaste"
     }
   },
   "capacity": {

--- a/web-frontend/public/locales/fi/common.json
+++ b/web-frontend/public/locales/fi/common.json
@@ -560,6 +560,11 @@
     "detail": {
       "backToArchive": "← Takaisin arkistoon",
       "photos": "Photos"
+    },
+    "sort": {
+      "newest": "Uusimmat ensin",
+      "oldest": "Vanhimmat ensin",
+      "mostAttended": "Eniten osallistujia"
     }
   },
   "notifications": {

--- a/web-frontend/public/locales/fi/events.json
+++ b/web-frontend/public/locales/fi/events.json
@@ -791,7 +791,8 @@
       "confirmed": "[MISSING] Confirmed",
       "registered": "[MISSING] Registered",
       "waitlist": "[MISSING] Waitlist",
-      "cancelled": "[MISSING] Cancelled"
+      "cancelled": "[MISSING] Cancelled",
+      "attended": "Osallistunut"
     }
   },
   "capacity": {

--- a/web-frontend/public/locales/fr/common.json
+++ b/web-frontend/public/locales/fr/common.json
@@ -560,6 +560,11 @@
     "detail": {
       "backToArchive": "← Retour aux archives",
       "photos": "Photos"
+    },
+    "sort": {
+      "newest": "Les plus récents",
+      "oldest": "Les plus anciens",
+      "mostAttended": "Les plus fréquentés"
     }
   },
   "notifications": {

--- a/web-frontend/public/locales/fr/events.json
+++ b/web-frontend/public/locales/fr/events.json
@@ -791,7 +791,8 @@
       "confirmed": "[MISSING] Confirmed",
       "registered": "[MISSING] Registered",
       "waitlist": "[MISSING] Waitlist",
-      "cancelled": "[MISSING] Cancelled"
+      "cancelled": "[MISSING] Cancelled",
+      "attended": "Participé"
     }
   },
   "capacity": {

--- a/web-frontend/public/locales/gsw-BE/common.json
+++ b/web-frontend/public/locales/gsw-BE/common.json
@@ -466,6 +466,11 @@
     "detail": {
       "backToArchive": "← Zrugg zum Archiv",
       "photos": "Fotos"
+    },
+    "sort": {
+      "newest": "Nöischti zerscht",
+      "oldest": "Ältischti zerscht",
+      "mostAttended": "Am meischte bsuecht"
     }
   },
   "notifications": {

--- a/web-frontend/public/locales/gsw-BE/events.json
+++ b/web-frontend/public/locales/gsw-BE/events.json
@@ -793,7 +793,8 @@
       "confirmed": "[MISSING] Confirmed",
       "registered": "[MISSING] Registered",
       "waitlist": "[MISSING] Waitlist",
-      "cancelled": "[MISSING] Cancelled"
+      "cancelled": "[MISSING] Cancelled",
+      "attended": "Debi gsi"
     }
   },
   "capacity": {

--- a/web-frontend/public/locales/it/common.json
+++ b/web-frontend/public/locales/it/common.json
@@ -560,6 +560,11 @@
     "detail": {
       "backToArchive": "← Torna all'archivio",
       "photos": "Photos"
+    },
+    "sort": {
+      "newest": "Più recenti",
+      "oldest": "Più vecchi",
+      "mostAttended": "Più frequentati"
     }
   },
   "notifications": {

--- a/web-frontend/public/locales/it/events.json
+++ b/web-frontend/public/locales/it/events.json
@@ -791,7 +791,8 @@
       "confirmed": "[MISSING] Confirmed",
       "registered": "[MISSING] Registered",
       "waitlist": "[MISSING] Waitlist",
-      "cancelled": "[MISSING] Cancelled"
+      "cancelled": "[MISSING] Cancelled",
+      "attended": "Partecipato"
     }
   },
   "capacity": {

--- a/web-frontend/public/locales/ja/common.json
+++ b/web-frontend/public/locales/ja/common.json
@@ -560,6 +560,11 @@
     "detail": {
       "backToArchive": "← アーカイブに戻る",
       "photos": "Photos"
+    },
+    "sort": {
+      "newest": "新しい順",
+      "oldest": "古い順",
+      "mostAttended": "参加者の多い順"
     }
   },
   "notifications": {

--- a/web-frontend/public/locales/ja/events.json
+++ b/web-frontend/public/locales/ja/events.json
@@ -791,7 +791,8 @@
       "confirmed": "[MISSING] Confirmed",
       "registered": "[MISSING] Registered",
       "waitlist": "[MISSING] Waitlist",
-      "cancelled": "[MISSING] Cancelled"
+      "cancelled": "[MISSING] Cancelled",
+      "attended": "参加済み"
     }
   },
   "capacity": {

--- a/web-frontend/public/locales/nl/common.json
+++ b/web-frontend/public/locales/nl/common.json
@@ -560,6 +560,11 @@
     "detail": {
       "backToArchive": "← Terug naar archief",
       "photos": "Photos"
+    },
+    "sort": {
+      "newest": "Nieuwste eerst",
+      "oldest": "Oudste eerst",
+      "mostAttended": "Meest bezocht"
     }
   },
   "notifications": {

--- a/web-frontend/public/locales/nl/events.json
+++ b/web-frontend/public/locales/nl/events.json
@@ -791,7 +791,8 @@
       "confirmed": "[MISSING] Confirmed",
       "registered": "[MISSING] Registered",
       "waitlist": "[MISSING] Waitlist",
-      "cancelled": "[MISSING] Cancelled"
+      "cancelled": "[MISSING] Cancelled",
+      "attended": "Bijgewoond"
     }
   },
   "capacity": {

--- a/web-frontend/public/locales/rm/common.json
+++ b/web-frontend/public/locales/rm/common.json
@@ -560,6 +560,11 @@
     "detail": {
       "backToArchive": "← Enavos a l'archiv",
       "photos": "Photos"
+    },
+    "sort": {
+      "newest": "I pli novs",
+      "oldest": "I pli vegls",
+      "mostAttended": "Il pli frequentà"
     }
   },
   "notifications": {

--- a/web-frontend/public/locales/rm/events.json
+++ b/web-frontend/public/locales/rm/events.json
@@ -791,7 +791,8 @@
       "confirmed": "[MISSING] Confirmed",
       "registered": "[MISSING] Registered",
       "waitlist": "[MISSING] Waitlist",
-      "cancelled": "[MISSING] Cancelled"
+      "cancelled": "[MISSING] Cancelled",
+      "attended": "Participà"
     }
   },
   "capacity": {

--- a/web-frontend/src/components/public/Event/EventProgram.tsx
+++ b/web-frontend/src/components/public/Event/EventProgram.tsx
@@ -212,7 +212,7 @@ export const EventProgram = ({ sessions, isArchived = false, eventCode }: EventP
                     ) : (
                       <div
                         key={session.sessionSlug}
-                        className="bg-zinc-900/50 border border-zinc-800 rounded-lg p-6 hover:border-zinc-700 transition-colors"
+                        className="bg-zinc-700 border border-zinc-600 rounded-lg p-6 hover:border-zinc-500 transition-colors"
                       >
                         <div className="flex items-start justify-between gap-4 mb-3">
                           <h3 className="text-xl font-light text-zinc-100">{session.title}</h3>
@@ -222,23 +222,22 @@ export const EventProgram = ({ sessions, isArchived = false, eventCode }: EventP
                         </div>
 
                         {session.description && (
-                          <p className="text-sm text-zinc-400 mb-4">{session.description}</p>
+                          <p className="text-sm text-zinc-300 mb-4">{session.description}</p>
                         )}
 
-                        <div className="flex flex-wrap gap-4 text-sm text-zinc-400">
-                          <span className="flex items-center gap-1.5">
-                            <Clock className="h-4 w-4" />
-                            {formatSessionDuration(session.startTime, session.endTime)}
-                          </span>
-                          {session.room && (
+                        {/* In-card session start/end time intentionally omitted on the public
+                            timeline — the time circle at the left of the row already shows it,
+                            and individual slot times are not advertised to attendees. */}
+                        {session.room && (
+                          <div className="flex flex-wrap gap-4 text-sm text-zinc-300">
                             <span className="flex items-center gap-1.5">
                               <MapPin className="h-4 w-4" />
                               {session.room}
                             </span>
-                          )}
-                        </div>
+                          </div>
+                        )}
 
-                        <div className="mt-4 pt-4 border-t border-zinc-800">
+                        <div className="mt-4 pt-4 border-t border-zinc-600">
                           {session.speakers && session.speakers.length > 0 ? (
                             <div>
                               <p className="text-xs text-zinc-500 mb-2">
@@ -264,7 +263,7 @@ export const EventProgram = ({ sessions, isArchived = false, eventCode }: EventP
 
                         {/* Materials Section - Only for archived events (Story 5.9 - Task 8b) */}
                         {isArchived && session.materials && session.materials.length > 0 && (
-                          <div className="mt-4 pt-4 border-t border-zinc-800">
+                          <div className="mt-4 pt-4 border-t border-zinc-600">
                             <p className="text-xs text-zinc-500 mb-3">
                               {t('public.program.materials', 'Materials')}:
                             </p>

--- a/web-frontend/src/components/public/Event/SessionCards.tsx
+++ b/web-frontend/src/components/public/Event/SessionCards.tsx
@@ -205,7 +205,7 @@ export const SessionCards = ({
         {filteredSessions.map((session) => (
           <Card
             key={session.sessionSlug}
-            className="group bg-zinc-900/50 border-zinc-800 hover:border-zinc-700 transition-colors"
+            className="group bg-zinc-700 border-zinc-600 hover:border-zinc-500 transition-colors"
           >
             <CardHeader>
               <div className="flex items-start justify-between gap-4">

--- a/web-frontend/src/components/public/Event/SpeakerGrid.tsx
+++ b/web-frontend/src/components/public/Event/SpeakerGrid.tsx
@@ -73,7 +73,7 @@ export const SpeakerGrid = ({ sessions }: SpeakerGridProps) => {
         {speakersWithSessions.map((speaker) => (
           <Card
             key={speaker.username}
-            className="group hover:border-blue-400 transition-colors bg-zinc-900/50 border-zinc-800"
+            className="group hover:border-blue-400 transition-colors bg-zinc-700 border-zinc-600"
           >
             <CardHeader className="pb-4">
               <SpeakerDisplay

--- a/web-frontend/src/components/public/EventCard.tsx
+++ b/web-frontend/src/components/public/EventCard.tsx
@@ -67,7 +67,7 @@ export function EventCard({
         data-testid={`event-card-${event.eventCode}`}
         data-view-mode={viewMode}
       >
-        <Card className="group bg-zinc-800/60 border-zinc-700 hover:border-zinc-600 transition-colors h-full">
+        <Card className="group bg-zinc-700 border-zinc-600 hover:border-zinc-500 transition-colors h-full">
           {/* Theme Image */}
           {event.themeImageUrl && (
             <div

--- a/web-frontend/src/components/public/FilterSheet.tsx
+++ b/web-frontend/src/components/public/FilterSheet.tsx
@@ -64,14 +64,17 @@ export function FilterSheet({
               </button>
             </div>
 
-            {/* Filter Content */}
+            {/* Filter Content.
+                onFilterChange must NOT auto-close the sheet: FilterSidebar fires it on
+                mount (300 ms-debounced search effect) and on every topic toggle, which
+                used to close the sheet the moment the user opened it. The sheet now
+                stays open until the user explicitly closes via the ✕ button or the
+                backdrop, so multiple topics can be selected in one go. Sort and Clear
+                remain one-shot actions that close the sheet after applying. */}
             <FilterSidebar
               filters={filters}
               topics={topics}
-              onFilterChange={(f) => {
-                onFilterChange(f);
-                setIsOpen(false);
-              }}
+              onFilterChange={onFilterChange}
               onClearFilters={() => {
                 onClearFilters();
                 setIsOpen(false);

--- a/web-frontend/src/components/public/Partners/PartnerShowcaseCard.tsx
+++ b/web-frontend/src/components/public/Partners/PartnerShowcaseCard.tsx
@@ -32,7 +32,7 @@ export const PartnerShowcaseCard = ({
 
   return (
     <Card
-      className={`flex-shrink-0 w-80 h-48 p-4 bg-zinc-900 border-zinc-800 hover:border-zinc-700 transition-colors ${
+      className={`flex-shrink-0 w-80 h-48 p-4 bg-zinc-700 border-zinc-600 hover:border-zinc-500 transition-colors ${
         website ? 'cursor-pointer' : 'cursor-default opacity-70'
       }`}
       onClick={handleClick}

--- a/web-frontend/src/components/public/Testimonials/TestimonialCard.tsx
+++ b/web-frontend/src/components/public/Testimonials/TestimonialCard.tsx
@@ -23,7 +23,7 @@ export const TestimonialCard = ({ avatar, name, quote, company }: TestimonialCar
   };
 
   return (
-    <Card className="flex-shrink-0 w-80 p-6 bg-zinc-900 border-zinc-800 hover:border-zinc-700 transition-colors">
+    <Card className="flex-shrink-0 w-80 p-6 bg-zinc-700 border-zinc-600 hover:border-zinc-500 transition-colors">
       <div className="flex items-start gap-4">
         {/* Avatar */}
         <div className="flex-shrink-0">

--- a/web-frontend/src/components/public/__tests__/FilterSheet.test.tsx
+++ b/web-frontend/src/components/public/__tests__/FilterSheet.test.tsx
@@ -146,11 +146,15 @@ describe('FilterSheet Component', () => {
   });
 
   describe('Filter Interactions', () => {
-    it('should_callOnFilterChangeAndClose_when_filtersApplied', async () => {
+    it('should_callOnFilterChangeAndStayOpen_when_filtersApplied', async () => {
+      // The sheet must NOT close on filter changes: FilterSidebar fires onFilterChange
+      // on mount (debounced search) and on every topic toggle. Closing on each call
+      // collapsed the popup the moment the user opened it (and would have closed it
+      // after the first topic in a multi-select session). The sheet only closes via
+      // the ✕ button or the backdrop.
       const onFilterChange = vi.fn();
       render(<FilterSheet {...defaultProps} onFilterChange={onFilterChange} />);
 
-      // Open modal
       const triggerButton = screen.getByText('Filters');
       fireEvent.click(triggerButton);
 
@@ -158,14 +162,14 @@ describe('FilterSheet Component', () => {
         expect(screen.getByTestId('filter-sidebar')).toBeInTheDocument();
       });
 
-      // Apply filters
       const applyButton = screen.getByTestId('apply-filters');
       fireEvent.click(applyButton);
 
       await waitFor(() => {
         expect(onFilterChange).toHaveBeenCalledWith({ topics: ['topic1'] });
-        expect(screen.queryByTestId('filter-sidebar')).not.toBeInTheDocument();
       });
+      // Sheet stays open after a filter change.
+      expect(screen.getByTestId('filter-sidebar')).toBeInTheDocument();
     });
 
     it('should_callOnClearFiltersAndClose_when_clearClicked', async () => {

--- a/web-frontend/src/pages/public/ArchiveEventDetailPage.tsx
+++ b/web-frontend/src/pages/public/ArchiveEventDetailPage.tsx
@@ -231,7 +231,7 @@ export default function ArchiveEventDetailPage() {
                   {(event.sessions as SessionUI[]).map((session) => (
                     <div
                       key={session.sessionId}
-                      className="bg-card border border-border rounded-lg p-6"
+                      className="bg-zinc-700 border border-zinc-600 rounded-lg p-6"
                     >
                       {/* Session Title and Time */}
                       <div className="flex justify-between items-start mb-3">


### PR DESCRIPTION
Three small public-page fixes that surfaced together while verifying the homepage / archive locally.

## 1. Lighter dark cards so dark logos read

Logos with dark elements (Swisscom blue, adesso black, aity black, …) were unreadable on the public homepage because every card sat at `bg-zinc-900` / `bg-zinc-900/50` against the same dark page background. All public-page cards that show speakers, companies, or events now use **`bg-zinc-700 border-zinc-600 hover:border-zinc-500`** — still dark-themed but visibly lighter than the page, enough for logos to register:

- `EventProgram.tsx` (homepage timeline) — plus the in-card start/end time block is dropped; the timeline circle on the left already shows the time, and individual slot times aren't advertised to attendees.
- `SessionCards.tsx` (homepage grid/list session view)
- `SpeakerGrid.tsx` (homepage speaker hero)
- `EventCard.tsx` (archive list cards — was `bg-zinc-800/60`)
- `PartnerShowcaseCard.tsx` (homepage + about partners)
- `TestimonialCard.tsx` (homepage testimonials — also shows company)
- `ArchiveEventDetailPage.tsx` (archive session cards — was theme `bg-card`/`border-border`, now matches the rest)

## 2. Mobile filter sheet vanishes the moment you open it

`FilterSidebar` fires `onFilterChange` on mount (300 ms-debounced search effect) and on every topic toggle. `FilterSheet` wrapped that handler to also call `setIsOpen(false)` — so the sheet closed itself 300 ms after opening, and would have closed after the first topic toggle anyway. `onFilterChange` is now passed through unchanged; the sheet closes only via the ✕ button, the backdrop, or the one-shot Sort / Clear actions. As a bonus the user can now multi-select topics in a single session.

## 3. Untranslated archive UI

- `archive.sort.newest` / `oldest` / `mostAttended` were missing from every locale — the sort dropdown rendered the bare keys.
- `eventCard.statusChip.attended` was missing from every locale — past events the user actually attended showed the raw key in the status chip.

Both added in all 10 locales (en, de, fr, it, rm, es, fi, nl, ja, gsw-BE) per the FE i18n rule.

## Tests

`FilterSheet.test.tsx` had been encoding the buggy behaviour (`should_callOnFilterChangeAndClose_when_filtersApplied`) — flipped to assert the sheet stays open after a filter change. 508 public-component tests pass; lint + type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)