### PR TITLE
ci(doc-drift): honor [no-doc] in commit messages, not just the PR title

### DIFF
--- a/.github/scripts/doc-drift-pr-check.sh
+++ b/.github/scripts/doc-drift-pr-check.sh
@@ -10,9 +10,17 @@ MAPPINGS_FILE="${MAPPINGS_FILE:-.github/doc-drift-mappings.yml}"
 BASE_REF="${BASE_REF:-main}"
 PR_TITLE="${PR_TITLE:-}"
 
-# ── 1. [no-doc] escape hatch ────────────────────────────────────────────────
+# ── 1. [no-doc] escape hatch (PR title OR any commit message on the branch) ──
+# CLAUDE.md documents the convention as "add [no-doc] to the commit message",
+# so honour either location. A single [no-doc] anywhere in the PR's commit
+# messages is enough — same permissive semantics as the PR title.
 if echo "$PR_TITLE" | grep -q "\[no-doc\]"; then
   echo "✅ [no-doc] flag present in PR title — doc drift check skipped."
+  exit 0
+fi
+
+if git log "origin/$BASE_REF..HEAD" --pretty=%B 2>/dev/null | grep -q "\[no-doc\]"; then
+  echo "✅ [no-doc] flag present in a commit message on this branch — doc drift check skipped."
   exit 0
 fi
 


### PR DESCRIPTION
`CLAUDE.md` documents the convention as

> "If no doc update is needed (e.g. pure internal refactor), add `[no-doc]` to the **commit message**."

but `.github/scripts/doc-drift-pr-check.sh` only honored `[no-doc]` in the PR **title**:

```bash
if echo "$PR_TITLE" | grep -q "\[no-doc\]"; then
  echo "✅ [no-doc] flag present in PR title — doc drift check skipped."
  exit 0
fi
```

So PRs that followed the documented pattern (tag in the commit body) still failed the audit. This silently blocked auto-merge on #685 and #687 even though both commits were correctly tagged.

## Fix

Add a second check that also looks at every commit message on the branch:

```bash
if git log "origin/$BASE_REF..HEAD" --pretty=%B 2>/dev/null | grep -q "\[no-doc\]"; then
  echo "✅ [no-doc] flag present in a commit message on this branch — doc drift check skipped."
  exit 0
fi
```

Same permissive semantics as the title check — a single `[no-doc]` anywhere in the PR's commits is enough. The PR-title escape hatch stays in place for callers who prefer to flag at the PR level.

## Verification

This PR is `ci(...)` — `ci` is in `skip_commit_types` in `.github/doc-drift-mappings.yml`, so the script self-skips. (Verified by hand-running the script with `commit_type=ci`.)

After this merges, PRs #685 and #687 (both of which have `[no-doc]` in their commit bodies) will pass Doc Drift on their next CI run without needing the workaround title-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)