### PR TITLE
Playwright staging-hardening: slice 10 (event workflow — OQ-3 hybrid lifecycle walk)

### DIFF
--- a/docs/plans/playwright-staging-hardening.md
+++ b/docs/plans/playwright-staging-hardening.md
@@ -59,11 +59,13 @@ production deploy.
 > Slice 3 (**users**) MERGED — squash `815b4078` (PR #693). Slices 4 (**topics + event-types**)
 > + 5 (**tasks**) MERGED — squash `9ff51818` (PR #694). Slice 6 (**sessions/slot-assignment**)
 > MERGED — squash `41669b5b` (PR #695; its deploy-to-staging `@smoke` gate job ran green). Slices
-> 8 (**speaker pool**) + 9 (**speaker portal**) are on `e2e-speaker` (rebased onto develop
-> post-#695; green ×2 vs dev). NOTE: this repo **auto-merges PRs once CI is green** — so each
-> stacked PR auto-merges + deploys when targeted at develop. Per-slice loop = §C "Repeatable
-> per-slice checklist". Run locally green ×2 vs dev first
-> (`run-playwright-tests.sh development --slice <name>`, §F).
+> 8 (**speaker pool**) + 9 (**speaker portal**) MERGED — squash `ce88fbc5` (PR #697; its
+> deploy-to-staging `@smoke` gate job ran green). Slice 10 (**event workflow**) is on
+> `e2e-event-workflow` (off develop post-#697; green ×2 vs dev). NOTE: this repo
+> **auto-merges PRs once CI is green** — so each stacked PR auto-merges + deploys when targeted
+> at develop. Per-slice loop = §C "Repeatable per-slice checklist". Run locally green ×2 vs dev
+> first (`run-playwright-tests.sh development --slice <name>`, §F). **Remaining: slices 11
+> (partners) + 13 (cross-cutting) + 12 (admin tabs), then PR 15 gate-flip.**
 
 Update this one line on every PR merge so a fresh session can pick up without re-reading the whole plan.
 
@@ -86,9 +88,9 @@ slice audit land as separate fix-commits in the same PR.
 | 6 | `e2e-tasks` | Slice 5: tasks | `tasks/test-task-creation-from-templates` (consolidated; `test-task-assignment` **deleted**) | `EventTasksTab` (`event-tasks-tab-content`, `task-template-<id>`, `task-assignee-<id>`) — assignee `organizer-option-<username>` already existed | ✅ dev (2×2) | `@gate` + **`@smoke`** (assign+save+verify, cascade cleanup) | ✅ merged (#694, `9ff51818`, 2026-05-31) | **rewrite-to-reality + prod-residue fix.** Both old specs created a real `BATbern${9000+random}` event via the UI and **never cleaned up** (leaked event+tasks/run) + used role/text locators + HARDCODED organizer names. Consolidated to one spec: read-only `@gate` (Tasks tab lists templates) + **`@smoke`** (assign first default template to the current organizer → save → GET `/events/{code}/tasks` asserts the assignee persisted). Uses the API event-fixture (captured `BATbern{N}`); cleanup = `cleanupByCode` → `event_tasks` FK `ON DELETE CASCADE` (tasks have no prefix-sweep). Deterministic assignee via `organizer-option-<token-username>` (no hardcoded names). `TaskTemplatesTab` (admin template catalog) is a SEPARATE surface, not exercised by these specs. See "PR 6 notes". |
 | 7 | `e2e-sessions` | Slice 6: sessions/slot-assignment | `slot-assignment/slot-assignment-workflow` | — (SlotAssignment already strong) | ✅ dev (2×2) | `@gate` + **`@smoke`** (auto-assign) | ✅ merged (#695, `41669b5b`, 2026-05-31; staging `@smoke` gate green) | **rewrite-to-reality.** Replaced an all-skipped 5-test RED-phase `describe.skip` asserting an idealized DOM that was never built (`assignment-progress`/`speaker-card`/`slot-dropzone`/`conflict-detection-modal`+room-change resolution/`speaker-preference-panel`/3-step `bulk-auto-assignment-modal` wizard/`assignment-complete-banner`/`/publishing` walk — NONE of those testids exist). **Zero new testids** — SlotAssignment is already richly testid'd. **Deterministic `@smoke` = auto-assign** (button→`auto-assign-modal`→`auto-assign-confirm`, `POST /sessions/auto-assign`), NOT native HTML5 drag-drop (too flaky to gate). Unassigned-session fixture: REST `POST /sessions` requires timing (`CreateSessionRequest @NotNull`), so `addUnassignedSessions` (event-fixture.ts) creates timed sessions then `DELETE /sessions/timing` to reach the placeholder state. Cleanup = event-delete cascade (`sessions`/`session_timing_history` `ON DELETE CASCADE`) — server-gen `sessionSlug` isn't prefix-sweepable. Verify via `GET /sessions/unassigned == 0`. See "PR 7 notes". |
 | 8 | `e2e-registrations` | Slice 7 (**full**): archive sub-slice + `registration-flow` + `presentation` | `archive-{browsing,filtering,event-detail,infinite-scroll}`, `registration-flow`, `presentation` | archive: ArchivePage, EventCard, FilterSidebar, FilterSheet, HomePage(archive), HeroSection, SessionCards, SpeakerGrid, SpeakerDisplay; reg: PersonalDetailsStep (5 inputs+5 errors), CompanyAutocomplete, ConfirmRegistrationStep (terms), RegistrationWizard (success); pres: WelcomeSlide | ✅ local | `@gate` (archive+pres read-only) + **`@smoke`** (registration mutating happy-path) | ✅ merged (#691, `8a9949a1`, 2026-05-30) | full rewrite-to-reality; reg `@smoke` is slice 7's first mutating gate path; see "PR 8 notes". Review follow-ups (#1/#2/#4/#8) carried on `e2e-uploads`, not in this merge. |
-| 9 | `e2e-speaker` (stacked on `e2e-sessions`) | Slice 8: speaker pool (organizer) | `organizer/speaker-{column-triage,card-primary-action}` (migrated), `speaker-pool-smoke` (new), DELETED `speaker-{brainstorming,outreach,invitation,kanban-guided-drag}`, untagged `speaker-onbehalf-vs-self-byte-identity` | `MarkContactedModal` (`contact-method-option-{email,phone,in-person}`) — kanban/drawer testids already existed | ✅ dev (5×2) | `@gate` + **`@smoke`** (log-outreach IDENTIFIED→CONTACTED) | 🔵 | **rewrite-to-reality + reliability.** The recon's "strong testids / light" was optimistic: 3 specs were FICTIONAL (`speaker-brainstorming` asserted a non-existent `/brainstorm` route; `speaker-outreach` a non-existent `/outreach` dashboard; `speaker-invitation` mixed) and **all** specs seeded via the unset `process.env.E2E_TEST_TOKEN` (`Bearer undefined`→401) + created events through the UI with `Date.now()` titles and **no cleanup** (event-leak/run). New shared `e2e/helpers/speaker-pool-fixture.ts` (seed/status/promote/get via `readOrganizerToken()`). Kept+migrated `column-triage` (2 tests) + `card-primary-action` (2 tests: IDENTIFIED→MarkContactedModal, CONTACTED→drawer promote sub-view — fixed: the old `promote-email-field` assertion targeted the now-dead legacy `PromoteSpeakerDialog`; post-Epic-11 CONTACTED opens the drawer's `promote-submit-button`). **`@smoke` = log-outreach (IDENTIFIED→CONTACTED via MarkContactedModal)** — deliberately NOT promote-to-READY: promote provisions a Cognito/CUMS user out-of-band, an **intermittently-flaky** external write (observed 500s on dev) that would make a blocking gate spurious; also not native DnD. DELETED `kanban-guided-drag` (manual-mouse DnD, flaky). Cleanup = event-delete cascade (`speaker_pool.event_id` ON DELETE CASCADE). **Follow-up (untagged):** `speaker-onbehalf-vs-self-byte-identity` — its inline event-create 400s (NotNull gap) + walks promote; migrate to `createRegistrationEvent` + a promote-free path to gate it. See "PR 9 notes". |
-| 10 | `e2e-speaker` (stacked, with slice 8) | Slice 9: speaker portal | `speaker/{speaker-portal-dashboard,magic-link-teardown,speaker-magic-login-404}` (kept→`@gate`); DELETED 3 fixme stubs (`speaker-portal-{respond,content-submit,cross-portal-nav}`) | `SpeakerDashboardPage` (`speaker-dashboard` root) | ✅ dev (4×2, speaker project) | `@gate` only (no safe deterministic `@smoke`) | 🔵 | **rewrite-to-reality + reliability.** Kept the 3 sound specs and tagged them `@gate`: dashboard renders (switched `getByRole('heading')` → new `speaker-dashboard` testid), `magic-link-teardown` (asserts no `speaker_jwt` cookie / no magic-login calls — Epic 11.F.1), `speaker-magic-login-404` (deprecated route → 404, not the old page). **DELETED all 3 fixme stubs** (no real assertions): `respond` would need an INVITED pool row provisioned via promote-to-READY (a flaky out-of-band Cognito write — same reason slice 8's `@smoke` is promote-free), `content-submit` needs an assigned-session fixture not available, `cross-portal-nav` needs a dual-role test user not provisioned. **No `@smoke`:** there is no safe + deterministic speaker-side mutation (every mutating speaker flow depends on an organizer-provisioned INVITED/assigned state via the flaky promote path); slice 9 gates read-only, like slice 7's archive. Runs under the `speaker` project (`SPEAKER_AUTH_TOKEN`; skips gracefully without it). See "PR 9 notes". |
-| 11 | `e2e-event-workflow` | Slice 10: full workflow create→archive | `event-lifecycle-e2e`, workflow walk | — | — | — | ⬜ | **heavy** — see Section C-bis |
+| 9 | `e2e-speaker` (stacked on `e2e-sessions`) | Slice 8: speaker pool (organizer) | `organizer/speaker-{column-triage,card-primary-action}` (migrated), `speaker-pool-smoke` (new), DELETED `speaker-{brainstorming,outreach,invitation,kanban-guided-drag}`, untagged `speaker-onbehalf-vs-self-byte-identity` | `MarkContactedModal` (`contact-method-option-{email,phone,in-person}`) — kanban/drawer testids already existed | ✅ dev (5×2) | `@gate` + **`@smoke`** (log-outreach IDENTIFIED→CONTACTED) | ✅ merged (#697, `ce88fbc5`, 2026-05-30; staging gate green) | **rewrite-to-reality + reliability.** The recon's "strong testids / light" was optimistic: 3 specs were FICTIONAL (`speaker-brainstorming` asserted a non-existent `/brainstorm` route; `speaker-outreach` a non-existent `/outreach` dashboard; `speaker-invitation` mixed) and **all** specs seeded via the unset `process.env.E2E_TEST_TOKEN` (`Bearer undefined`→401) + created events through the UI with `Date.now()` titles and **no cleanup** (event-leak/run). New shared `e2e/helpers/speaker-pool-fixture.ts` (seed/status/promote/get via `readOrganizerToken()`). Kept+migrated `column-triage` (2 tests) + `card-primary-action` (2 tests: IDENTIFIED→MarkContactedModal, CONTACTED→drawer promote sub-view — fixed: the old `promote-email-field` assertion targeted the now-dead legacy `PromoteSpeakerDialog`; post-Epic-11 CONTACTED opens the drawer's `promote-submit-button`). **`@smoke` = log-outreach (IDENTIFIED→CONTACTED via MarkContactedModal)** — deliberately NOT promote-to-READY: promote provisions a Cognito/CUMS user out-of-band, an **intermittently-flaky** external write (observed 500s on dev) that would make a blocking gate spurious; also not native DnD. DELETED `kanban-guided-drag` (manual-mouse DnD, flaky). Cleanup = event-delete cascade (`speaker_pool.event_id` ON DELETE CASCADE). **Follow-up (untagged):** `speaker-onbehalf-vs-self-byte-identity` — its inline event-create 400s (NotNull gap) + walks promote; migrate to `createRegistrationEvent` + a promote-free path to gate it. See "PR 9 notes". |
+| 10 | `e2e-speaker` (stacked, with slice 8) | Slice 9: speaker portal | `speaker/{speaker-portal-dashboard,magic-link-teardown,speaker-magic-login-404}` (kept→`@gate`); DELETED 3 fixme stubs (`speaker-portal-{respond,content-submit,cross-portal-nav}`) | `SpeakerDashboardPage` (`speaker-dashboard` root) | ✅ dev (4×2, speaker project) | `@gate` only (no safe deterministic `@smoke`) | ✅ merged (#697, `ce88fbc5`, 2026-05-30) | **rewrite-to-reality + reliability.** Kept the 3 sound specs and tagged them `@gate`: dashboard renders (switched `getByRole('heading')` → new `speaker-dashboard` testid), `magic-link-teardown` (asserts no `speaker_jwt` cookie / no magic-login calls — Epic 11.F.1), `speaker-magic-login-404` (deprecated route → 404, not the old page). **DELETED all 3 fixme stubs** (no real assertions): `respond` would need an INVITED pool row provisioned via promote-to-READY (a flaky out-of-band Cognito write — same reason slice 8's `@smoke` is promote-free), `content-submit` needs an assigned-session fixture not available, `cross-portal-nav` needs a dual-role test user not provisioned. **No `@smoke`:** there is no safe + deterministic speaker-side mutation (every mutating speaker flow depends on an organizer-provisioned INVITED/assigned state via the flaky promote path); slice 9 gates read-only, like slice 7's archive. Runs under the `speaker` project (`SPEAKER_AUTH_TOKEN`; skips gracefully without it). See "PR 9 notes". |
+| 11 | `e2e-event-workflow` | Slice 10: full workflow create→archive | `event-lifecycle-e2e` (rewritten) | `workflow-status-badge` gains `data-workflow-state` (EventOverviewTab) | ✅ dev (2×2) | `@gate` + **`@smoke`** (hybrid lifecycle walk CREATED→…→ARCHIVED) | 🔵 | **rewrite-to-reality + reliability (OQ-3 hybrid).** Replaced a 6-phase monolithic UI walk that created its event via the UI with a `Date.now()` number and **never cleaned up** (leaked event+tasks/speakers/sessions per run), drove the kanban with raw `page.mouse` native-DnD + HARDCODED organizer/speaker display names, and depended on slice-8 speaker/content flows + cron-only auto-transitions. New hybrid: force-advance state via the override transition API (`PUT /events/{code}/workflow/transition` `overrideValidation:true` — `transitionToState` skips ALL validation, so any target incl. cron-only EVENT_LIVE/EVENT_COMPLETED is reachable), UI asserts the overview `workflow-status-badge` after each step + an authoritative `GET /workflow/status` cross-check. **`@smoke` walks the FULL 7-state forward sequence** (not just the recon's 3-state subset — override makes all states equally deterministic, ~15.5s). New fixture helpers `transitionWorkflow`/`getWorkflowState` + `WORKFLOW_FORWARD_STATES` (event-fixture.ts). Cleanup = afterAll force-archive (events DELETE-able only when ARCHIVED → 409 otherwise) then `cleanupByCode`; robust even if the walk fails mid-sequence. No cron, no DnD, no content. See "PR 11 notes". |
 | 12 | `e2e-partners` | Slice 11: partners + meetings | `partner-management/*`, `organizer/partner-meetings`, `partner/*` | — | — | — | ⬜ | **no cleanup today** (residue source); needs `PARTNER_AUTH_TOKEN` |
 | 13 | `e2e-admin-tabs` | Slice 12: organizer admin tabs | `organizer/admin-settings` | 8 admin tabs, `OrganizerAnalyticsPage`, `NotificationsPage` | — | — | ⬜ | **heaviest** — zero testids |
 | 14 | `e2e-cross-cutting` | Slice 13: a11y/auth/cors sweep | `accessibility/*`, `auth/*`, `api-integration/cors-validation` | — | — | — | ⬜ | mostly non-mutating |
@@ -558,6 +560,60 @@ case-sensitive `--grep`) also matches the heavy `event-lifecycle-e2e` "Phase D �
 & Publish Agenda" test, which is slow and currently red on dev (slice-10/PR-11 territory, not
 touched here). Run this slice with `--slice "Story 5.7"` to scope to these two specs only.
 
+### PR 11 notes — event-workflow slice (rewrite-to-reality, OQ-3 hybrid walk)
+
+Slice 10's lone chromium spec (`workflows/event-lifecycle-e2e.spec.ts`) was a **6-phase
+monolithic UI walk** (Story 5.1a) that:
+- created its event **through the UI** with a `Date.now()`-salted number and **never cleaned
+  up** — a leaked event plus its tasks/speakers/sessions on every run (the exact residue class
+  this plan exists to kill);
+- drove the speaker kanban with raw `page.mouse` **native HTML5 drag-and-drop** (CONTACTED→
+  READY→ACCEPTED) — the precise flaky DnD the plan keeps out of any gate — and **HARDCODED
+  organizer/speaker display names** (`Nissim Buchs`, `Daniel Kühni`, `N Nissim ELCA AI`),
+  environment-specific + fragile, with pervasive `waitForTimeout`;
+- depended on the speaker/content flows that belong to **slice 8** (speaker pool) and on
+  AUTOMATIC/cron transitions (EVENT_LIVE 00:01, EVENT_COMPLETED 23:59 Bern) a UI walk can't
+  drive deterministically.
+
+**OQ-3 resolved: hybrid (architect's default).** The 8-state lifecycle (CREATED →
+TOPIC_SELECTION → SPEAKER_IDENTIFICATION → SLOT_ASSIGNMENT → AGENDA_PUBLISHED → EVENT_LIVE →
+EVENT_COMPLETED → ARCHIVED) is force-advanced via the **same override the organizer UI exposes**
+— `PUT /events/{code}/workflow/transition` `{ targetState, overrideValidation:true,
+overrideReason }`. Verified in `EventWorkflowStateMachine.transitionToState`: `if (!override)`
+guards ALL validation, so `override=true` reaches **any** target state, including non-adjacent
+jumps and the cron-only EVENT_LIVE/EVENT_COMPLETED. The walk is API-driven, **UI-asserted**:
+after each transition the spec reloads the overview tab and asserts the `workflow-status-badge`
+reflects the new state, plus an authoritative `GET /workflow/status` cross-check.
+
+**`@smoke` walks the FULL 7-state forward sequence**, not the recon's 3-state subset
+(CREATED→TOPIC_SELECTION→AGENDA_PUBLISHED→ARCHIVED). Rationale: once the transition is an
+override API call + page reload, every state is *equally* deterministic, so the full walk is
+strictly more coverage at marginal cost (~15.5s total). The read-only `@gate` first asserts the
+fresh event renders in CREATED; the `@smoke` then force-advances the same (serial, shared) event
+through all 7 forward states.
+
+**Locale-independent assertion (testid bar).** The badge's visible `label` is **translated**
+(`getWorkflowStateLabel(state, t)`), so it can't be asserted by text. Added a
+`data-workflow-state={event.workflowState}` attribute to the `workflow-status-badge` Chip
+(EventOverviewTab.tsx) carrying the raw state — the same data-attribute pattern slice 7 used for
+`data-view-mode`. The only component change; 170 EventPage unit tests still green.
+
+**New fixture helpers** (event-fixture.ts): `transitionWorkflow(token, code, state)` (override
+PUT, returns server-confirmed state, throws loudly on non-2xx), `getWorkflowState(token, code)`
+(GET status → currentState), and `WORKFLOW_FORWARD_STATES` (the 7 non-CREATED states in order).
+
+**Cleanup contract.** Events are DELETE-able **only when ARCHIVED** (`cleanupByCode` accepts
+204/404/**409**; 409 = not-yet-archived). afterAll therefore **force-archives** the event
+(override transition, tolerant `.catch`) **then** `cleanupByCode` — robust even if the walk
+failed mid-sequence (the happy path already ends in ARCHIVED, so the force-archive is a no-op
+there). The `BATPW-E2E` title token is the orphan backstop. Green ×2 on dev (2/2 both runs);
+final global-teardown sweep `events:0` (residue-free); tsc + eslint clean. Unlike testid-adding
+slices, the spec changes go green on staging immediately post-deploy, but the new
+`data-workflow-state` attribute needs this PR's frontend build first (deploy-then-green pattern,
+PRs 2/4/5/8). The opt-in `documentation`/`screencast` projects keep the pure-UI walk + their
+page objects (TopicSelectionPage/SpeakerManagementPage/EventWorkflowPage, test-data.config,
+cleanup-helpers) — untouched here.
+
 ### CI fix (2026-05-30) — Playwright teardown sweep raced the concurrent Bruno job
 
 First PR-691 CI run: `bruno-tests` failed `users-api` → auto-rollback fired. Root cause was
@@ -852,8 +908,11 @@ composites last.
 
 ## C-bis. Event-workflow slice — design question (OQ-3, deferred to PR 11)
 
-> **Deferred** (PO, 2026-05-30): resolve OQ-3 when slice 10 (PR 11) is picked up, not now.
-> The recommendation below is the architect's default; revisit with fresh eyes at PR 11.
+> **✅ RESOLVED 2026-05-31 (PR 11): hybrid.** Implemented exactly as the architect's default
+> below — force-advance via the `overrideValidation:true` transition API, UI-assert the
+> `workflow-status-badge` per state. The `@smoke` walks the full 7-state forward sequence
+> (override makes every state equally deterministic). The pure-UI walk stays in the opt-in
+> documentation project. See "PR 11 notes".
 
 
 Driving `CREATED → TOPIC_SELECTION → SPEAKER_IDENTIFICATION → SLOT_ASSIGNMENT →
@@ -954,11 +1013,13 @@ so staging-issued JWTs resolve roles against the local DB.
   polls `www.batbern.ch` for the freshly-deployed asset hash / `/version` marker (matching
   `github.sha`) with backoff before launching browsers (A1).
 
-- **OQ-3 — event-workflow walk: hybrid vs pure-UI. ⏸ DEFERRED to PR 11** (PO, 2026-05-30).
-  Decide when slice 10 is picked up. Architect's default: hybrid (use the `overrideValidation`
-  transition endpoint to force-advance cron/auto states — fast, low-flake, API-driven +
-  UI-asserted), with the pure-UI walk kept in the opt-in documentation project. Revisit with
-  fresh eyes at PR 11.
+- **OQ-3 — event-workflow walk: hybrid vs pure-UI. ✅ RESOLVED 2026-05-31 (PR 11): hybrid.**
+  Implemented as the architect's default: force-advance via `PUT /workflow/transition`
+  `overrideValidation:true` (verified `transitionToState` skips ALL validation under override,
+  so any state incl. cron-only EVENT_LIVE/EVENT_COMPLETED is reachable), UI-assert the
+  `workflow-status-badge`'s new `data-workflow-state` after each step. The `@smoke` walks the
+  full 7-state forward sequence (~15.5s, deterministic); the pure-UI walk stays in the opt-in
+  documentation project. See "PR 11 notes".
 
 ## Verification (end-to-end, after PR 15)
 1. Push a trivial change to `develop` → `deploy-staging.yml` runs; confirm `playwright-tests`

--- a/web-frontend/e2e/helpers/event-fixture.ts
+++ b/web-frontend/e2e/helpers/event-fixture.ts
@@ -164,6 +164,97 @@ export function companySlug(displayName: string): string {
 }
 
 /* ────────────────────────────────────────────────────────────────────────────────────
+ * Workflow-walk fixtures (plan §C slice 10 — event lifecycle / §C-bis OQ-3)
+ *
+ * The 8-state lifecycle (CREATED → TOPIC_SELECTION → SPEAKER_IDENTIFICATION → SLOT_ASSIGNMENT
+ * → AGENDA_PUBLISHED → EVENT_LIVE → EVENT_COMPLETED → ARCHIVED, see EventWorkflowState.java)
+ * is mostly driven by AUTOMATIC transitions in production — event listeners (topic selected,
+ * speaker accepted, sessions timed) and cron jobs (EVENT_LIVE at 00:01, EVENT_COMPLETED at
+ * 23:59 Bern time). A pure-UI walk would stall on cron and depend on flaky DnD/content flows.
+ *
+ * Per OQ-3 (resolved: hybrid), the gate force-advances state via the same test-override the
+ * organizer UI exposes — `PUT /events/{code}/workflow/transition` with
+ * `overrideValidation:true` — which `EventWorkflowStateMachine.transitionToState` honours by
+ * SKIPPING ALL validation (so any target state is reachable, incl. non-adjacent jumps and the
+ * cron-only EVENT_LIVE/EVENT_COMPLETED). The walk is API-driven, UI-asserted: after each
+ * transition the spec reloads the event overview and asserts the `workflow-status-badge`'s
+ * `data-workflow-state` attribute reflects the new state. No cron, no DnD, fully deterministic.
+ * ──────────────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * The forward workflow states in linear order, excluding the initial CREATED (which a freshly
+ * created fixture event already occupies — it's a starting state, never a transition target).
+ * The spec walks these in order, force-advancing + UI-asserting each.
+ */
+export const WORKFLOW_FORWARD_STATES = [
+  'TOPIC_SELECTION',
+  'SPEAKER_IDENTIFICATION',
+  'SLOT_ASSIGNMENT',
+  'AGENDA_PUBLISHED',
+  'EVENT_LIVE',
+  'EVENT_COMPLETED',
+  'ARCHIVED',
+] as const;
+
+/** Every workflow state including the initial CREATED. */
+export type WorkflowState = 'CREATED' | (typeof WORKFLOW_FORWARD_STATES)[number];
+
+/**
+ * Force-advance `eventCode` to `targetState`, bypassing all business-rule validation
+ * (`overrideValidation:true`). Returns the server-confirmed new state. Throws loudly on any
+ * non-2xx (per the plan's fail-loud / no-empty-tests bar). Requires an organizer token.
+ */
+export async function transitionWorkflow(
+  token: string,
+  eventCode: string,
+  targetState: WorkflowState,
+  overrideReason = 'Playwright slice-10 lifecycle walk — force-advance (test override)'
+): Promise<string> {
+  const res = await fetch(`${API_BASE_URL}/api/v1/events/${eventCode}/workflow/transition`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ targetState, overrideValidation: true, overrideReason }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(
+      `[event-fixture] transition ${eventCode} → ${targetState} failed: ${res.status} ${res.statusText} ${body}`
+    );
+  }
+  const data = (await res.json()) as { workflowState?: string };
+  if (data.workflowState !== targetState) {
+    throw new Error(
+      `[event-fixture] transition ${eventCode} → ${targetState} returned ${data.workflowState}`
+    );
+  }
+  return data.workflowState;
+}
+
+/**
+ * Read the authoritative current workflow state via `GET /events/{code}/workflow/status` — the
+ * server-side signal the @smoke verifies against (stronger than the UI badge alone). Requires an
+ * organizer token (the status endpoint requires authentication).
+ */
+export async function getWorkflowState(token: string, eventCode: string): Promise<string> {
+  const res = await fetch(`${API_BASE_URL}/api/v1/events/${eventCode}/workflow/status`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(
+      `[event-fixture] workflow status ${eventCode} failed: ${res.status} ${res.statusText} ${body}`
+    );
+  }
+  const data = (await res.json()) as { currentState?: string };
+  if (!data.currentState) {
+    throw new Error(
+      `[event-fixture] workflow status ${eventCode} had no currentState: ${JSON.stringify(data)}`
+    );
+  }
+  return data.currentState;
+}
+
+/* ────────────────────────────────────────────────────────────────────────────────────
  * Slot-assignment fixtures (plan §C slice 6 — sessions/slot-assignment)
  *
  * The slot-assignment page consumes "unassigned" (placeholder) sessions: non-structural

--- a/web-frontend/e2e/workflows/event-lifecycle-e2e.spec.ts
+++ b/web-frontend/e2e/workflows/event-lifecycle-e2e.spec.ts
@@ -1,874 +1,122 @@
 /**
- * Event Lifecycle E2E Test
+ * E2E: Event Lifecycle workflow walk — slice 10 / event-workflow (plan §C, §C-bis OQ-3)
+ * docs/plans/playwright-staging-hardening.md
  *
- * This test executes the complete event management workflow from creation to archival.
+ * Rewritten 2026-05-31 to reality + the quality bar (testid-only locators, API/factory fixture
+ * data, mandatory cleanup, no empty tests). Story 5.1a: Workflow State Machine.
  *
- * Workflow Coverage:
- * - Phase A: Setup (Event creation, topic selection, speaker brainstorming)
- * - Phase B: Outreach (Speaker contact, status management, content collection)
- * - Phase C: Quality (Content review and approval)
- * - Phase D: Assignment (Slot assignment, overflow management)
- * - Phase E: Publishing (Progressive publishing, finalization)
- * - Phase F: Archival (Event archival)
+ * What this replaces (rewrite-to-reality):
+ *   • The old spec was a 6-phase monolithic UI walk (Phase A create-via-UI + heatmap topic +
+ *     speaker brainstorming; Phase B native-MOUSE drag-drop kanban CONTACTED→READY→ACCEPTED;
+ *     Phase B.5 content submission; Phase C quality review; Phase D slot-assign + publish;
+ *     Phase E archive-via-edit-modal). It:
+ *       – created its event through the UI with a `Date.now()`-salted number and NEVER cleaned
+ *         up the event (leaked one event + its tasks/speakers/sessions per run);
+ *       – drove the kanban with raw `page.mouse` drag-drop (the exact flaky native-DnD the plan
+ *         keeps out of any gate) and HARDCODED organizer/speaker display names
+ *         ('Nissim Buchs'/'Daniel Kühni'/'N Nissim ELCA AI'), environment-specific + fragile;
+ *       – depended on the speaker workflow + content flows that belong to slice 8 (speaker pool),
+ *         and on automatic/cron transitions a UI walk can't drive deterministically.
  *
- * Prerequisites:
- * 1. Backend services running (make dev-native-up)
- * 2. Frontend running (npm run dev)
- * 3. Seed data loaded (companies, users, topics, speakers)
- * 4. Auth token available (./scripts/auth/get-token.sh)
+ * Reality (verified in EventWorkflowController / EventWorkflowStateMachine / EventOverviewTab):
+ *   • The 8-state lifecycle is CREATED → TOPIC_SELECTION → SPEAKER_IDENTIFICATION →
+ *     SLOT_ASSIGNMENT → AGENDA_PUBLISHED → EVENT_LIVE → EVENT_COMPLETED → ARCHIVED. Most
+ *     transitions are AUTOMATIC (event listeners + cron at 00:01/23:59 Bern), so a pure-UI walk
+ *     stalls on cron and adds flake.
+ *   • `PUT /events/{code}/workflow/transition` with `overrideValidation:true` is the test-only
+ *     override the organizer UI itself exposes (the "override workflow validation" checkbox).
+ *     `transitionToState` honours it by SKIPPING ALL validation — so the gate can force-advance
+ *     to ANY state, including the cron-only EVENT_LIVE/EVENT_COMPLETED, deterministically.
+ *   • The event overview tab (default tab at `/organizer/events/:code`) renders a
+ *     `workflow-status-badge` Chip whose visible label is TRANSLATED; slice 10 added a
+ *     locale-independent `data-workflow-state` attribute carrying the raw state for assertions.
  *
- * Run:
- *   npm run test:e2e -- event-lifecycle-e2e.spec.ts
+ * Approach (OQ-3 resolved: hybrid — API force-advances, UI asserts each screen):
+ *   The walk drives state via the override transition API and, after each step, reloads the
+ *   overview and asserts the badge's `data-workflow-state` reflects the new state — plus an
+ *   authoritative `GET /workflow/status` cross-check. No cron, no DnD, no content/speaker flows.
+ *
+ * Cleanup contract: ONE throwaway event per file (serial, shared), created via the API fixture
+ * (captured `BATbern{N}`). afterAll force-advances it to ARCHIVED (events are only DELETE-able
+ * once ARCHIVED — DELETE returns 409 otherwise) and then `cleanupByCode` deletes it; the
+ * force-archive makes teardown robust even if the walk failed mid-sequence. The `BATPW-E2E`
+ * title token is the orphan backstop. Never touches a real event.
  */
 
-import { test, expect } from '@playwright/test';
-import { testConfig, getPresentation } from './documentation/test-data.config';
-import { cleanupAfterTests } from './documentation/helpers/cleanup-helpers';
-import { EventWorkflowPage } from './documentation/page-objects/EventWorkflowPage';
-import { SpeakerManagementPage } from './documentation/page-objects/SpeakerManagementPage';
-import { TopicSelectionPage } from './documentation/page-objects/TopicSelectionPage';
+import { test, expect, type Page } from '@playwright/test';
+import {
+  readOrganizerToken,
+  createRegistrationEvent,
+  transitionWorkflow,
+  getWorkflowState,
+  WORKFLOW_FORWARD_STATES,
+  type RegistrationEvent,
+} from '../helpers/event-fixture';
+import { cleanupByCode } from '../helpers/test-fixtures-cleanup';
 
-/**
- * Test Suite: Event Lifecycle E2E
- * Using .serial to run tests in order and share state between phases
- */
-test.describe.serial('Event Lifecycle E2E', () => {
-  let authToken: string;
-  let testEventCode: string;
+test.describe('Event Lifecycle workflow walk (Story 5.1a)', { tag: '@gate' }, () => {
+  // One throwaway event for the file (serial) — created once, torn down once. The read-only
+  // @gate asserts the initial CREATED render first; the @smoke then force-advances the SAME
+  // event through every forward state. Serial so the @smoke's mutation can't race the @gate.
+  test.describe.configure({ mode: 'serial' });
 
-  /**
-   * Setup
-   */
+  let token: string;
+  let fixtureEvent: RegistrationEvent;
+
   test.beforeAll(async () => {
-    console.log('\n🚀 Starting Event Lifecycle E2E Test\n');
-    authToken = process.env.AUTH_TOKEN || '';
-    console.log('\n✅ Setup complete\n');
+    token = readOrganizerToken();
+    // A CREATED event with a captured BATbern{N} code — the walk's starting state.
+    fixtureEvent = await createRegistrationEvent(token);
   });
 
-  /**
-   * Cleanup: Delete test event and orphaned data
-   */
   test.afterAll(async () => {
-    console.log('\n🧹 Cleaning up test data...\n');
-    if (authToken) {
-      await cleanupAfterTests(authToken, testEventCode);
-    }
-    console.log('\n✅ Test complete\n');
-  });
-
-  /**
-   * Phase A: Event Setup (Steps 1-5)
-   * - Login
-   * - Event Creation & Configuration
-   * - Task Assignment to Organizers
-   * - Topic Selection via Heat Map
-   * - Speaker Brainstorming (add candidates to pool)
-   */
-  test('Phase A: Event Setup (Steps 1-5)', async ({ page }) => {
-    test.setTimeout(10 * 60 * 1000);
-
-    console.log('\n📋 Phase A: Event Setup\n');
-
-    const eventPage = new EventWorkflowPage(page);
-    const topicPage = new TopicSelectionPage(page);
-    const speakerPage = new SpeakerManagementPage(page);
-
-    // Enable network logging
-    page.on('request', (request) => {
-      console.log(`→ ${request.method()} ${request.url()}`);
-    });
-    page.on('response', (response) => {
-      const status = response.status();
-      const url = response.url();
-      if (status >= 400 || url.includes('/api/')) {
-        console.log(`← ${status} ${url}`);
-      }
-    });
-    page.on('requestfailed', (request) => {
-      console.log(
-        `✗ FAILED: ${request.method()} ${request.url()} - ${request.failure()?.errorText}`
-      );
-    });
-
-    try {
-      // ========================================
-      // Step 1: Navigate to Dashboard
-      // ========================================
-      console.log('  → Step 1: Navigate to Event Dashboard (authenticated via global setup)');
-
-      await eventPage.navigateToDashboard();
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(1000);
-
-      await expect(eventPage.createEventButton).toBeVisible({ timeout: 10000 });
-      console.log('    ✓ Dashboard loaded - authentication successful');
-
-      // ========================================
-      // Step 2: Create New Event
-      // ========================================
-      console.log('  → Step 2: Create Event');
-
-      // Close any dialogs that might be open (language-independent)
-      const dialogCloseButton = page.getByRole('dialog').getByRole('button').first();
-      if (await dialogCloseButton.isVisible().catch(() => false)) {
-        console.log('    → Closing dialog first');
-        await dialogCloseButton.click();
-        await page.waitForTimeout(500);
-      }
-
-      console.log('    → Clicking "Neue Veranstaltung" button');
-      await eventPage.clickCreateEvent();
-
-      console.log('    → Waiting for event creation modal');
-      await expect(eventPage.eventNumberField).toBeVisible({ timeout: 10000 });
-      await page.waitForTimeout(500);
-
-      // Fill event form
-      const uniqueEventNumber = testConfig.event.eventNumber + Math.floor(Math.random() * 1000);
-      console.log(`    → Creating event #${uniqueEventNumber}`);
-
-      await eventPage.fillEventForm({
-        eventNumber: uniqueEventNumber,
-        title: testConfig.event.title,
-        description: testConfig.event.description,
-        date: testConfig.event.date,
-        registrationDeadline: testConfig.event.registrationDeadline,
-        eventType: testConfig.event.eventType as 'EVENING' | 'AFTERNOON' | 'FULL_DAY',
-        venueName: testConfig.event.venue.name,
-        venueAddress: testConfig.event.venue.address,
-        venueCapacity: 200,
-      });
-
-      await page.waitForTimeout(500);
-
-      // Submit event creation form
-      await eventPage.submitEventForm();
-
-      // Store event code for cleanup
-      testEventCode = `BATbern${uniqueEventNumber}`;
-
-      console.log(`    → Waiting for event creation to complete...`);
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(1500);
-
-      // Check if modal closed successfully
-      const modalStillOpen = await eventPage.eventNumberField
-        .isVisible({ timeout: 3000 })
-        .catch(() => false);
-      if (modalStillOpen) {
-        console.log(`    ⚠️  Modal still open - checking for validation errors`);
-        const errorText = await page
-          .locator('text=/error|fehler|ungültig/i')
-          .first()
-          .textContent({ timeout: 1000 })
-          .catch(() => 'No error text found');
-        console.log(`    ⚠️  Error message: ${errorText}`);
-        throw new Error(`Event creation modal did not close - validation error: ${errorText}`);
-      }
-
-      await expect(eventPage.createEventButton).toBeVisible({ timeout: 5000 });
-      console.log(`    ✓ Event created: ${testEventCode}, back on dashboard`);
-
-      // ========================================
-      // Step 3: Assign Tasks to Organizers
-      // ========================================
-      console.log('  → Step 3: Assign Tasks to Organizers');
-
-      const eventUrl = `http://localhost:8100/organizer/events/${testEventCode}`;
-      console.log(`    → Navigating to event detail page: ${eventUrl}`);
-      await page.goto(eventUrl);
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(1000);
-      console.log(`    ✓ Event detail page loaded`);
-
-      // Click Edit button
-      console.log('    → Clicking Edit button');
-      const editButton = page.getByTestId('edit-event-button');
-      await editButton.click();
-      await page.waitForTimeout(500);
-
-      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
-      await page.waitForTimeout(500);
-      console.log('    ✓ Edit modal opened on Info tab');
-
-      // Click Tasks tab
-      console.log('    → Clicking Tasks tab');
-      const tasksTab = page.getByTestId('tasks-tab');
-      await tasksTab.click();
-      await page.waitForTimeout(500);
-      console.log('    ✓ Tasks tab loaded');
-
-      // Define task assignments
-      const taskAssignments = [
-        { taskName: 'Venue Booking', assignee: 'Nissim Buchs' },
-        { taskName: 'Partner Meeting', assignee: 'Daniel Kühni' },
-        { taskName: 'Moderator Assignment', assignee: 'Andreas Grütter' },
-        { taskName: 'Newsletter: Topic', assignee: 'Baltisar Oswald' },
-        { taskName: 'Newsletter: Speaker', assignee: 'Baltisar Oswald' },
-        { taskName: 'Newsletter: Final', assignee: 'Baltisar Oswald' },
-      ];
-
-      // Assign each task
-      for (let i = 0; i < taskAssignments.length; i++) {
-        const { taskName, assignee } = taskAssignments[i];
-        console.log(`    → Assigning "${taskName}" to ${assignee}`);
-
-        const taskRow = page.getByRole('listitem').filter({ hasText: taskName });
-        const assigneeSelect = taskRow.getByRole('combobox');
-        await assigneeSelect.scrollIntoViewIfNeeded();
-        await assigneeSelect.click();
-        await page.waitForTimeout(300);
-
-        await page.getByRole('option', { name: assignee }).first().click();
-        await page.waitForTimeout(300);
-      }
-
-      console.log(`    ✓ All ${taskAssignments.length} tasks assigned`);
-
-      // Click Save button
-      console.log('    → Saving task assignments');
-      const saveButton = page.getByTestId('save-event-button');
-      await saveButton.click();
-      await page.waitForTimeout(1000);
-
-      await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5000 });
-      console.log('    ✓ Tasks saved, modal closed');
-
-      // Navigate to task list to verify
-      console.log('    → Navigating to task list');
-      const tasksButton = page.getByTestId('tasks-button');
-      await tasksButton.click();
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(500);
-      console.log('    ✓ Task list loaded');
-
-      // Change filter to "All Tasks" (language-independent)
-      console.log('    → Changing filter to "All Tasks"');
-      const filterCombobox = page.getByTestId('task-filter-select');
-      await filterCombobox.click();
-      await page.waitForTimeout(300);
-
-      await page.getByTestId('task-filter-option-all').click();
-      await page.waitForTimeout(500);
-      console.log('    ✓ Filter changed to "All Tasks"');
-
-      // Navigate back to event detail page
-      console.log(`    → Navigating back to event detail page`);
-      await page.goto(eventUrl);
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(500);
-
-      console.log(`    → Verifying topic selection button is available...`);
-      const topicButton = page.getByTestId('select-topic-button');
-      await topicButton.scrollIntoViewIfNeeded({ timeout: 10000 });
-      await expect(topicButton).toBeVisible({ timeout: 5000 });
-      console.log(`    ✓ Event detail page ready for topic selection`);
-
-      // ========================================
-      // Step 4: Topic Selection via Heat Map
-      // ========================================
-      console.log('  → Step 4: Topic Selection');
-
-      await topicPage.openTopicSelection();
-      await expect(topicPage.heatmapButton).toBeVisible({ timeout: 5000 });
-
-      await topicPage.openHeatmap();
-      await page.waitForTimeout(1000);
-
-      const { row, column } = testConfig.topics.heatmapSelection;
-      await topicPage.selectTopicFromHeatmap(row, column);
-      await page.waitForTimeout(500);
-
-      await topicPage.confirmSelection();
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(500);
-
-      await expect(page.getByTestId('speaker-name-field')).toBeVisible({
-        timeout: 10000,
-      });
-      console.log(`    ✓ Topic selected from heatmap (row ${row}, col ${column})`);
-
-      // ========================================
-      // Step 5: Speaker Brainstorming
-      // ========================================
-      console.log('  → Step 5: Speaker Brainstorming');
-
-      await page.waitForTimeout(500);
-
-      const candidates = testConfig.speakerCandidates.map((c) => ({
-        firstName: c.firstName,
-        company: c.company,
-        expertise: c.expertise,
-        assignedUserName: c.assignedUserName,
-      }));
-
-      console.log(`    → Adding ${candidates.length} speaker candidates`);
-      await speakerPage.addMultipleSpeakers(candidates);
-      await page.waitForTimeout(500);
-      console.log(`    ✓ All ${candidates.length} speakers added to pool`);
-
-      await expect(speakerPage.proceedToOutreachButton).toBeVisible({ timeout: 5000 });
-      await speakerPage.proceedToOutreach();
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(1000);
-
-      await expect(page.getByTestId('speaker-card').first()).toBeVisible({ timeout: 10000 });
-      console.log('    ✓ Proceeded to outreach phase');
-
-      console.log('\n✅ Phase A Complete\n');
-    } catch (error) {
-      console.error('\n❌ Phase A Failed:', error);
-      throw error;
+    if (fixtureEvent?.eventCode) {
+      // Events are only deletable once ARCHIVED (DELETE → 409 otherwise). Force-archive first
+      // (override, tolerate any error if the walk already archived it) so teardown is robust
+      // regardless of where the walk stopped, then delete.
+      await transitionWorkflow(token, fixtureEvent.eventCode, 'ARCHIVED').catch(() => {});
+      await cleanupByCode(token, fixtureEvent.eventCode);
     }
   });
 
-  /**
-   * Phase B: Speaker Outreach & Kanban Management (Steps 4-6)
-   * - Speaker Outreach Tracking (contact 5 speakers with notes)
-   * - Kanban Workflow: Drag speakers from CONTACTED → READY
-   * - Kanban Workflow: Drag speakers from READY → ACCEPTED
-   */
-  test('Phase B: Speaker Outreach (Steps 4-6)', async ({ page }) => {
-    test.setTimeout(10 * 60 * 1000);
+  /** Navigate to the event overview tab (default) and return the workflow badge locator. */
+  async function openOverview(page: Page) {
+    await page.goto(`/organizer/events/${fixtureEvent.eventCode}`);
+    const badge = page.getByTestId('workflow-status-badge');
+    await expect(badge).toBeVisible();
+    return badge;
+  }
 
-    console.log('\n📋 Phase B: Speaker Outreach\n');
-
-    const speakerPage = new SpeakerManagementPage(page);
-
-    try {
-      // ========================================
-      // Step 1: Navigate to event outreach view
-      // ========================================
-      console.log('  → Step 1: Navigate to Event Outreach View');
-
-      const eventUrl = `http://localhost:8100/organizer/events/${testEventCode}?tab=speakers&view=kanban`;
-      console.log(`    → Navigating to event speakers tab: ${eventUrl}`);
-      await page.goto(eventUrl);
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(1000);
-
-      await expect(page.getByTestId('speaker-card').first()).toBeVisible({ timeout: 10000 });
-      console.log('    ✓ Outreach view loaded with speaker cards visible');
-
-      // ========================================
-      // Step 2: Contact Speakers (5 interactions)
-      // ========================================
-      console.log('  → Step 2: Contact Speakers');
-
-      for (let i = 0; i < testConfig.speakerOutreach.length; i++) {
-        const contact = testConfig.speakerOutreach[i];
-        console.log(
-          `    → Contacting speaker ${i + 1}/${testConfig.speakerOutreach.length}: ${contact.displayName}`
-        );
-
-        await speakerPage.contactSpeaker(contact.displayName, contact.contactMethod, contact.notes);
-
-        await page.waitForTimeout(500);
-
-        console.log(
-          `    ✓ Speaker ${i + 1} contacted via ${contact.contactMethod}: ${contact.notes.substring(0, 30)}...`
-        );
-      }
-
-      console.log(`    ✓ All ${testConfig.speakerOutreach.length} speaker contacts recorded`);
-
-      // ========================================
-      // Step 3: Drag Speakers from CONTACTED to READY
-      // ========================================
-      console.log('  → Step 3: Move Speakers to READY');
-
-      // Wait longer for kanban board state to settle after contact operations
-      // The original test had screenshot operations here that added extra time
-      await page.waitForTimeout(2000);
-
-      const readyColumn = page.getByTestId('status-lane-READY');
-
-      const speakersToMove = [
-        { name: 'N Nissim ELCA AI', label: 'Nissim' },
-        { name: 'B Balti Galenica AI', label: 'Balti' },
-        { name: 'A Andreas Mobiliar AI', label: 'Andreas' },
-        { name: 'D Daniel BKW AI', label: 'Daniel' },
-      ];
-
-      for (const speaker of speakersToMove) {
-        console.log(`    → Dragging ${speaker.label} to READY`);
-        const speakerCard = page.getByRole('button', { name: speaker.name });
-
-        await expect(speakerCard).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(500);
-
-        const cardBox = await speakerCard.boundingBox();
-        const columnBox = await readyColumn.boundingBox();
-
-        if (!cardBox) {
-          console.error(`      ✗ Failed to get boundingBox for ${speaker.label}`);
-          continue;
-        }
-        if (!columnBox) {
-          console.error(`      ✗ Failed to get boundingBox for READY column`);
-          continue;
-        }
-
-        await page.mouse.move(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height / 2);
-        await page.mouse.down();
-        await page.waitForTimeout(100);
-
-        await page.mouse.move(
-          columnBox.x + columnBox.width / 2,
-          columnBox.y + columnBox.height / 2,
-          { steps: 10 }
-        );
-        await page.waitForTimeout(100);
-
-        await page.mouse.up();
-        await page.waitForTimeout(300);
-
-        const confirmButton = page.getByTestId('status-change-confirm');
-        if (await confirmButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-          await confirmButton.click();
-          await page.waitForTimeout(500);
-        }
-
-        console.log(`      ✓ ${speaker.label} moved to READY`);
-      }
-
-      await page.waitForTimeout(1000);
-      console.log('    ✓ All speakers moved to READY');
-
-      // ========================================
-      // Step 4: Drag Speakers from READY to ACCEPTED
-      // ========================================
-      console.log('  → Step 4: Move Speakers to ACCEPTED');
-
-      // Wait for previous drag operations to fully settle
-      await page.waitForTimeout(1500);
-
-      const readyColumnCheck = page.getByTestId('status-lane-READY');
-      await expect(readyColumnCheck).toBeVisible({ timeout: 5000 });
-
-      const acceptedColumn = page.getByTestId('status-lane-ACCEPTED');
-      await expect(acceptedColumn).toBeVisible({ timeout: 5000 });
-      console.log('    → ACCEPTED column found, starting drag operations');
-
-      const firstSpeakerCheck = page.getByRole('button', { name: speakersToMove[0].name });
-      await expect(firstSpeakerCheck).toBeVisible({ timeout: 5000 });
-      console.log(`    → First speaker (${speakersToMove[0].label}) confirmed visible in READY`);
-
-      for (const speaker of speakersToMove) {
-        console.log(`    → Dragging ${speaker.label} to ACCEPTED`);
-
-        await page.waitForTimeout(300);
-
-        const speakerCard = page.getByRole('button', { name: speaker.name });
-
-        await expect(speakerCard).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(300);
-
-        const cardBox = await speakerCard.boundingBox();
-        const columnBox = await acceptedColumn.boundingBox();
-
-        if (!cardBox) {
-          console.error(`      ✗ Failed to get boundingBox for ${speaker.label}`);
-          continue;
-        }
-        if (!columnBox) {
-          console.error(`      ✗ Failed to get boundingBox for ACCEPTED column`);
-          continue;
-        }
-
-        await page.mouse.move(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height / 2);
-        await page.mouse.down();
-        await page.waitForTimeout(100);
-
-        await page.mouse.move(
-          columnBox.x + columnBox.width / 2,
-          columnBox.y + columnBox.height / 2,
-          { steps: 10 }
-        );
-        await page.waitForTimeout(100);
-
-        await page.mouse.up();
-        await page.waitForTimeout(300);
-
-        const confirmButton = page.getByTestId('status-change-confirm');
-        if (await confirmButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-          await confirmButton.click();
-          await page.waitForTimeout(500);
-        }
-
-        console.log(`      ✓ ${speaker.label} moved to ACCEPTED`);
-      }
-
-      await page.waitForTimeout(1000);
-      console.log('    ✓ All speakers moved to ACCEPTED');
-
-      console.log('\n✅ Phase B Complete\n');
-    } catch (error) {
-      console.error('\n❌ Phase B Failed:', error);
-      throw error;
-    }
+  test('should_renderOverviewWithCreatedBadge_when_eventOpened', async ({ page }) => {
+    // A freshly created event opens on the overview tab in CREATED — proves the event detail
+    // screen renders and the badge reflects the persisted workflow state.
+    const badge = await openOverview(page);
+    await expect(badge).toHaveAttribute('data-workflow-state', 'CREATED');
+    expect(await getWorkflowState(token, fixtureEvent.eventCode)).toBe('CREATED');
   });
 
-  /**
-   * Phase B.5: Content Submission
-   * - Switch to Sessions view
-   * - Publish Topic
-   * - Submit speaker content (3 speakers: Nissim, Balti, Andreas)
-   * - Fill presentation title and abstract
-   */
-  test('Phase B.5: Content Submission', async ({ page }) => {
-    test.setTimeout(10 * 60 * 1000);
+  test(
+    'should_advanceThroughEveryWorkflowState_when_forceTransitioned',
+    { tag: ['@smoke', '@gate'] },
+    async ({ page }) => {
+      // Walk the full forward lifecycle: force-advance via the override API, then reload the
+      // overview and assert the badge reflects the new state, with an authoritative status
+      // cross-check. Each iteration is one mutating step of the one happy path for this entity.
+      for (const state of WORKFLOW_FORWARD_STATES) {
+        const confirmed = await transitionWorkflow(token, fixtureEvent.eventCode, state);
+        expect(confirmed).toBe(state);
 
-    console.log('\n📋 Phase B.5: Content Submission\n');
+        // Authoritative server-side verification the transition persisted.
+        expect(await getWorkflowState(token, fixtureEvent.eventCode)).toBe(state);
 
-    try {
-      expect(testEventCode).toBeTruthy();
-      console.log(`Using event code: ${testEventCode}`);
-
-      // STEP 1: Navigate directly to Publishing tab
-      console.log('📍 Step 1: Navigate to Publishing tab');
-      await page.goto(`http://localhost:8100/organizer/events/${testEventCode}?tab=publishing`);
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(500);
-
-      // STEP 2: Click "Publish Topic" button
-      console.log('📍 Step 2: Publish topic');
-      await page.getByTestId('publish-topic-button').click();
-      await page.waitForTimeout(1000);
-
-      // STEP 3: Return to Speakers tab
-      console.log('📍 Step 3: Return to Speakers tab');
-      await page.getByTestId('event-tab-speakers').click();
-      await page.waitForTimeout(500);
-
-      // STEP 4: Submit content for each speaker
-      for (let i = 0; i < testConfig.presentations.length; i++) {
-        const presentation = getPresentation(i);
-        const speakerCandidate = testConfig.speakerCandidates[presentation.speakerIndex];
-
-        console.log(
-          `\n📍 Step 4.${i + 1}: Submit content for ${speakerCandidate.firstName} (${presentation.actualSpeakerName})`
-        );
-
-        const cardPattern = new RegExp(
-          `${speakerCandidate.firstName.charAt(0)} ${speakerCandidate.firstName}.*${speakerCandidate.company}`,
-          'i'
-        );
-        console.log(`  🔍 Looking for speaker card matching: ${cardPattern}`);
-
-        try {
-          const speakerCard = page.getByRole('button', { name: cardPattern });
-          await speakerCard.waitFor({ state: 'visible', timeout: 5000 });
-          await speakerCard.click();
-          await page.waitForTimeout(500);
-        } catch (error) {
-          console.error(`  ❌ Failed to find speaker card for ${speakerCandidate.firstName}`);
-          throw error;
-        }
-
-        // Fill speaker search if needed
-        if (presentation.speakerSearchTerm) {
-          console.log(`  🔍 Searching for speaker: ${presentation.speakerSearchTerm}`);
-          const searchField = page.getByTestId('speaker-search-field');
-          await searchField.click();
-          await searchField.fill(presentation.speakerSearchTerm);
-          await page.waitForTimeout(500);
-
-          await page.getByText(presentation.actualSpeakerName).first().click();
-          await page.waitForTimeout(300);
-        } else {
-          console.log(`  ✓ Speaker auto-mapped to ${presentation.actualSpeakerName}`);
-        }
-
-        // Fill presentation title
-        console.log(`  📝 Filling title: ${presentation.title}`);
-        await page.getByTestId('presentation-title-field').click();
-        await page.getByTestId('presentation-title-field').fill(presentation.title);
-
-        // Fill presentation abstract
-        console.log(`  📝 Filling abstract: ${presentation.abstract}`);
-        await page.getByTestId('presentation-abstract-field').click();
-        await page.getByTestId('presentation-abstract-field').fill(presentation.abstract);
-
-        // Submit content
-        console.log('  ✅ Submitting content');
-        await page.getByTestId('submit-speaker-content-button').click();
-
-        await page.waitForTimeout(1000);
-        await page.waitForLoadState('networkidle');
-
-        console.log(`  ✅ Content submitted for ${speakerCandidate.firstName}`);
+        // UI assertion: the overview badge reflects the new state (toHaveAttribute auto-retries
+        // through the fresh-page refetch).
+        const badge = await openOverview(page);
+        await expect(badge).toHaveAttribute('data-workflow-state', state);
       }
 
-      console.log('\n✅ Phase B.5 Complete: All speaker content submitted');
-    } catch (error) {
-      console.error('❌ Phase B.5 failed:', error);
-      throw error;
+      // Ended in ARCHIVED — the only DELETE-able state, so afterAll's cleanup will succeed (204).
+      expect(await getWorkflowState(token, fixtureEvent.eventCode)).toBe('ARCHIVED');
     }
-  });
-
-  /**
-   * Phase C: Quality Review
-   * - Publish Speakers
-   * - Approve presentations (3 speakers)
-   */
-  test('Phase C: Quality Review', async ({ page }) => {
-    test.setTimeout(10 * 60 * 1000);
-
-    console.log('\n📋 Phase C: Quality Review\n');
-
-    try {
-      expect(testEventCode).toBeTruthy();
-      console.log(`Using event code: ${testEventCode}`);
-
-      await page.goto(`http://localhost:8100/organizer/events/${testEventCode}`);
-      await page.waitForLoadState('networkidle');
-
-      // STEP 1: Navigate to Publish tab
-      console.log('📍 Step 1: Navigate to Publish tab');
-      await page.getByTestId('event-tab-publishing').click();
-      await page.waitForTimeout(500);
-
-      // STEP 2: Click "Publish Speakers" button
-      console.log('📍 Step 2: Publish speakers');
-      await page.getByTestId('publish-speakers-button').click();
-      await page.waitForTimeout(1000);
-
-      // STEP 3: Return to Speakers tab
-      console.log('📍 Step 3: Return to Speakers tab');
-      await page.getByTestId('event-tab-speakers').click();
-      await page.waitForTimeout(500);
-
-      // STEP 4: Approve each presentation
-      for (let i = 0; i < testConfig.presentations.length; i++) {
-        const presentation = getPresentation(i);
-        console.log(`\n📍 Step 4.${i + 1}: Approve ${presentation.title}`);
-
-        const presentationCard = page.getByRole('button', {
-          name: new RegExp(presentation.title),
-        });
-        await presentationCard.click();
-        await page.waitForTimeout(500);
-
-        console.log('  ✅ Approving content');
-        await page.getByTestId('approve-content-button').click();
-        await page.waitForTimeout(1000);
-      }
-
-      console.log('\n✅ Phase C Complete: All presentations approved');
-    } catch (error) {
-      console.error('❌ Phase C failed:', error);
-      throw error;
-    }
-  });
-
-  /**
-   * Phase D: Slot Assignment & Publish Agenda
-   * - Navigate to Sessions view
-   * - Open Slot Assignment page
-   * - Auto-assign speakers to time slots
-   * - Publish Agenda
-   */
-  test('Phase D: Slot Assignment & Publish Agenda', async ({ page }) => {
-    test.setTimeout(10 * 60 * 1000);
-
-    console.log('\n📋 Phase D: Slot Assignment & Publish Agenda\n');
-
-    try {
-      await page.goto(`http://localhost:8100/organizer/events/${testEventCode}`);
-      await page.waitForTimeout(500);
-
-      // ========================================
-      // STEP 1: Navigate to Sessions View
-      // ========================================
-      console.log('📍 Step 1: Navigate to Sessions view');
-
-      await page.getByTestId('event-tab-speakers').click();
-      await page.waitForTimeout(500);
-
-      console.log('  → Switching to Sessions view');
-      await page.getByTestId('sessions-view-toggle').click();
-      await page.waitForTimeout(500);
-
-      console.log('  ✓ Sessions view loaded');
-
-      // ========================================
-      // STEP 2: Open Slot Assignment Page
-      // ========================================
-      console.log('📍 Step 2: Open Slot Assignment page');
-
-      await page.getByTestId('manage-slot-assignments-button').click();
-      await page.waitForTimeout(1000);
-
-      console.log('  ✓ Slot Assignment page opened');
-
-      // ========================================
-      // STEP 3: Auto-Assign Speakers
-      // ========================================
-      console.log('📍 Step 3: Auto-assign speakers to time slots');
-
-      await page.waitForTimeout(500);
-
-      console.log('  → Clicking Auto-Assign button');
-      const autoAssignButton = page.getByTestId('auto-assign-button');
-      await expect(autoAssignButton).toBeVisible({ timeout: 5000 });
-      await autoAssignButton.click();
-      await page.waitForTimeout(500);
-
-      const autoAssignModal = page.getByTestId('auto-assign-modal');
-      await expect(autoAssignModal).toBeVisible({ timeout: 3000 });
-
-      console.log('  → Confirming auto-assignment');
-      const confirmButton = page.getByTestId('auto-assign-confirm');
-      await confirmButton.click();
-      await page.waitForTimeout(2000);
-
-      console.log('  ✓ Speakers auto-assigned to slots');
-
-      // ========================================
-      // STEP 4: Return to Event Page
-      // ========================================
-      console.log('📍 Step 4: Return to event page');
-
-      const backButton = page.getByTestId('back-to-event-button');
-      if (await backButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-        await backButton.click();
-        await page.waitForTimeout(1000);
-      } else {
-        await page.goto(`http://localhost:8100/organizer/events/${testEventCode}`);
-        await page.waitForTimeout(1000);
-      }
-
-      await expect(page.getByTestId('event-tab-overview')).toBeVisible({
-        timeout: 5000,
-      });
-
-      console.log('  ✓ Returned to event page');
-
-      // ========================================
-      // STEP 5: Navigate to Publishing Tab
-      // ========================================
-      console.log('📍 Step 5: Navigate to Publishing tab');
-
-      await page.getByTestId('event-tab-publishing').click();
-      await page.waitForTimeout(2000);
-
-      await expect(page.getByTestId('publish-agenda-button')).toBeVisible({ timeout: 10000 });
-
-      console.log('  ✓ Publishing tab loaded');
-
-      // ========================================
-      // STEP 6: Publish Agenda
-      // ========================================
-      console.log('📍 Step 6: Publish Agenda');
-
-      await page.getByTestId('publish-agenda-button').click();
-      await page.waitForTimeout(1000);
-
-      console.log('  ✓ Agenda published');
-
-      console.log('\n✅ Phase D Complete: Slot assignment and agenda published');
-    } catch (error) {
-      console.error('❌ Phase D failed:', error);
-      throw error;
-    }
-  });
-
-  /**
-   * Phase E: Archival (Workflow completion)
-   * - Navigate to Overview tab
-   * - Edit event status to ARCHIVED
-   * - Override workflow validation
-   * - Save changes
-   */
-  test('Phase E: Archival (Event archival)', async ({ page }) => {
-    test.setTimeout(5 * 60 * 1000);
-
-    console.log('\n📋 Phase E: Archival\n');
-
-    try {
-      console.log('Navigating to event page...');
-      await page.goto(`http://localhost:8100/organizer/events/${testEventCode}`);
-      await page.waitForTimeout(1000);
-
-      // Step 1: Navigate to Overview tab
-      console.log('Step 1: Navigate to Overview tab');
-      await page.getByTestId('event-tab-overview').click();
-      await page.waitForTimeout(500);
-
-      console.log('  ✓ On Overview tab');
-
-      // Step 2: Click Edit button
-      console.log('\nStep 2: Open event edit modal');
-      const editButton = page.getByTestId('edit-event-button');
-      await editButton.waitFor({ state: 'visible', timeout: 5000 });
-      await editButton.click();
-      await page.waitForTimeout(1000);
-
-      const modalTitle = page.getByTestId('event-form-dialog-title');
-      await modalTitle.waitFor({ state: 'visible', timeout: 5000 });
-
-      console.log('  ✓ Edit modal opened');
-
-      // Step 3: Change status to ARCHIVED
-      console.log('\nStep 3: Change status to ARCHIVED');
-      const statusSelect = page.getByTestId('event-status-select');
-      await statusSelect.waitFor({ state: 'visible', timeout: 5000 });
-      await statusSelect.click();
-      await page.waitForTimeout(300);
-
-      console.log('  ✓ Status dropdown opened');
-
-      await page.getByTestId('status-option-ARCHIVED').click();
-      await page.waitForTimeout(300);
-
-      console.log('  ✓ Status changed to ARCHIVED');
-
-      // Step 4: Click Save button (will trigger validation error)
-      console.log('\nStep 4: Click Save button (expect validation error)');
-      const saveButton = page.getByTestId('save-event-button');
-      await saveButton.click();
-      await page.waitForTimeout(1000);
-
-      await modalTitle.waitFor({ state: 'visible', timeout: 3000 });
-
-      console.log('  ✓ Validation error triggered (as expected)');
-
-      // Step 5: Check "Override workflow validation" checkbox
-      console.log('\nStep 5: Enable workflow validation override');
-      const overrideCheckbox = page.getByTestId('override-workflow-validation-checkbox');
-      await overrideCheckbox.waitFor({ state: 'visible', timeout: 5000 });
-      await overrideCheckbox.check();
-      await page.waitForTimeout(300);
-
-      console.log('  ✓ Override checkbox enabled');
-
-      // Step 6: Click Save button again
-      console.log('\nStep 6: Save with override (should succeed)');
-      await saveButton.click();
-      await page.waitForTimeout(1500);
-
-      const modalClosed = await page
-        .locator('.MuiDialog-root')
-        .isVisible({ timeout: 3000 })
-        .catch(() => false);
-      if (modalClosed) {
-        console.log('  ⚠️  Modal still visible, waiting longer...');
-        await page.waitForTimeout(1000);
-      }
-
-      console.log('  ✓ Event archived successfully');
-
-      // Verify ARCHIVED badge is visible
-      const archivedBadge = page.getByTestId('workflow-status-badge');
-      await archivedBadge.waitFor({ state: 'visible', timeout: 5000 });
-
-      console.log('  ✓ ARCHIVED badge visible');
-
-      console.log('\n✅ Phase E Complete: Event archived successfully');
-    } catch (error) {
-      console.error('❌ Phase E failed:', error);
-      throw error;
-    }
-  });
+  );
 });

--- a/web-frontend/src/components/organizer/EventPage/EventOverviewTab.tsx
+++ b/web-frontend/src/components/organizer/EventPage/EventOverviewTab.tsx
@@ -189,6 +189,9 @@ export const EventOverviewTab: React.FC<EventOverviewTabProps> = ({ event, event
                 color="primary"
                 size="small"
                 data-testid="workflow-status-badge"
+                // Locale-independent assertion hook: the visible `label` is translated, so the
+                // raw workflow state is exposed here for testid-only E2E assertions (slice 10).
+                data-workflow-state={event.workflowState || 'CREATED'}
               />
               <Typography variant="body2" color="text.secondary">
                 {t('eventPage.overview.step', 'Step')}{' '}


### PR DESCRIPTION
Rewrites the event-workflow slice's `event-lifecycle-e2e.spec.ts` to the **OQ-3 hybrid** approach, bringing it to the staging-gate quality bar (testid-only, factory data, mandatory cleanup, no empty tests).

## What changed
The old spec was a 6-phase monolithic UI walk that:
- created its event **through the UI** with a `Date.now()` number and **never cleaned up** (leaked event + tasks/speakers/sessions per run),
- drove the speaker kanban with raw `page.mouse` **native HTML5 drag-drop** + **hardcoded** organizer/speaker display names,
- depended on slice-8 speaker/content flows and **cron-only** auto-transitions a UI walk can't drive deterministically.

New **hybrid** (architect's OQ-3 default): force-advance workflow state via the override transition API (`PUT /events/{code}/workflow/transition`, `overrideValidation:true` — verified `EventWorkflowStateMachine.transitionToState` skips **all** validation under override, so any target incl. cron-only `EVENT_LIVE`/`EVENT_COMPLETED` is reachable), then **UI-assert** the overview `workflow-status-badge` after each step + an authoritative `GET /workflow/status` cross-check.

- **`@smoke`** walks the full 7-state forward sequence (`CREATED → … → ARCHIVED`, ~15.5s, deterministic — no cron/DnD/content).
- **`@gate`** read-only check that a fresh event renders in `CREATED`.

## Prod change (one)
`EventOverviewTab` — added a locale-independent `data-workflow-state` attribute to the `workflow-status-badge` Chip (the visible label is translated → can't assert by text; mirrors slice-7's `data-view-mode`). New `transitionWorkflow`/`getWorkflowState` fixture helpers + `WORKFLOW_FORWARD_STATES`.

## Cleanup contract
afterAll **force-archives** the event (events are DELETE-able only when `ARCHIVED` → 409 otherwise) then `cleanupByCode` — robust even if the walk fails mid-sequence. `BATPW-E2E` title token is the orphan backstop.

## Verification
- Green ×2 on dev (2/2 both runs); final teardown sweep `events:0` (residue-free).
- `tsc` + `eslint` clean; 170 EventPage unit tests green; pre-push suite 4954 passed.
- Also flips plan-doc rows 9/10 (slices 8/9) to merged (#697), records PR 11 notes, resolves OQ-3.

Refs: docs/plans/playwright-staging-hardening.md PR #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)