### PR TITLE
Playwright staging-hardening: slice 6 (sessions / slot-assignment)

### DIFF
--- a/docs/plans/playwright-staging-hardening.md
+++ b/docs/plans/playwright-staging-hardening.md
@@ -57,10 +57,11 @@ production deploy.
 >
 > **NEXT:** slices 1 (**uploads**) + 2 (**companies**) MERGED — squash `c46c6463` (PR #692).
 > Slice 3 (**users**) MERGED — squash `815b4078` (PR #693). Slices 4 (**topics + event-types**)
-> + 5 (**tasks**) are on `e2e-tasks` (rebased onto develop post-#693, green ×2 vs dev),
-> awaiting review/merge in ONE PR (see "PR 5 notes" + "PR 6 notes"). After merge: slice 6
-> (sessions). Per-slice loop = §C "Repeatable per-slice checklist". Run locally green ×2 vs
-> dev first (`run-playwright-tests.sh development --slice <name>`, §F).
+> + 5 (**tasks**) MERGED — squash `9ff51818` (PR #694). Slice 6 (**sessions/slot-assignment**)
+> + the slices stacked after it are on `e2e-sessions` (rebased onto develop post-#694; green ×2
+> vs dev — see "PR 7 notes"+). Per-slice loop = §C "Repeatable per-slice checklist". Run locally
+> green ×2 vs dev first
+> (`run-playwright-tests.sh development --slice <name>`, §F).
 
 Update this one line on every PR merge so a fresh session can pick up without re-reading the whole plan.
 
@@ -79,9 +80,9 @@ slice audit land as separate fix-commits in the same PR.
 | 2 | `e2e-uploads` | Slice 1: file-upload/uploads | `user-account/photo-upload` | `profile-photo-input` | ✅ dev | `@gate` (control) + **`@smoke`** (upload+remove mutating) | ✅ merged (#692, `c46c6463`, 2026-05-30) | **bug found+fixed: self-service photo removal was broken** (`DELETE /users/me/picture` had no handler → fell through to admin `/{username}` with literal `me` → 404). Added `@DeleteMapping("/me/picture")` + integration test + OpenAPI `delete`. Also: presigned-PUT auth-header strip helper (global `extraHTTPHeaders` Authorization broke S3/MinIO uploads). Carries #691 follow-ups (`aef98a5a`, `139a09db`). See "PR 2 notes". |
 | 3 | `e2e-uploads` (stacked) | Slice 2: companies | `company-management/{company-creation,company-search}`, `api-integration/companies-api-integration` | — | ✅ dev | `@gate` (×10) + **`@smoke`** (UI create+cleanup) | ✅ merged (#692, `c46c6463`, 2026-05-30) | **fixes 3 prod-residue sources** (`E2E Test Company` no-cleanup POST; `Acme/Beta/Gamma` + cleanup-by-missing-`id`; `TestCompany-…`). Rewrite-to-reality: deleted/consolidated 26 dead·skip·duplicate tests (37→11 active), moved API contract into the api-integration spec, removed stray `.bak`. All data → canonical `BRUNOTESTCO%` + `cleanupById`. See "PR 3 notes". |
 | 4 | `e2e-users` | Slice 3: users | `user-management/{user-creation,user-deletion,role-management,user-list-search}`, `user-sync/reconciliation-drift-fix`, `user-account/{profile-management,settings-management}`, `organizer/user-settings-additional-emails` | `user-add-button`, `user-search-input`, `user-clear-filters`, `user-sort-{name,email,company}`, `user-actions-button-<id>`, keyed `user-table-row-<id>`, `user-create-{dialog,close}`, `role-manager-dialog`, `delete-user-{dialog,email,gdpr-warning,cascade-warning}` | ✅ dev (32×2) | `@gate` + **`@smoke`** (UI create+cleanup) | ✅ | **bug found+fixed: stale `window.confirm` handler** in additional-emails spec (component switched to a MUI confirm dialog → row never deleted). **Rewrite-to-reality + prod-safety:** role-management/user-deletion/list-search now operate on a dedicated API-created `bruno.test` fixture user (`e2e/helpers/user-fixture.ts`) instead of the table's FIRST row — the old role spec **saved role changes to a random real prod user**. Deleted 2 user-sync specs (`role-change-sync` dup Bruno `06` + random-user-mutating; `user-registration-sync` all-skipped dup of disabled `09-get-or-create`) + 3 `.backup` files. Dropped authenticated reconcile-POST (mutates prod + not dev-greenable); kept sync-status + auth-negatives. All data → factory; cleanup by captured username. See "PR 4 notes". ✅ merged (#693, `815b4078`, 2026-05-30). |
-| 5 | `e2e-topics` | Slice 4: topics + event-types | `organizer/{topic-selection,blob-topic-selector,event-type-selection}` | `EventTypesTab` (`event-types-tab`, `event-type-card-<T>`, `edit-event-type-<T>`, `edit-event-type-modal`), `SlotTemplatePreview` (`slot-template-preview`), `EventTypeConfigurationForm` (`event-type-config-{save,cancel}`), `BlobTopicSelectorPage` (`blob-unsaved-dialog`, `blob-back-{confirm,cancel}`) — **topics needed ZERO** (already richly testid'd) | ✅ dev (18×2) | `@gate` + **`@smoke`** (UI topic create+cleanup) | 🔵 | **rewrite-to-reality + prod-safety.** Topics already fully testid'd → the "zero testids/heavy" estimate was wrong; the testid work was all event-types. **Deleted dead code:** standalone `EventTypeConfigurationAdmin.tsx` + its unit test (the `/organizer/event-types` route now `<Navigate>`-redirects to `/organizer/admin?tab=0`/`EventTypesTab`; the page was unrouted). **Dropped all event-type mutations** (PUT `/events/types` = global prod-config change, no restore; the old PUT-200/400 used unset `E2E_TEST_TOKEN` and the "403 without role" is untestable since playwright.config injects a global `Authorization` header → would mutate, not 403). Topic API-contract describe deleted (dup of Bruno `event-topics-api`). Heat-map + topic→event-selection UI tests deleted (fresh topic has no usage→no heat map; selection's `success-message` never existed + Bruno-covered). Topic cleanup verified: `topic_code` slugifies from title, so `factory.topicCode()` title → swept by `bruno-test-topic-%` + deletable by captured code. See "PR 5 notes". |
-| 6 | `e2e-tasks` | Slice 5: tasks | `tasks/test-task-creation-from-templates` (consolidated; `test-task-assignment` **deleted**) | `EventTasksTab` (`event-tasks-tab-content`, `task-template-<id>`, `task-assignee-<id>`) — assignee `organizer-option-<username>` already existed | ✅ dev (2×2) | `@gate` + **`@smoke`** (assign+save+verify, cascade cleanup) | 🔵 | **rewrite-to-reality + prod-residue fix.** Both old specs created a real `BATbern${9000+random}` event via the UI and **never cleaned up** (leaked event+tasks/run) + used role/text locators + HARDCODED organizer names. Consolidated to one spec: read-only `@gate` (Tasks tab lists templates) + **`@smoke`** (assign first default template to the current organizer → save → GET `/events/{code}/tasks` asserts the assignee persisted). Uses the API event-fixture (captured `BATbern{N}`); cleanup = `cleanupByCode` → `event_tasks` FK `ON DELETE CASCADE` (tasks have no prefix-sweep). Deterministic assignee via `organizer-option-<token-username>` (no hardcoded names). `TaskTemplatesTab` (admin template catalog) is a SEPARATE surface, not exercised by these specs. See "PR 6 notes". |
-| 7 | `e2e-sessions` | Slice 6: sessions/slot-assignment | `slot-assignment/slot-assignment-workflow` | — | — | — | ⬜ | server-gen sessionSlug → explicit-delete |
+| 5 | `e2e-topics` | Slice 4: topics + event-types | `organizer/{topic-selection,blob-topic-selector,event-type-selection}` | `EventTypesTab` (`event-types-tab`, `event-type-card-<T>`, `edit-event-type-<T>`, `edit-event-type-modal`), `SlotTemplatePreview` (`slot-template-preview`), `EventTypeConfigurationForm` (`event-type-config-{save,cancel}`), `BlobTopicSelectorPage` (`blob-unsaved-dialog`, `blob-back-{confirm,cancel}`) — **topics needed ZERO** (already richly testid'd) | ✅ dev (18×2) | `@gate` + **`@smoke`** (UI topic create+cleanup) | ✅ merged (#694, `9ff51818`, 2026-05-31) | **rewrite-to-reality + prod-safety.** Topics already fully testid'd → the "zero testids/heavy" estimate was wrong; the testid work was all event-types. **Deleted dead code:** standalone `EventTypeConfigurationAdmin.tsx` + its unit test (the `/organizer/event-types` route now `<Navigate>`-redirects to `/organizer/admin?tab=0`/`EventTypesTab`; the page was unrouted). **Dropped all event-type mutations** (PUT `/events/types` = global prod-config change, no restore; the old PUT-200/400 used unset `E2E_TEST_TOKEN` and the "403 without role" is untestable since playwright.config injects a global `Authorization` header → would mutate, not 403). Topic API-contract describe deleted (dup of Bruno `event-topics-api`). Heat-map + topic→event-selection UI tests deleted (fresh topic has no usage→no heat map; selection's `success-message` never existed + Bruno-covered). Topic cleanup verified: `topic_code` slugifies from title, so `factory.topicCode()` title → swept by `bruno-test-topic-%` + deletable by captured code. See "PR 5 notes". |
+| 6 | `e2e-tasks` | Slice 5: tasks | `tasks/test-task-creation-from-templates` (consolidated; `test-task-assignment` **deleted**) | `EventTasksTab` (`event-tasks-tab-content`, `task-template-<id>`, `task-assignee-<id>`) — assignee `organizer-option-<username>` already existed | ✅ dev (2×2) | `@gate` + **`@smoke`** (assign+save+verify, cascade cleanup) | ✅ merged (#694, `9ff51818`, 2026-05-31) | **rewrite-to-reality + prod-residue fix.** Both old specs created a real `BATbern${9000+random}` event via the UI and **never cleaned up** (leaked event+tasks/run) + used role/text locators + HARDCODED organizer names. Consolidated to one spec: read-only `@gate` (Tasks tab lists templates) + **`@smoke`** (assign first default template to the current organizer → save → GET `/events/{code}/tasks` asserts the assignee persisted). Uses the API event-fixture (captured `BATbern{N}`); cleanup = `cleanupByCode` → `event_tasks` FK `ON DELETE CASCADE` (tasks have no prefix-sweep). Deterministic assignee via `organizer-option-<token-username>` (no hardcoded names). `TaskTemplatesTab` (admin template catalog) is a SEPARATE surface, not exercised by these specs. See "PR 6 notes". |
+| 7 | `e2e-sessions` | Slice 6: sessions/slot-assignment | `slot-assignment/slot-assignment-workflow` | — (SlotAssignment already strong) | ✅ dev (2×2) | `@gate` + **`@smoke`** (auto-assign) | 🔵 | **rewrite-to-reality.** Replaced an all-skipped 5-test RED-phase `describe.skip` asserting an idealized DOM that was never built (`assignment-progress`/`speaker-card`/`slot-dropzone`/`conflict-detection-modal`+room-change resolution/`speaker-preference-panel`/3-step `bulk-auto-assignment-modal` wizard/`assignment-complete-banner`/`/publishing` walk — NONE of those testids exist). **Zero new testids** — SlotAssignment is already richly testid'd. **Deterministic `@smoke` = auto-assign** (button→`auto-assign-modal`→`auto-assign-confirm`, `POST /sessions/auto-assign`), NOT native HTML5 drag-drop (too flaky to gate). Unassigned-session fixture: REST `POST /sessions` requires timing (`CreateSessionRequest @NotNull`), so `addUnassignedSessions` (event-fixture.ts) creates timed sessions then `DELETE /sessions/timing` to reach the placeholder state. Cleanup = event-delete cascade (`sessions`/`session_timing_history` `ON DELETE CASCADE`) — server-gen `sessionSlug` isn't prefix-sweepable. Verify via `GET /sessions/unassigned == 0`. See "PR 7 notes". |
 | 8 | `e2e-registrations` | Slice 7 (**full**): archive sub-slice + `registration-flow` + `presentation` | `archive-{browsing,filtering,event-detail,infinite-scroll}`, `registration-flow`, `presentation` | archive: ArchivePage, EventCard, FilterSidebar, FilterSheet, HomePage(archive), HeroSection, SessionCards, SpeakerGrid, SpeakerDisplay; reg: PersonalDetailsStep (5 inputs+5 errors), CompanyAutocomplete, ConfirmRegistrationStep (terms), RegistrationWizard (success); pres: WelcomeSlide | ✅ local | `@gate` (archive+pres read-only) + **`@smoke`** (registration mutating happy-path) | ✅ merged (#691, `8a9949a1`, 2026-05-30) | full rewrite-to-reality; reg `@smoke` is slice 7's first mutating gate path; see "PR 8 notes". Review follow-ups (#1/#2/#4/#8) carried on `e2e-uploads`, not in this merge. |
 | 9 | `e2e-speaker-pool` | Slice 8: speaker pool (organizer) | `organizer/speaker-*` | — | — | — | ⬜ | strong testids already |
 | 10 | `e2e-speaker-portal` | Slice 9: speaker portal | `speaker/*` | — | — | — | ⬜ | **net-new** for 3 fixme stubs; needs `SPEAKER_AUTH_TOKEN` |
@@ -477,6 +478,83 @@ dev (2/2 both runs); type-check + lint clean; `@smoke`→1 / `@gate`→2 via tag
 admin `TaskTemplatesTab` (managing the template catalog itself) is a separate surface, untouched
 by this slice. Staging can't validate the new testids until this PR's frontend deploys (same
 deploy-then-green pattern as PRs 2/4/5/8).
+
+### PR 7 notes — sessions/slot-assignment slice (rewrite-to-reality, deterministic non-DnD @smoke)
+
+Slice 6's lone spec (`slot-assignment/slot-assignment-workflow.spec.ts`) was an all-skipped
+5-test `test.describe.skip(...)` RED-PHASE TDD block (Story 5.7 / BAT-11) asserting an
+**idealized DOM that was never built**. The feature itself IS fully built and routed
+(`/organizer/events/:eventCode/slot-assignment` → `SlotAssignmentPage` → `DragDropSlotAssignment`),
+so this is a pure rewrite-to-reality of the test, not the feature.
+
+**Tests deleted (asserted testids/flows that do not exist):**
+- `should assign via drag-and-drop`: `speaker-card`, `slot-dropzone[data-time]`,
+  `assignment-success-toast`, `assignment-progress` ("0 of 3 assigned"). The real cards live in
+  `speaker-pool-sidebar` (per-card `drag-handle`), the real drop cells are
+  `slot-<HH:MM>-Main-Hall`, there is no success toast, and the count is plain (untestid'd) text.
+- `should detect and resolve timing conflicts`: `conflict-detection-modal` + `conflict-type` +
+  "Find Alternative Slot"/"Change Room"/"Reassign" resolution buttons + `room-selector`. The real
+  conflict surface is `ConflictDetectionAlert` (`conflict-type-badge`/`conflict-severity`), shown
+  only on a genuine 409 overlap, with no room-change resolver. Provoking a real overlap
+  deterministically needs two slot-aligned assignments — not gate-worthy for the value.
+- `should show speaker time preferences during drag`: `speaker-preference-panel`,
+  `time-preferences-section`, `preference-match-high/low` class assertions mid-drag. The panel is
+  `SpeakerPreferencePanel` (different testids) and is populated from MOCK data
+  (`getSpeakerData` is hardcoded in the component) — asserting it tests a stub, not a feature.
+- `should use bulk auto-assignment` + `should navigate to publishing tab`: a 3-step
+  `bulk-auto-assignment-modal` wizard (`algorithm-balanced`/`assignment-preview-list`/
+  `match-score`/"Apply Assignments"), `assignment-complete-banner`, and a `/publishing` tab with
+  `publishing-timeline`/`validation-session-timings`. NONE exist — auto-assign is a single
+  confirm modal (`auto-assign-modal`→`auto-assign-confirm`); the success banner is an untestid'd
+  MUI Alert with an inert `href="#"` link, and there is no `/publishing` route walk here.
+
+**`@smoke` = auto-assign, deliberately NOT drag-drop (reliability, plan risk #3).** Assignment's
+primary UI is **native HTML5** drag-and-drop (no dnd-kit), which Playwright's `dragTo` drives
+unreliably — wrong for a blocking gate. The deterministic equivalent is the **auto-assign**
+button → `auto-assign-modal` → `auto-assign-confirm`, which calls `POST /sessions/auto-assign`
+(places every unassigned session into a free slot from the backend timetable) and awaits the
+POST + refetch before closing the modal — so modal-hidden is a clean completion signal. That is
+this slice's one mutating+cleanup happy path.
+
+**Unassigned-session fixture (the create-then-clear trick).** "Unassigned" = a non-structural
+session with `startTime IS NULL`. The REST `POST /events/{code}/sessions` endpoint REQUIRES
+`startTime`/`endTime` (`CreateSessionRequest @NotNull`), so a session cannot be born timing-less
+through the API. In production these placeholders come from the speaker workflow; reproducing
+that via the UI would drag in cron/state transitions. New helper `addUnassignedSessions`
+(event-fixture.ts) instead creates each session WITH throwaway timing, then issues one
+`DELETE /events/{code}/sessions/timing` to clear ALL timings — leaving them unassigned. The
+read-only `@gate` needs no sessions at all: the slot GRID is computed from the EVENING event-type
+config (4 speaker slots + a break, seeded Flyway V10), so `slot-<HH:MM>-Main-Hall` cells render
+for any EVENING event. Slot-cell times are rendered in the browser timezone (`toTimeStr` over the
+backend slot start) → matched by testid SHAPE (`/^slot-\d{1,2}:\d{2}-Main-Hall$/`), never a
+hardcoded time.
+
+**Two tests, zero new testids** (SlotAssignment was already richly testid'd):
+- `should_renderSlotAssignmentLayout_when_pageOpened` (`@gate`, read-only): the three-column
+  layout (`speaker-pool-sidebar`/`session-timeline-grid`+`timeline-grid`/`quick-actions-panel`),
+  both quick-action buttons, and ≥1 droppable `slot-*` cell (proves the grid is wired to the
+  event-type slot template, not an empty shell).
+- `should_assignAllSessions_when_autoAssignConfirmed` (**`@smoke`**+`@gate`): seed 2 unassigned
+  sessions via the API → assert 2 `drag-handle` cards in the sidebar → auto-assign → assert the
+  modal closes and the sidebar shows `empty-state` → **authoritative verify**
+  `GET /sessions/unassigned == 0` (the assignment actually persisted, stronger than the UI alone).
+
+**Cleanup contract.** One throwaway EVENING event per file (serial, shared) created via the API
+fixture (`createRegistrationEvent`, captured `BATbern{N}`) and deleted in `afterAll`
+(`cleanupByCode`). `sessions.event_id` (V2) and `session_timing_history.session_id` (V28) are
+`ON DELETE CASCADE`, so the event delete removes every session + timing row; the server-generated
+`sessionSlug` isn't reachable by the `bruno-test-session-` prefix sweep, so the parent-event
+delete is the only teardown (plan §A5 server-generated-code caveat). Serial mode + one shared
+event means the read-only `@gate` renders the bare event first, then the `@smoke` adds + assigns
+its own sessions — no cross-test race. Green ×2 on dev (2/2 both runs); final global-teardown
+sweep `events:0 sessions:0` (residue-free); tsc + eslint clean. Zero `src/` component changes, so
+no unit tests affected. Unlike testid-adding slices, the new specs go green on staging
+immediately post-deploy (no new build artifact needed — only e2e files changed).
+
+**Local-run footgun (noted for the next author):** `--slice "Slot Assignment"` (a positive
+case-sensitive `--grep`) also matches the heavy `event-lifecycle-e2e` "Phase D — Slot Assignment
+& Publish Agenda" test, which is slow and currently red on dev (slice-10/PR-11 territory, not
+touched here). Run this slice with `--slice "Story 5.7"` to scope to these two specs only.
 
 ### CI fix (2026-05-30) — Playwright teardown sweep raced the concurrent Bruno job
 

--- a/web-frontend/e2e/helpers/event-fixture.ts
+++ b/web-frontend/e2e/helpers/event-fixture.ts
@@ -31,7 +31,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { eventTitle } from './test-data-factory';
+import { eventTitle, EVENT_TITLE_TOKEN } from './test-data-factory';
 
 const API_BASE_URL = process.env.E2E_API_URL || 'http://localhost:8000';
 
@@ -161,4 +161,115 @@ export function companySlug(displayName: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]/g, '')
     .slice(0, 12);
+}
+
+/* ────────────────────────────────────────────────────────────────────────────────────
+ * Slot-assignment fixtures (plan §C slice 6 — sessions/slot-assignment)
+ *
+ * The slot-assignment page consumes "unassigned" (placeholder) sessions: non-structural
+ * sessions with `startTime IS NULL`. In the real product these are born timing-less via the
+ * speaker workflow. But the REST `POST /events/{code}/sessions` endpoint REQUIRES startTime/
+ * endTime (`CreateSessionRequest` `@NotNull`), so a session cannot be created timing-less
+ * directly. We reproduce the unassigned state deterministically WITHOUT a cron-driven workflow
+ * walk: create each session WITH throwaway timing, then `DELETE /sessions/timing` to clear ALL
+ * timings — leaving them unassigned (they then appear in `GET /sessions/unassigned` and the
+ * slot-assignment speaker-pool sidebar). `sessionType` is a non-structural value so the
+ * unassigned filter (which excludes moderation/break/lunch) keeps them.
+ *
+ * Cleanup rides the event-delete cascade (`cleanupByCode`): `sessions.event_id` is
+ * `ON DELETE CASCADE` (V2), and `session_timing_history.session_id` cascades too (V28). The
+ * server-generated `sessionSlug` (slugified from title) is NOT reachable by the
+ * `bruno-test-session-` prefix sweep, so the parent-event delete is the only teardown — same
+ * server-generated-code caveat the plan §A5 calls out.
+ * ──────────────────────────────────────────────────────────────────────────────────── */
+
+/** A speaker session created on the fixture event (its parent event's delete cascades it away). */
+export interface SlotSession {
+  sessionSlug: string;
+  title: string;
+}
+
+/** Shape of the session-creation response we read the server-generated slug from. */
+interface SessionCreateResponse {
+  sessionSlug?: string;
+  title?: string;
+}
+
+/**
+ * Create `count` placeholder (unassigned) speaker sessions on `eventCode` and return their
+ * handles. Each session is created with throwaway timing (required by the API) and then ALL
+ * timings are cleared in one call, so every returned session is unassigned. Throws loudly on
+ * any failure (per the plan's "no empty tests" / fail-loud bar). Requires an organizer token.
+ */
+export async function addUnassignedSessions(
+  token: string,
+  eventCode: string,
+  count: number
+): Promise<SlotSession[]> {
+  // Throwaway timing — valid ISO instants; cleared immediately below, never asserted on.
+  const start = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000);
+  const end = new Date(start.getTime() + 45 * 60 * 1000);
+
+  const sessions: SlotSession[] = [];
+  for (let i = 0; i < count; i++) {
+    // Unique title → unique server-derived slug (the backend also de-dupes with a -N suffix).
+    const title = `${EVENT_TITLE_TOKEN} Slot Session ${i + 1} ${Date.now()}-${i}`;
+    const res = await fetch(`${API_BASE_URL}/api/v1/events/${eventCode}/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        title,
+        description: 'Playwright slice-6 slot-assignment fixture session — cascade-deleted.',
+        sessionType: 'presentation', // non-structural → stays in the unassigned list
+        startTime: start.toISOString(),
+        endTime: end.toISOString(),
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(
+        `[event-fixture] create session failed: ${res.status} ${res.statusText} ${body}`
+      );
+    }
+    const data = (await res.json()) as SessionCreateResponse;
+    if (!data.sessionSlug) {
+      throw new Error(
+        `[event-fixture] create session response had no sessionSlug: ${JSON.stringify(data)}`
+      );
+    }
+    sessions.push({ sessionSlug: data.sessionSlug, title });
+  }
+
+  // Clear ALL timings → every session above becomes unassigned (startTime IS NULL).
+  const clearRes = await fetch(`${API_BASE_URL}/api/v1/events/${eventCode}/sessions/timing`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+  });
+  if (!clearRes.ok) {
+    const body = await clearRes.text().catch(() => '');
+    throw new Error(
+      `[event-fixture] clear timings failed: ${clearRes.status} ${clearRes.statusText} ${body}`
+    );
+  }
+  console.log(`[event-fixture] ✓ ${count} unassigned session(s) on ${eventCode}`);
+  return sessions;
+}
+
+/**
+ * Count the event's unassigned (placeholder) sessions via the same endpoint the page reads —
+ * the authoritative signal the slot-assignment `@smoke` asserts on (0 after a successful
+ * auto-assign). Requires an organizer token.
+ */
+export async function getUnassignedSessionCount(token: string, eventCode: string): Promise<number> {
+  const res = await fetch(`${API_BASE_URL}/api/v1/events/${eventCode}/sessions/unassigned`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(
+      `[event-fixture] get unassigned failed: ${res.status} ${res.statusText} ${body}`
+    );
+  }
+  const data = (await res.json()) as unknown[];
+  return Array.isArray(data) ? data.length : 0;
 }

--- a/web-frontend/e2e/workflows/slot-assignment/slot-assignment-workflow.spec.ts
+++ b/web-frontend/e2e/workflows/slot-assignment/slot-assignment-workflow.spec.ts
@@ -1,263 +1,135 @@
 /**
- * E2E Tests for Slot Assignment Workflow
- * Story BAT-11 (5.7): Slot Assignment & Progressive Publishing (AC1-13)
+ * E2E: Slot Assignment — slice 6 / sessions+slot-assignment (plan §C)
+ * docs/plans/playwright-staging-hardening.md
  *
- * IMPORTANT: These tests are RED PHASE tests (TDD). They should FAIL until
- * the Slot Assignment functionality is fully implemented.
+ * Rewritten 2026-05-30 to reality + the quality bar (testid-only locators, API/factory fixture
+ * data, mandatory cleanup, no empty tests). Story 5.7 (BAT-11): Slot Assignment & Progressive
+ * Publishing.
  *
- * Requirements:
- * 1. Event Management Service with session timing endpoints deployed
- * 2. PostgreSQL database with session_timing_history table (Migration V28)
- * 3. SlotAssignmentPage component with drag-and-drop
- * 4. ConflictDetectionAlert modal
- * 5. SpeakerPreferencePanel component
- * 6. API endpoints: PATCH /api/v1/events/{eventCode}/sessions/{sessionSlug}/timing
+ * What this replaces (rewrite-to-reality):
+ *   • The old spec was a 5-test `test.describe.skip(...)` RED-PHASE TDD block asserting an
+ *     IDEALIZED DOM that was never built: `assignment-progress` ("0 of 3 assigned"),
+ *     `speaker-card`, `slot-dropzone[data-time]`, `assignment-success-toast`,
+ *     `conflict-detection-modal` + room-change resolution, `speaker-preference-panel`,
+ *     `auto-assign-all-button` + a 3-step `bulk-auto-assignment-modal` wizard with
+ *     `algorithm-balanced`/`assignment-preview-list`/`match-score`, an
+ *     `assignment-complete-banner` and a `/publishing` tab walk. NONE of those testids exist.
+ *   • Its helpers POSTed placeholder sessions to a hardcoded `BATbern997` and created events
+ *     through the UI with hardcoded speakers ('john.doe'/'jane.smith') — no cleanup, fictional flow.
  *
- * Setup Instructions:
- * 1. Ensure migration V28 is applied: session_timing_history, speaker_slot_preferences tables
- * 2. Ensure Event Management Service is running with slot assignment endpoints
- * 3. Run: npx playwright test e2e/workflows/slot-assignment/slot-assignment-workflow.spec.ts
+ * Reality (verified in SlotAssignmentPage / DragDropSlotAssignment / SlotAssignmentController):
+ *   • The page is routed in production at `/organizer/events/:eventCode/slot-assignment` and is
+ *     a three-column layout: `speaker-pool-sidebar` (unassigned sessions), `session-timeline-grid`
+ *     + `timeline-grid` (drop cells `slot-<HH:MM>-Main-Hall`, driven by the BACKEND timetable),
+ *     `quick-actions-panel` (`generate-structural-button`, `auto-assign-button`, clear-all).
+ *   • The slot GRID is computed from the event-type config (EVENING is seeded in Flyway V10:
+ *     4 speaker slots + a break), so it renders rows for ANY EVENING event — no sessions needed.
+ *   • Assignment uses native HTML5 drag-and-drop, which is too flaky to gate. The deterministic
+ *     mutating path is the **auto-assign** button → modal → confirm (`POST /sessions/auto-assign`),
+ *     which assigns every unassigned session into a free slot. That is this slice's `@smoke`.
+ *   • "Unassigned" = a non-structural session with `startTime IS NULL`. The REST create endpoint
+ *     requires timing (`CreateSessionRequest @NotNull`), so the fixture creates timed sessions then
+ *     clears all timings to reach the unassigned state (`addUnassignedSessions`, event-fixture.ts).
+ *
+ * Cleanup contract: each run creates ONE throwaway EVENING event via the API fixture (captured
+ * `BATbern{N}` code) and deletes it in afterAll (`cleanupByCode`) — `sessions.event_id` (V2) and
+ * `session_timing_history.session_id` (V28) are `ON DELETE CASCADE`, so the event delete removes
+ * every session + timing row. Server-generated `sessionSlug`s aren't prefix-sweepable, so the
+ * parent-event delete is the only teardown (plan §A5 server-generated-code caveat). Never touches
+ * a real event.
+ *
+ * Prod-safety (plan risk #1 + #2): the `@smoke` mutates ONLY its own throwaway event; the
+ * server-generated code is captured and explicit-deleted. No drag-drop, no cron/workflow walk.
  */
 
 import { test, expect, type Page } from '@playwright/test';
-import { BASE_URL, API_URL } from '../../../playwright.config';
+import {
+  readOrganizerToken,
+  createRegistrationEvent,
+  addUnassignedSessions,
+  getUnassignedSessionCount,
+  type RegistrationEvent,
+} from '../../helpers/event-fixture';
+import { cleanupByCode } from '../../helpers/test-fixtures-cleanup';
 
-/**
- * Helper: Create event with confirmed speakers (ready for slot assignment)
- */
-async function createEventWithConfirmedSpeakers(page: Page): Promise<string> {
-  await page.goto(`${BASE_URL}/organizer/events`);
-  await page.click('button:has-text("New Event")');
+// EVENING-event slot cells are `slot-<HH:MM>-Main-Hall`. The <HH:MM> is rendered in the
+// BROWSER's timezone (toTimeStr on the backend-computed slot start), so it varies by env —
+// match the testid by shape, never a hardcoded time.
+const SLOT_CELL = /^slot-\d{1,2}:\d{2}-Main-Hall$/;
 
-  // Fill event form
-  await page.fill('input[name="title"]', `E2E Slot Test ${Date.now()}`);
-  await page.fill('input[name="eventNumber"]', '997');
-  await page.fill('input[name="eventDate"]', '2025-06-15');
-  await page.fill('input[name="venueName"]', 'Test Venue');
-  await page.fill('input[name="venueAddress"]', 'Test Address, Bern');
-  await page.fill('input[name="venueCapacity"]', '100');
+test.describe('Slot Assignment (Story 5.7)', { tag: '@gate' }, () => {
+  // One throwaway EVENING event for the file (serial) — created once, torn down once. The
+  // read-only @gate runs first on the bare event; the @smoke then adds + auto-assigns its own
+  // sessions. Serial so the @smoke's mutation can't race the @gate's render.
+  test.describe.configure({ mode: 'serial' });
 
-  // Select event type (creates placeholder sessions)
-  await page.click('[data-testid="event-type-selector"]');
-  await page.click('[role="option"]:has-text("Evening Event")');
+  let token: string;
+  let fixtureEvent: RegistrationEvent;
 
-  await page.click('button[type="submit"]:has-text("Create Event")');
+  test.beforeAll(async () => {
+    token = readOrganizerToken();
+    // createRegistrationEvent makes a CREATED, EVENING-type event with a captured BATbern{N} —
+    // EVENING's seeded slot template is what makes the timetable/auto-assign deterministic.
+    fixtureEvent = await createRegistrationEvent(token);
+  });
 
-  // Extract event code
-  await page.waitForSelector('[data-testid="event-card"]', { timeout: 5000 });
-  const eventCode = await page.locator('[data-testid="event-code"]').first().textContent();
+  test.afterAll(async () => {
+    if (fixtureEvent?.eventCode) {
+      await cleanupByCode(token, fixtureEvent.eventCode); // cascade removes sessions + timing
+    }
+  });
 
-  // Add speakers and move to SLOT_ASSIGNMENT state
-  // (This would normally be done through the speaker workflow)
-  // For E2E, we use API to set up state
-  await setupConfirmedSpeakers(eventCode || 'BATbern997');
-
-  return eventCode || 'BATbern997';
-}
-
-/**
- * Helper: Setup confirmed speakers via API (bypasses speaker workflow for testing)
- */
-async function setupConfirmedSpeakers(eventCode: string) {
-  // Create placeholder sessions with confirmed speakers
-  const speakers = [
-    { username: 'john.doe', company: 'TechCorp', topic: 'Cloud Architecture' },
-    { username: 'jane.smith', company: 'DataInc', topic: 'Machine Learning' },
-    { username: 'bob.wilson', company: 'DevOps AG', topic: 'Kubernetes Best Practices' },
-  ];
-
-  for (const speaker of speakers) {
-    await fetch(`${API_URL}/api/v1/events/${eventCode}/sessions`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        title: `${speaker.username} - ${speaker.company}`,
-        description: speaker.topic,
-        sessionType: 'presentation',
-        // startTime: null, endTime: null (placeholder session)
-        speakers: [speaker.username],
-      }),
-    });
+  /** Navigate to the slot-assignment page and wait for the three-column layout to render. */
+  async function openSlotAssignment(page: Page) {
+    await page.goto(`/organizer/events/${fixtureEvent.eventCode}/slot-assignment`);
+    await expect(page.getByTestId('quick-actions-panel')).toBeVisible();
   }
-}
 
-// Skip these tests until Slot Assignment feature is implemented (RED PHASE TDD)
-test.describe.skip('Slot Assignment Workflow (Story BAT-11)', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/organizer/events');
+  test('should_renderSlotAssignmentLayout_when_pageOpened', async ({ page }) => {
+    await openSlotAssignment(page);
+
+    // Three-column layout.
+    await expect(page.getByTestId('speaker-pool-sidebar')).toBeVisible();
+    await expect(page.getByTestId('session-timeline-grid')).toBeVisible();
+    await expect(page.getByTestId('timeline-grid')).toBeVisible();
+    await expect(page.getByTestId('quick-actions-panel')).toBeVisible();
+
+    // Quick actions present.
+    await expect(page.getByTestId('generate-structural-button')).toBeVisible();
+    await expect(page.getByTestId('auto-assign-button')).toBeVisible();
+
+    // The backend timetable produced at least one droppable speaker slot (EVENING config) —
+    // proves the grid is wired to the event-type slot template, not an empty shell.
+    await expect(page.getByTestId(SLOT_CELL).first()).toBeVisible();
   });
 
-  test('should assign session timing via drag-and-drop (AC5-AC9)', async ({ page }) => {
-    const eventCode = await createEventWithConfirmedSpeakers(page);
+  test(
+    'should_assignAllSessions_when_autoAssignConfirmed',
+    { tag: ['@smoke', '@gate'] },
+    async ({ page }) => {
+      // Seed two unassigned (placeholder) sessions on the fixture event via the API.
+      await addUnassignedSessions(token, fixtureEvent.eventCode, 2);
+      expect(await getUnassignedSessionCount(token, fixtureEvent.eventCode)).toBe(2);
 
-    // Navigate from Speakers tab to Slot Assignment page
-    await page.goto(`${BASE_URL}/organizer/events/${eventCode}/speakers`);
-    await expect(page.locator('[data-testid="assign-timings-button"]')).toBeVisible();
-    await page.click('[data-testid="assign-timings-button"]');
+      await openSlotAssignment(page);
 
-    // Should navigate to slot assignment page
-    await page.waitForURL(`${BASE_URL}/organizer/events/${eventCode}/slot-assignment`);
+      // The sidebar shows the two unassigned session cards (default filter = unassigned).
+      await expect(page.getByTestId('drag-handle')).toHaveCount(2);
 
-    // Verify three-column layout
-    await expect(page.locator('[data-testid="speaker-pool-sidebar"]')).toBeVisible();
-    await expect(page.locator('[data-testid="session-timeline-grid"]')).toBeVisible();
-    await expect(page.locator('[data-testid="quick-actions-panel"]')).toBeVisible();
+      // Auto-assign: button → modal → confirm. Deterministic (no native drag-drop). The
+      // component awaits the POST + refetch before closing the modal, so modal-hidden is the
+      // completion signal.
+      await page.getByTestId('auto-assign-button').click();
+      await expect(page.getByTestId('auto-assign-modal')).toBeVisible();
+      await page.getByTestId('auto-assign-confirm').click();
+      await expect(page.getByTestId('auto-assign-modal')).toBeHidden({ timeout: 15_000 });
 
-    // Verify unassigned speakers count
-    const progressText = await page.locator('[data-testid="assignment-progress"]').textContent();
-    expect(progressText).toContain('0 of 3 assigned');
+      // UI confirmation: the unassigned list is now empty (all sessions got a slot).
+      await expect(page.getByTestId('empty-state')).toBeVisible();
 
-    // Drag first speaker to a time slot
-    const speakerCard = page.locator('[data-testid="speaker-card"]').first();
-    const slotDropZone = page.locator('[data-testid="slot-dropzone"][data-time="09:00"]').first();
-
-    await speakerCard.dragTo(slotDropZone);
-
-    // Verify assignment success
-    await expect(page.locator('[data-testid="assignment-success-toast"]')).toBeVisible();
-    await expect(page.locator('[data-testid="session-timeline-grid"]')).toContainText('john.doe');
-
-    // Verify progress updated
-    const updatedProgress = await page.locator('[data-testid="assignment-progress"]').textContent();
-    expect(updatedProgress).toContain('1 of 3 assigned');
-  });
-
-  test('should detect and resolve timing conflicts (AC9)', async ({ page }) => {
-    const eventCode = await createEventWithConfirmedSpeakers(page);
-    await page.goto(`${BASE_URL}/organizer/events/${eventCode}/slot-assignment`);
-
-    // Assign first speaker to 09:00-09:45
-    const speaker1 = page.locator('[data-testid="speaker-card"]').first();
-    const slot1 = page.locator('[data-testid="slot-dropzone"][data-time="09:00"]').first();
-    await speaker1.dragTo(slot1);
-    await page.waitForTimeout(500); // Wait for assignment to complete
-
-    // Try to assign second speaker to overlapping time (same room, overlapping time)
-    const speaker2 = page.locator('[data-testid="speaker-card"]').nth(1);
-    const slot2 = page.locator('[data-testid="slot-dropzone"][data-time="09:15"]').first(); // Overlaps with 09:00-09:45
-
-    await speaker2.dragTo(slot2);
-
-    // Conflict detection modal should appear
-    await expect(page.locator('[data-testid="conflict-detection-modal"]')).toBeVisible();
-    await expect(page.locator('[data-testid="conflict-type"]')).toHaveText('room_overlap');
-    await expect(page.locator('[data-testid="conflict-message"]')).toContainText(
-      'Session timing conflicts with existing schedule'
-    );
-
-    // Verify resolution options
-    await expect(page.locator('button:has-text("Find Alternative Slot")')).toBeVisible();
-    await expect(page.locator('button:has-text("Change Room")')).toBeVisible();
-    await expect(page.locator('button:has-text("Reassign Other Session")')).toBeVisible();
-    await expect(page.locator('button:has-text("Cancel")')).toBeVisible();
-
-    // Choose "Change Room" resolution
-    await page.click('button:has-text("Change Room")');
-    await page.selectOption('[data-testid="room-selector"]', 'Room B');
-    await page.click('button:has-text("Confirm Assignment")');
-
-    // Verify conflict resolved and assignment successful
-    await expect(page.locator('[data-testid="conflict-detection-modal"]')).not.toBeVisible();
-    await expect(page.locator('[data-testid="assignment-success-toast"]')).toBeVisible();
-  });
-
-  test('should show speaker time preferences during drag (AC7-AC8, AC11)', async ({ page }) => {
-    const eventCode = await createEventWithConfirmedSpeakers(page);
-    await page.goto(`${BASE_URL}/organizer/events/${eventCode}/slot-assignment`);
-
-    // Click on speaker card to view preferences
-    await page.click('[data-testid="speaker-card"]').first();
-    await page.click('[data-testid="view-preferences-button"]');
-
-    // Speaker preference panel should slide in from right
-    await expect(page.locator('[data-testid="speaker-preference-panel"]')).toBeVisible();
-
-    // Verify preference sections
-    await expect(page.locator('[data-testid="time-preferences-section"]')).toBeVisible();
-    await expect(page.locator('[data-testid="av-requirements-section"]')).toBeVisible();
-    await expect(page.locator('[data-testid="room-setup-section"]')).toBeVisible();
-
-    // Start dragging speaker - should highlight matching slots
-    const speakerCard = page.locator('[data-testid="speaker-card"]').first();
-    await speakerCard.hover();
-    await page.mouse.down();
-
-    // Verify preference match highlighting (green for good match)
-    const morningSlot = page.locator('[data-testid="slot-dropzone"][data-time="09:00"]').first();
-    await expect(morningSlot).toHaveClass(/preference-match-high/); // Green highlight
-
-    const eveningSlot = page.locator('[data-testid="slot-dropzone"][data-time="18:00"]').first();
-    await expect(eveningSlot).toHaveClass(/preference-match-low/); // Red highlight
-
-    await page.mouse.up();
-  });
-
-  test('should use bulk auto-assignment based on preferences (AC13)', async ({ page }) => {
-    const eventCode = await createEventWithConfirmedSpeakers(page);
-    await page.goto(`${BASE_URL}/organizer/events/${eventCode}/slot-assignment`);
-
-    // Click Auto-Assign All button
-    await page.click('[data-testid="auto-assign-all-button"]');
-
-    // Auto-assignment modal should appear
-    await expect(page.locator('[data-testid="bulk-auto-assignment-modal"]')).toBeVisible();
-
-    // Step 1: Select algorithm
-    await page.click('[data-testid="algorithm-balanced"]'); // Balanced approach
-    await page.click('button:has-text("Next")');
-
-    // Step 2: Preview assignments
-    await expect(page.locator('[data-testid="assignment-preview-list"]')).toBeVisible();
-    await expect(page.locator('[data-testid="preview-item"]')).toHaveCount(3); // 3 speakers
-
-    // Verify match scores are shown
-    await expect(page.locator('[data-testid="match-score"]').first()).toBeVisible();
-
-    // Step 3: Confirm and apply
-    await page.click('button:has-text("Apply Assignments")');
-
-    // Wait for bulk assignment to complete
-    await expect(page.locator('[data-testid="bulk-assignment-success-toast"]')).toBeVisible();
-    await expect(page.locator('[data-testid="bulk-auto-assignment-modal"]')).not.toBeVisible();
-
-    // Verify all speakers assigned
-    const progressText = await page.locator('[data-testid="assignment-progress"]').textContent();
-    expect(progressText).toContain('3 of 3 assigned (100%)');
-
-    // Verify success banner appears
-    await expect(page.locator('[data-testid="assignment-complete-banner"]')).toBeVisible();
-    await expect(page.locator('[data-testid="assignment-complete-banner"]')).toContainText(
-      'All timings assigned!'
-    );
-    await expect(page.locator('a:has-text("Go to Publishing Tab")')).toBeVisible();
-  });
-
-  test('should navigate to publishing tab after completing assignments', async ({ page }) => {
-    const eventCode = await createEventWithConfirmedSpeakers(page);
-    await page.goto(`${BASE_URL}/organizer/events/${eventCode}/slot-assignment`);
-
-    // Complete all assignments (using auto-assign for speed)
-    await page.click('[data-testid="auto-assign-all-button"]');
-    await page.click('[data-testid="algorithm-balanced"]');
-    await page.click('button:has-text("Next")');
-    await page.click('button:has-text("Apply Assignments")');
-
-    // Wait for completion banner
-    await expect(page.locator('[data-testid="assignment-complete-banner"]')).toBeVisible();
-
-    // Click "Go to Publishing Tab" link
-    await page.click('a:has-text("Go to Publishing Tab")');
-
-    // Should navigate to publishing tab
-    await page.waitForURL(`${BASE_URL}/organizer/events/${eventCode}/publishing`);
-    await expect(page.locator('[data-testid="publishing-timeline"]')).toBeVisible();
-
-    // Verify session timings validation shows as complete
-    await expect(page.locator('[data-testid="validation-session-timings"]')).toHaveClass(
-      /validation-passed/
-    );
-    await expect(page.locator('[data-testid="validation-session-timings-status"]')).toContainText(
-      'Ready (3/3 sessions assigned)'
-    );
-  });
+      // Authoritative verification: the server has zero unassigned sessions left — the
+      // assignment actually persisted (stronger than the UI signal alone).
+      expect(await getUnassignedSessionCount(token, fixtureEvent.eventCode)).toBe(0);
+    }
+  );
 });


### PR DESCRIPTION
## Slice 6 — sessions / slot-assignment (PR 7 in the plan)

Brings the slot-assignment E2E spec to the gate quality bar. Part of the incremental Playwright staging-hardening effort.

Refs: `docs/plans/playwright-staging-hardening.md` PR #7

### What changed
- **Rewrite-to-reality** of `e2e/workflows/slot-assignment/slot-assignment-workflow.spec.ts`. It was an all-skipped 5-test RED-phase `describe.skip` asserting an idealized DOM that was never built (`assignment-progress`, `speaker-card`, `slot-dropzone`, `conflict-detection-modal` + room-change resolution, `speaker-preference-panel`, a 3-step `bulk-auto-assignment` wizard, `assignment-complete-banner`, a `/publishing` walk — none of those testids exist). The feature itself is fully built + routed; only the test was fiction.
- **Two specs, testid-only, zero new component testids** (SlotAssignment is already richly testid'd):
  - `@gate` (read-only): three-column layout + ≥1 backend-timetable slot cell renders for any EVENING event (4 speaker slots + break, seeded V10).
  - `@smoke` + `@gate`: **deterministic auto-assign** (button → modal → confirm, `POST /sessions/auto-assign`) — NOT native HTML5 drag-drop (too flaky to gate). Seeds 2 unassigned sessions via the API, auto-assigns, verifies `GET /sessions/unassigned == 0`.
- **New fixture helpers** in `e2e/helpers/event-fixture.ts`: `addUnassignedSessions` (creates timed sessions then `DELETE /sessions/timing` — the REST create endpoint requires timing, so this is how the placeholder/unassigned state is reached) and `getUnassignedSessionCount`.
- Cleanup = event-delete cascade (`sessions` / `session_timing_history` `ON DELETE CASCADE`); server-generated `sessionSlug` isn't prefix-sweepable.
- Progress-log hygiene: marked slices 4+5 merged (#694) after the develop rebase.

### Verification
- Green ×2 on dev; teardown sweep residue-free (`events:0 sessions:0`).
- `tsc` + `eslint` clean. Zero `src/` component changes → no unit tests affected; specs go green on staging immediately post-deploy (no new build artifact needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)