### PR TITLE
fix(ci): exclude dependabot PRs from staging deploy gate + serialize deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -740,10 +740,21 @@ jobs:
   deploy-to-staging:
     needs: [build-shared-kernel, build-services, build-frontend]
     # Deploy to staging on: (1) push to develop OR (2) PR to develop
-    # This allows testing PRs in staging environment before merge
+    # This allows testing PRs in staging environment before merge.
+    #
+    # Dependabot PRs are EXCLUDED from the PR-to-develop deploy gate: their runs
+    # execute with a restricted token and no access to repo secrets, so the
+    # staging auth-token fetch silently no-ops and every authenticated Bruno /
+    # Playwright assertion fails (expected 401 to equal 200). They also have no
+    # business firing a real production deploy per-PR. Build + unit-test jobs
+    # still run; the real deploy gate runs once on the push-to-develop after
+    # merge, where secrets exist. (Root-caused 2026-06-01: monthly dependabot
+    # batch left 18 PRs unmergeable + thrashed prod with concurrent deploys.)
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop')
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.base.ref == 'develop' &&
+       github.actor != 'dependabot[bot]')
     uses: ./.github/workflows/deploy-staging.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -24,6 +24,16 @@ on:
         required: false
         default: false
 
+# Serialize all staging deploys. The staging account (188701360969) serves
+# production traffic and CloudFormation rejects an update while a stack is in
+# UPDATE_IN_PROGRESS. A static group makes concurrent deploys (e.g. a wave of
+# merges to develop) queue instead of colliding with
+# "ValidationError: ... is in UPDATE_IN_PROGRESS state and can not be updated".
+# cancel-in-progress: false so an in-flight prod deploy is never killed mid-roll.
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
 env:
   AWS_REGION: eu-central-1
   ENVIRONMENT: staging


### PR DESCRIPTION
## Why

The 2026-06-01 monthly Dependabot run created 18 PRs (#705–#722); **none built green or merged**. Root cause is the `deploy-to-staging` gate `build.yml` runs on every PR to develop — not the dependency bumps themselves (`build-services`, `build-frontend`, `build-shared-kernel` all pass on every PR).

Two failure modes, both in the gate:

1. **Bruno/Playwright can't authenticate.** Dependabot-triggered runs use a restricted token with **no access to repo secrets** (`STAGING_ORGANIZER_*`…), so the staging auth-token fetch silently no-ops → every authenticated assertion fails `expected 401 to equal 200` (#710, #721, #722).
2. **CloudFormation deploy collisions.** No concurrency group anywhere → multiple PRs deploy to the single staging (= production) account at once → `BATbern-staging-CompanyManagement is in UPDATE_IN_PROGRESS state and can not be updated` (#709, #718, #719, #720).

Each PR was also firing a **real production deploy**, which was never the intent — `CLAUDE.md` describes dependabot batch-merge as running "full CI (tests, lint, security scans)", not a prod deploy. The PR→develop deploy gate (from the Playwright/Bruno hardening) swept dependabot in by accident.

## What

1. **`build.yml`** — add `github.actor != 'dependabot[bot]'` to the PR branch of the deploy-gate condition. Dependabot PRs run build + unit tests only (which pass); auto-merge already accepts `skipped`, so they become mergeable. The real gate still runs once on the push-to-develop **after** merge, where secrets exist and auto-rollback is armed.
2. **`deploy-staging.yml`** — add `concurrency: { group: deploy-staging, cancel-in-progress: false }` so staging deploys serialize instead of colliding. `cancel-in-progress: false` ensures an in-flight prod deploy is never killed mid-roll.

## Cleanup

The 18 stuck PRs (#705–#722) are being closed; the next scheduled Dependabot run recreates them and — with this fix in place — they build green and merge cleanly via batch-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)