### PR TITLE
fix(frontend): SSO follow-ups — My Profile for all roles, NetworkFirst navigations (stale-SW fix), real dashboard completeness

### DIFF
--- a/services/event-management-service/src/main/java/ch/batbern/events/service/SpeakerDashboardService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/SpeakerDashboardService.java
@@ -267,22 +267,32 @@ public class SpeakerDashboardService {
     private SpeakerDashboardDto buildEmptyDashboard(String username) {
         // Code review 2026-05-18 (P23): fall back to the User's display name from CUMS
         // rather than echoing the raw username (e.g. "alice.muller" → "Alice Müller").
+        // 2026-06-05: also carry profileCompleteness + profilePictureUrl from the SAME
+        // profile fetch — the hardcoded 0 made the speaker-portal dashboard show "0%
+        // complete" for membership-less speakers while /profile showed 100%.
         String fallbackName = username;
+        String profilePictureUrl = null;
+        int profileCompleteness = 0;
         try {
             UserResponse userProfile = userApiClient.getUserByUsername(username);
-            if (userProfile != null
-                    && userProfile.getFirstName() != null
-                    && userProfile.getLastName() != null) {
-                fallbackName = (userProfile.getFirstName() + " " + userProfile.getLastName())
-                        .trim();
+            if (userProfile != null) {
+                if (userProfile.getFirstName() != null && userProfile.getLastName() != null) {
+                    fallbackName = (userProfile.getFirstName() + " "
+                            + userProfile.getLastName()).trim();
+                }
+                if (userProfile.getProfilePictureUrl() != null) {
+                    profilePictureUrl = userProfile.getProfilePictureUrl().toString();
+                }
+                profileCompleteness = calculateProfileCompleteness(userProfile);
             }
         } catch (Exception e) {
-            LOG.debug("Could not resolve display name for empty-dashboard: {} ({})",
+            LOG.debug("Could not resolve profile for empty-dashboard: {} ({})",
                     username, e.getMessage());
         }
         return SpeakerDashboardDto.builder()
                 .speakerName(fallbackName)
-                .profileCompleteness(0)
+                .profilePictureUrl(profilePictureUrl)
+                .profileCompleteness(profileCompleteness)
                 .upcomingEvents(List.of())
                 .pastEvents(List.of())
                 .build();

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/SpeakerDashboardServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/SpeakerDashboardServiceTest.java
@@ -1,0 +1,114 @@
+package ch.batbern.events.service;
+
+import ch.batbern.events.client.UserApiClient;
+import ch.batbern.events.dto.SpeakerDashboardDto;
+import ch.batbern.events.dto.generated.users.UserResponse;
+import ch.batbern.events.exception.UserNotFoundException;
+import ch.batbern.events.repository.EventRepository;
+import ch.batbern.events.repository.SessionContentHistoryRepository;
+import ch.batbern.events.repository.SessionMaterialsRepository;
+import ch.batbern.events.repository.SessionRepository;
+import ch.batbern.events.repository.SessionUserRepository;
+import ch.batbern.events.repository.SpeakerPoolRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SpeakerDashboardService}.
+ *
+ * 2026-06-05 regression: the empty-state dashboard (speaker with SPEAKER role but no
+ * session_users rows — e.g. a freshly provisioned federated user) hardcoded
+ * profileCompleteness=0 and dropped the profile picture, even though it already fetched
+ * the CUMS profile for the display-name fallback. The speaker-portal dashboard then
+ * showed 0% while /profile (computed client-side from the same five fields) showed 100%.
+ */
+@ExtendWith(MockitoExtension.class)
+class SpeakerDashboardServiceTest {
+
+    @Mock
+    private SpeakerPoolRepository speakerPoolRepository;
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private SessionRepository sessionRepository;
+    @Mock
+    private SessionContentHistoryRepository sessionContentHistoryRepository;
+    @Mock
+    private SessionMaterialsRepository sessionMaterialsRepository;
+    @Mock
+    private SessionUserRepository sessionUserRepository;
+    @Mock
+    private UserApiClient userApiClient;
+
+    private SpeakerDashboardService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SpeakerDashboardService(
+                speakerPoolRepository,
+                eventRepository,
+                sessionRepository,
+                sessionContentHistoryRepository,
+                sessionMaterialsRepository,
+                sessionUserRepository,
+                userApiClient);
+    }
+
+    @Test
+    void should_resolveCompletenessAndPicture_when_speakerHasNoSessionMemberships() {
+        when(sessionUserRepository.findByUsername("john.doe")).thenReturn(List.of());
+        when(userApiClient.getUserByUsername("john.doe")).thenReturn(new UserResponse()
+                .firstName("John")
+                .lastName("Doe")
+                .email("john.doe@example.com")
+                .bio("Cloud architect")
+                .profilePictureUrl(URI.create("https://cdn.batbern.ch/profiles/john.jpg")));
+
+        SpeakerDashboardDto dashboard = service.getDashboard("john.doe");
+
+        // All five completeness fields are filled → 100%, same as /profile shows.
+        assertThat(dashboard.profileCompleteness()).isEqualTo(100);
+        assertThat(dashboard.profilePictureUrl())
+                .isEqualTo("https://cdn.batbern.ch/profiles/john.jpg");
+        assertThat(dashboard.speakerName()).isEqualTo("John Doe");
+        assertThat(dashboard.upcomingEvents()).isEmpty();
+        assertThat(dashboard.pastEvents()).isEmpty();
+    }
+
+    @Test
+    void should_reportPartialCompleteness_when_profileFieldsMissingAndNoMemberships() {
+        when(sessionUserRepository.findByUsername("jane.new")).thenReturn(List.of());
+        // 3 of 5 fields filled (firstName, lastName, email) → 60%.
+        when(userApiClient.getUserByUsername("jane.new")).thenReturn(new UserResponse()
+                .firstName("Jane")
+                .lastName("New")
+                .email("jane.new@example.com"));
+
+        SpeakerDashboardDto dashboard = service.getDashboard("jane.new");
+
+        assertThat(dashboard.profileCompleteness()).isEqualTo(60);
+        assertThat(dashboard.profilePictureUrl()).isNull();
+    }
+
+    @Test
+    void should_fallBackToZeroCompletenessAndUsername_when_profileLookupFails() {
+        when(sessionUserRepository.findByUsername("ghost.user")).thenReturn(List.of());
+        when(userApiClient.getUserByUsername("ghost.user"))
+                .thenThrow(new UserNotFoundException("ghost.user"));
+
+        SpeakerDashboardDto dashboard = service.getDashboard("ghost.user");
+
+        assertThat(dashboard.profileCompleteness()).isZero();
+        assertThat(dashboard.speakerName()).isEqualTo("ghost.user");
+        assertThat(dashboard.profilePictureUrl()).isNull();
+    }
+}

--- a/web-frontend/src/components/public/Navigation/PublicNavigation.test.tsx
+++ b/web-frontend/src/components/public/Navigation/PublicNavigation.test.tsx
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import { PublicNavigation } from './PublicNavigation';
 import * as useAuthModule from '@/hooks/useAuth';
@@ -107,4 +108,54 @@ describe('PublicNavigation', () => {
   // Note: Mobile menu toggle not yet implemented in simplified navigation
   // Component currently uses md:flex to hide nav on mobile
   // TODO: Add mobile hamburger menu in future iteration
+
+  // 2026-06-05: "My Profile" must be visible to EVERY authenticated user (the
+  // role-neutral /profile page serves all roles since Story 12.11), not just speakers.
+  describe('My Profile dropdown entry', () => {
+    const authenticatedAs = (roles: string[]) => {
+      vi.mocked(useAuthModule.useAuth).mockReturnValue({
+        user: {
+          userId: '123',
+          email: 'test@example.com',
+          role: roles[0],
+          roles,
+          companyId: '456',
+          firstName: 'Test',
+          lastName: 'User',
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        error: null,
+        accessToken: 'fake-token',
+        signIn: vi.fn(),
+        signOut: vi.fn(),
+        signUp: vi.fn(),
+        refreshToken: vi.fn(),
+        clearError: vi.fn(),
+        hasRole: vi.fn(),
+        hasPermission: vi.fn(),
+        canAccess: vi.fn(),
+        isTokenExpired: vi.fn(),
+      } as never);
+    };
+
+    it.each([['attendee'], ['speaker'], ['organizer'], ['partner']])(
+      'should_showMyProfileLinkingToProfile_when_%sOpensUserDropdown',
+      async (role) => {
+        authenticatedAs([role]);
+        const user = userEvent.setup();
+
+        render(
+          <BrowserRouter>
+            <PublicNavigation />
+          </BrowserRouter>
+        );
+
+        await user.click(screen.getByTestId('public-nav-user-menu'));
+
+        const profileLink = await screen.findByRole('link', { name: /my profile/i });
+        expect(profileLink).toHaveAttribute('href', '/profile');
+      }
+    );
+  });
 });

--- a/web-frontend/src/components/public/Navigation/PublicNavigation.tsx
+++ b/web-frontend/src/components/public/Navigation/PublicNavigation.tsx
@@ -126,7 +126,11 @@ export const PublicNavigation = ({ topOffset = '0px' }: PublicNavigationProps) =
               {isAuthenticated ? (
                 <Popover>
                   <PopoverTrigger asChild>
-                    <Button variant="outline" className="flex items-center gap-2 px-3">
+                    <Button
+                      variant="outline"
+                      className="flex items-center gap-2 px-3"
+                      data-testid="public-nav-user-menu"
+                    >
                       <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary text-primary-foreground text-xs font-semibold leading-none">
                         {initials}
                       </span>
@@ -137,16 +141,17 @@ export const PublicNavigation = ({ topOffset = '0px' }: PublicNavigationProps) =
                     <div className="flex flex-col gap-1">
                       {/* 2026-05-20 (Q#2b) — Portal + My Sessions moved out to the main
                           nav bar above. The dropdown is now secondary actions only:
-                          My Profile (speakers), language switcher, logout. */}
-                      {isSpeaker && (
-                        <Link
-                          to="/profile"
-                          className="flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent transition-colors"
-                        >
-                          <UserCircle className="h-4 w-4" />
-                          {t('navigation.myProfile', 'My Profile')}
-                        </Link>
-                      )}
+                          My Profile, language switcher, logout.
+                          2026-06-05 — My Profile shown to EVERY authenticated user (the
+                          role-neutral /profile page serves all roles since Story 12.11;
+                          canAccess allows '/profile' for all four roles). */}
+                      <Link
+                        to="/profile"
+                        className="flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent transition-colors"
+                      >
+                        <UserCircle className="h-4 w-4" />
+                        {t('navigation.myProfile', 'My Profile')}
+                      </Link>
                       <div className="py-1 px-1">
                         <LanguageSwitcher />
                       </div>
@@ -270,14 +275,14 @@ export const PublicNavigation = ({ topOffset = '0px' }: PublicNavigationProps) =
                   {user?.email ?? ''}
                 </Link>
               </Button>
-              {isSpeaker && (
-                <Button asChild variant="secondary" className="w-full">
-                  <Link to="/profile" onClick={closeMobileMenu} className="flex items-center gap-2">
-                    <UserCircle className="h-4 w-4" />
-                    {t('navigation.myProfile', 'My Profile')}
-                  </Link>
-                </Button>
-              )}
+              {/* 2026-06-05 — My Profile for every authenticated user (role-neutral
+                  /profile since Story 12.11), mirroring the desktop dropdown. */}
+              <Button asChild variant="secondary" className="w-full">
+                <Link to="/profile" onClick={closeMobileMenu} className="flex items-center gap-2">
+                  <UserCircle className="h-4 w-4" />
+                  {t('navigation.myProfile', 'My Profile')}
+                </Link>
+              </Button>
               <div className="px-1">
                 <LanguageSwitcher />
               </div>

--- a/web-frontend/vite.config.ts
+++ b/web-frontend/vite.config.ts
@@ -68,9 +68,40 @@ export default defineConfig({
       workbox: {
         // Service worker caching strategies
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
+        // 2026-06-05 — index.html is deliberately NOT precached and navigations are
+        // served NetworkFirst (see runtimeCaching below). Precache-pinning index.html
+        // froze BOTH the app shell AND its response headers (CSP!) until the SW
+        // updated: after every deploy, each SW-controlled client ran the OLD bundle for
+        // one more full page-load cycle. Two prod incidents: the CSP connect-src fix
+        // never reaching SW clients (2026-06-04), and the 12.8-F8 federated-login fix
+        // failing one last time per client (2026-06-05, first registration of
+        // buchsjosefnissim@gmail.com). Hashed assets stay precached — they are
+        // immutable; only the HTML entry must always be fresh.
+        globIgnores: ['**/index.html'],
+        // Disable the precache-bound SPA navigation route (createHandlerBoundToURL
+        // requires index.html in the manifest). Navigations fall through to the
+        // runtimeCaching NetworkFirst route below; CloudFront handles 404→index.html.
+        navigateFallback: null,
         skipWaiting: true, // Activate new service worker immediately
         clientsClaim: true, // Take control of all pages immediately
         runtimeCaching: [
+          // Navigations (full page loads): network first so a fresh deploy reaches
+          // every client on their NEXT page load; cached copy only as offline fallback.
+          {
+            urlPattern: ({ request }) => request.mode === 'navigate',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'html-cache',
+              networkTimeoutSeconds: 5,
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24 * 7, // offline fallback for up to 1 week
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
           // Google Fonts caching removed — the app loads no web fonts (system
           // font stack only). See index.html.
           {


### PR DESCRIPTION
## Three follow-ups from the 12.8-F8 live verification (reported by Nissim, 2026-06-05)

### 1. "My Profile" visible to every authenticated user
Attendee-only users had no path to `/profile` — the public-nav dropdown (desktop + mobile) gated the entry on `isSpeaker`. The page itself is role-neutral since 12.11 and `canAccess` allows `/profile` for all four roles. Gate removed; link already pointed to `/profile` directly. +4 RTL tests (one per role).

### 2. Speaker dashboard completeness bar showed 0% while /profile showed 100%
`SpeakerDashboardService.buildEmptyDashboard` (speaker with no `session_users` rows — e.g. a freshly provisioned federated speaker) hardcoded `profileCompleteness(0)` and dropped the profile picture, despite already fetching the CUMS profile for the name fallback. Now computes completeness + carries the picture from the same fetch. +3 unit tests (RED first).

### 3. Stale service worker pinned the old bundle one page-load cycle past every deploy
**Root cause of the "error after first registration":** the 12:28:28Z registration's first attempt ran the OLD pre-F8 bundle — that browser profile's SW (last visit 06:40Z, pre-deploy) served the precached index.html. Evidence: PreTokenGeneration fired for the first time at 12:28:56.99 — the token exchange never ran during the first attempt's 12:28:31→46 window (the F8 signature), and no PreAuthentication preceded the 12:28:57 exchange (session-cookie re-click).

Durable fix for the class (second prod bite after the 2026-06-04 CSP header pinning): `index.html` removed from the SW precache (`globIgnores`), precache-bound navigation route disabled (`navigateFallback: null`), navigations served **NetworkFirst** (`html-cache`, 5s network timeout, cached copy only as offline fallback). Hashed immutable assets stay precached. Generated `sw.js` inspected: 0 index.html precache entries, `navigate → NetworkFirst` route present, `createHandlerBoundToURL` gone.

## Verification
- PublicNavigation 8/8, SpeakerDashboardServiceTest 3/3, SpeakerPortalAuthIntegrationTest green
- tsc clean, eslint clean, `npm run build` + generated-SW inspection
- Post-deploy: fresh Google registration in a clean profile should now work **first try**; existing stale-SW clients converge on their next page load (one last old-bundle cycle, then never again)

🤖 Generated with [Claude Code](https://claude.com/claude-code)