### PR TITLE
feat(auth): SSO login via verified additional email + verification flow (Stories A+B)

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -210,3 +210,15 @@
 
 ## 2026-06-05 — from spec-organizer-mobile-responsiveness-2 review
 - `web-frontend/src/pages/organizer/EventManagementAdminPage.tsx:64` — pre-existing: `?tab=<non-numeric>` deep link yields `Number()=NaN` → no tab content renders and (since round 2) the mobile BottomNavigation selects nothing. Guard: `Number.isFinite(n) ? clamp(n,0,8) : 0`.
+
+## Deferred from: spec-additional-email-verification (2026-06-06) — Story B queued next
+
+**Google SSO login via verified additional email** (implement immediately after Story A merges; user-approved scope):
+- `infrastructure/lib/lambda/triggers/pre-signup.ts` (PreSignUp_ExternalProvider, lines ~91-205): after the primary-email `LOWER(email)` match on `user_profiles`, add fallback lookup on `user_additional_emails` gated on `verified_at IS NOT NULL` AND IdP claim `email_verified=true`; on match → `AdminLinkProviderForUser` to owning user (same as primary path). Trigger must never throw (503s all auth).
+- `services/company-user-management-service/.../interceptor/JITUserProvisioningInterceptor.java` (~lines 140-160): same verified-additional-email fallback before JIT-creating a new user.
+- Tests: Lambda handler unit tests importing/running the handler (mandatory rule); CUMS integration tests for JIT fallback.
+
+## Deferred from: review of spec-additional-email-verification (2026-06-06)
+
+- **SES IAM grant includes `identity/*` wildcard** — both `partner-coordination-stack.ts:99-103` (origin of the pattern) and the new grant in `company-management-stack.ts` carry a third resource ARN `identity/*` that negates the scoped domain ARNs. Tighten both stacks together after verifying which identity ARNs SES sends actually require (test in staging; sending uses From `noreply@batbern.ch` → `identity/batbern.ch` should suffice).
+- **No cooldown/rate-limit on `POST /me/additional-emails/{email}/resend-verification`** — authenticated user can spam SES sends to their registered addresses. Add a per-row 60s cooldown (compare token issue time or a lightweight in-memory Caffeine cache) if abuse is observed.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -222,3 +222,8 @@
 
 - **SES IAM grant includes `identity/*` wildcard** — both `partner-coordination-stack.ts:99-103` (origin of the pattern) and the new grant in `company-management-stack.ts` carry a third resource ARN `identity/*` that negates the scoped domain ARNs. Tighten both stacks together after verifying which identity ARNs SES sends actually require (test in staging; sending uses From `noreply@batbern.ch` → `identity/batbern.ch` should suffice).
 - **No cooldown/rate-limit on `POST /me/additional-emails/{email}/resend-verification`** — authenticated user can spam SES sends to their registered addresses. Add a per-row 60s cooldown (compare token issue time or a lightweight in-memory Caffeine cache) if abuse is observed.
+
+## Deferred from: review of spec-sso-link-verified-additional-email (2026-06-06)
+
+- **Primary-email federated linking has no `email_verified` gate** — `pre-signup.ts` links a federated identity to a matching `user_profiles.email` WITHOUT checking the IdP's `email_verified` attribute (pre-existing Epic 12 behavior; the new additional-email fallback IS gated). Low risk while Google is the only IdP (always verified); MUST be hardened before Apple/generic OIDC lands (backlog Story 12.10) — an IdP asserting an arbitrary unverified email could link into a victim's account.
+- **`AdminLinkProviderForUser` "already linked" not distinguished from real failures** — a concurrent sign-in/retry throws `InvalidParameterException` and pollutes the `PreSignUpFailure` metric. `post-authentication.ts:105` already special-cases this; mirror that in `pre-signup.ts` for both linking paths.

--- a/_bmad-output/implementation-artifacts/spec-additional-email-verification.md
+++ b/_bmad-output/implementation-artifacts/spec-additional-email-verification.md
@@ -1,0 +1,140 @@
+---
+title: 'Additional-email verification flow (v2 of Story 10.32)'
+type: 'feature'
+created: '2026-06-06'
+status: 'done'
+baseline_commit: 'd896fe13'
+context:
+  - '{project-root}/_bmad-output/project-context.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** `user_additional_emails.verified_at` (V16) is always NULL — any logged-in user can claim any address with no ownership proof. This blocks the planned SSO-linking-via-additional-email feature (account-takeover vector) and means forwarder/CC fan-out trusts unverified addresses.
+
+**Approach:** On add (and on demand via resend), CUMS emails a signed verification link (HMAC JWT, 48h TTL, stateless — no new table) to the additional address. A public frontend page confirms via POST, setting `verified_at`. Wire the existing "Unverified" pill to real state and add Verified/Resend UI.
+
+## Boundaries & Constraints
+
+**Always:** Contract-first (`docs/api/users-api.openapi.yml` updated before code, regen backend DTOs + frontend types, both committed). TDD with `AbstractIntegrationTest` (PostgreSQL Testcontainers). Email templates DE + EN only; UI i18n keys in all 10 locales. Verification confirm is POST-only (mail scanners prefetch GETs — GET must never mutate). Send failure must never fail/roll back the add. New Flyway migrations only if truly needed (target: none). Mock `EmailService` in all tests — no real outbound email.
+
+**Ask First:** Any new Flyway migration. Any change to Cognito/auth flow (that's Story B). Any new Secrets Manager secret (reuse `WATCH_JWT_SECRET`→`JWT_SECRET` pattern).
+
+**Never:** Don't gate existing fan-out/CC behaviour on `verified_at` in this story (forwarder/CC keep using all emails — behaviour change is out of scope). Don't touch `pre-signup.ts`/JIT (Story B). Don't store tokens in the DB. Don't edit applied migrations V1–V19.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Add email | POST /users/me/additional-emails | 201 + verification email sent async (locale de/en per user pref, else en) | send failure → WARN log, add still succeeds |
+| Verify (check) | GET /users/additional-emails/verify?token= | 200 `{email(masked), status}` | invalid/expired → 400 `TOKEN_INVALID`/`TOKEN_EXPIRED` |
+| Confirm | POST /users/additional-emails/verify `{token}` | 200, `verified_at` set | row deleted since issuance → 404; expired → 400 |
+| Confirm again | already-verified row | 200 idempotent (`alreadyVerified: true`) | n/a |
+| Re-added email | row deleted + re-added (new row id) | old token → 404 (token carries row UUID) | n/a |
+| Resend | POST /users/me/additional-emails/{email}/resend-verification (auth) | 204 + new email | 404 if not caller's; 409 `ALREADY_VERIFIED` if verified |
+| Tampered token | bad signature | 400 `TOKEN_INVALID` | never 500 |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `services/company-user-management-service/.../service/UserService.java:~1352` — `addAdditionalEmail` (hook send here); `UserAdditionalEmailRepository` has `findByUserAndEmailIgnoreCase`
+- `services/event-management-service/.../service/ConfirmationTokenService.java` — JJWT HS256 pattern to copy (claims: type + ids, `${jwt.secret}`, TTL property)
+- `shared-kernel/.../service/EmailService.java` — `@Service`, already component-scanned by CUMS (`scanBasePackages` includes `ch.batbern.shared`); `{{var}}` template replacement
+- `services/event-management-service/src/main/resources/email-templates/` — `{key}-{locale}.html` naming convention
+- `api-gateway/.../config/SecurityConfig.java:199-309` + `services/company-user-management-service/.../config/SecurityConfig.java` (both profiles) — permitAll lists; new verify endpoints go in BOTH (dual-SecurityConfig rule)
+- `web-frontend/src/pages/public/UnsubscribePage.tsx` — verify→confirm landing-page pattern to mirror
+- `web-frontend/src/components/user/UserSettingsTab/UserSettingsTab.tsx:90-336` — AdditionalEmailsSection; unverified pill at 235-241
+- `web-frontend/src/hooks/useUserAccount/useUserAccount.ts:159-181` — add/delete mutation hooks; invalidate `['user-profile']`
+- `infrastructure/lib/stacks/company-management-stack.ts` — add SES grant (copy partner-coordination-stack.ts:92-103) + `JWT_SECRET` secret mapping (copy event-management-stack.ts:139-143) + `APP_BASE_URL` env (event-management-stack.ts:108)
+- `docs/api/users-api.openapi.yml` — contract source of truth
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `docs/api/users-api.openapi.yml` — add `GET/POST /users/additional-emails/verify` (public, token-credentialed) + `POST /users/me/additional-emails/{email}/resend-verification`; regen: `./gradlew :services:company-user-management-service:openApiGenerateUsers` + `cd web-frontend && npm run generate:api-types:users` — contract-first
+- [x] `services/company-user-management-service/.../service/AdditionalEmailVerificationTokenService.java` — NEW: JJWT HS256, claims `{type: additional-email-verification, additionalEmailId, email}`, `${jwt.secret}`, `${batbern.user.additional-emails.verification.token-validity-hours:48}`; CUMS `application.yml` gains `jwt.secret: ${JWT_SECRET:changeme}` — stateless token, row-UUID binding invalidates on delete/re-add
+- [x] `services/company-user-management-service/src/main/resources/email-templates/additional-email-verification-{de,en}.html` — NEW: link `{{baseUrl}}/verify-email?token={{token}}`; rendering via EmailService `{{var}}` replacement; user-locale de/en, fallback en
+- [x] `services/company-user-management-service/.../service/UserService.java` — send on add (async-safe, failure tolerated); `resendVerification` (404/409 rules); `verifyAdditionalEmail(token)` (load row by UUID, match email ignore-case, set `verified_at` if null, idempotent)
+- [x] `services/company-user-management-service/.../controller/UserController.java` + both SecurityConfigs (CUMS local+prod profiles, api-gateway) — wire 3 endpoints; verify endpoints permitAll in BOTH configs
+- [x] `services/company-user-management-service/src/test/...` — integration tests FIRST (RED): full I/O matrix above + token round-trip; `@MockBean EmailService`, assert template key + recipient + token link var
+- [x] `infrastructure/lib/stacks/company-management-stack.ts` — SES grant + JWT_SECRET + APP_BASE_URL (see Code Map); `cd infrastructure && npm test` green
+- [x] `web-frontend/src/pages/public/VerifyAdditionalEmailPage.tsx` + route `/verify-email` — NEW, mirror UnsubscribePage (verify→confirm→success/error states) + Vitest tests
+- [x] `web-frontend/src/components/user/UserSettingsTab/UserSettingsTab.tsx` + `useUserAccount` — pill: Verified (success) / Unverified + Resend button (`useResendVerification` mutation); Vitest tests; i18n keys ×10 locales (`userManagement.json`)
+
+**Acceptance Criteria:**
+- Given a fresh additional email, when the user clicks the emailed link and confirms on `/verify-email`, then `verified_at` is set and the settings pill shows Verified
+- Given an expired (>48h) or tampered token, when confirming, then 400 with errorCode and the page shows a localized error + no DB change
+- Given the email row was deleted after issuance, when confirming, then 404 and `verified_at` of any other row unchanged
+- Given an unverified email, when the owner clicks Resend, then a new verification email is dispatched and 204 returned; a verified one returns 409
+- Given EmailService throws on add, when POSTing a new additional email, then 201 is still returned and a WARN is logged
+
+## Spec Change Log
+
+## Design Notes
+
+Token is the credential → endpoints public (`permitAll` both layers), no JWT needed on verify path. Row-UUID claim (not email alone) makes delete/re-add a hard invalidation and prevents cross-user replay (global email uniqueness + fresh UUID per row). Two-step GET-verify/POST-confirm copied from newsletter unsubscribe to survive mail-scanner prefetch. `verifiedAt` already exists in OpenAPI `AdditionalEmail` schema and frontend types — response shape unchanged except new endpoints.
+
+## Verification
+
+**Commands:**
+- `set -o pipefail; ./gradlew :services:company-user-management-service:test 2>&1 | tee /tmp/cums-test.log` — expected: BUILD SUCCESSFUL, new integration tests green
+- `cd infrastructure && npx jest test/unit --silent 2>&1 | tee /tmp/infra-test.log` — expected: green (stack snapshot updated)
+- `cd web-frontend && npx vitest run src/components/user/UserSettingsTab src/pages/public/VerifyAdditionalEmailPage 2>&1 | tee /tmp/fe-test.log` — expected: green
+- `cd web-frontend && npm run type-check` — expected: clean after type regen
+
+## Suggested Review Order
+
+**Token design — the security core**
+
+- Stateless HS256 JWT bound to the row UUID; delete/re-add hard-invalidates outstanding links
+  [`AdditionalEmailVerificationTokenService.java:73`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/AdditionalEmailVerificationTokenService.java#L73)
+- Claim extraction inside validation — malformed-but-signed tokens → 400, never 500 (review patch)
+  [`AdditionalEmailVerificationTokenService.java:98`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/AdditionalEmailVerificationTokenService.java#L98)
+
+**Verify endpoints — public, token-credentialed**
+
+- GET check is read-only by design (mail scanners prefetch links); only POST mutates
+  [`UserService.java:1495`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/UserService.java#L1495)
+- Confirm: row-UUID + email match, idempotent `alreadyVerified`, `@Transactional` (review patch)
+  [`UserService.java:1524`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/UserService.java#L1524)
+- Three endpoints; resend stays auth-gated, verify pair is public
+  [`UserController.java:594`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/controller/UserController.java#L594)
+- Dual-SecurityConfig rule: permitAll in CUMS (all 3 profiles)…
+  [`SecurityConfig.java:143`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/config/SecurityConfig.java#L143)
+- …and in the gateway
+  [`SecurityConfig.java:291`](../../api-gateway/src/main/java/ch/batbern/gateway/config/SecurityConfig.java#L291)
+
+**Send path — failure-tolerant**
+
+- Send-on-add hook: `flush()` to materialise the row UUID before token minting
+  [`UserService.java:1369`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/UserService.java#L1369)
+- Swallow-and-WARN wrapper — SES outage never rolls back the 201
+  [`UserService.java:1430`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/UserService.java#L1430)
+- DE/EN template selection (`de*` prefix match), EN fallback
+  [`AdditionalEmailVerificationEmailService.java:47`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/AdditionalEmailVerificationEmailService.java#L47)
+
+**Infra — first email-sending capability for CUMS**
+
+- SES grant (PCS pattern), JWT_SECRET reuse of WATCH_JWT_SECRET, APP_BASE_URL
+  [`company-management-stack.ts:180`](../../infrastructure/lib/stacks/company-management-stack.ts#L180)
+
+**Frontend**
+
+- Public landing page: useEffect-driven state machine, distinct 404 (`notFound`) vs 400 (`invalid`) states
+  [`VerifyAdditionalEmailPage.tsx:46`](../../web-frontend/src/pages/public/VerifyAdditionalEmailPage.tsx#L46)
+- Settings pill: Verified/Unverified + double-click-guarded Resend
+  [`UserSettingsTab.tsx:284`](../../web-frontend/src/components/user/UserSettingsTab/UserSettingsTab.tsx#L284)
+- Resend mutation hook
+  [`useUserAccount.ts:188`](../../web-frontend/src/hooks/useUserAccount/useUserAccount.ts#L188)
+
+**Peripherals — contract, tests, i18n**
+
+- Contract-first: 3 new operations + schemas
+  [`users-api.openapi.yml:1000`](../../docs/api/users-api.openapi.yml#L1000)
+- Full I/O-matrix integration suite (16 tests, mocked EmailService, Testcontainers)
+  [`AdditionalEmailVerificationIntegrationTest.java:57`](../../services/company-user-management-service/src/test/java/ch/batbern/companyuser/controller/AdditionalEmailVerificationIntegrationTest.java#L57)
+- i18n ×10 locales (`verifyEmail.*` + pill/resend keys)
+  [`en/userManagement.json`](../../web-frontend/public/locales/en/userManagement.json)

--- a/_bmad-output/implementation-artifacts/spec-sso-link-verified-additional-email.md
+++ b/_bmad-output/implementation-artifacts/spec-sso-link-verified-additional-email.md
@@ -2,7 +2,8 @@
 title: 'Google SSO login via verified additional email (Epic 12 follow-up)'
 type: 'feature'
 created: '2026-06-06'
-status: 'draft'
+status: 'done'
+baseline_commit: '88978256'
 context:
   - '{project-root}/_bmad-output/project-context.md'
 ---
@@ -49,12 +50,12 @@ context:
 ## Tasks & Acceptance
 
 **Execution:**
-- [ ] `infrastructure/test/unit/pre-signup.test.ts` — RED first: mock pg client; cases = happy link (verified+email_verified → AdminLinkProviderForUser with owner's username), unverified row, email_verified absent/'false', owner without cognito_user_id, fallback query throws → still auto-confirms
-- [ ] `infrastructure/lib/lambda/triggers/pre-signup.ts` — after empty primary-match result: if `email_verified === 'true'` (case-insensitive), query `SELECT u.cognito_user_id, u.username FROM user_additional_emails ae JOIN user_profiles u ON u.id = ae.user_id WHERE LOWER(ae.email) = LOWER($1) AND ae.verified_at IS NOT NULL`; on hit with `cognito_user_id` → same AdminLink block as primary path + new metric; on hit without → log, fall through; reuse the single client/finally-release
-- [ ] `services/company-user-management-service/.../repository/UserAdditionalEmailRepository.java` — `Optional<UserAdditionalEmail> findVerifiedByEmailIgnoreCase(String email)` via `@Query` with `JOIN FETCH ae.user`
-- [ ] `services/company-user-management-service/.../interceptor/JITUserProvisioningInterceptor.java` — before JIT-create: if JWT email matches a verified additional email → skip creation, WARN (masked email) referencing pre-signup linking; never touch owner's `cognito_user_id`
-- [ ] `services/company-user-management-service/src/test/...JITUserProvisioning*IntegrationTest` — RED first: duplicate-guard case (no user row created), unverified case (existing create behaviour unchanged)
-- [ ] `docs/architecture/ADR-010-federated-identity-via-cognito.md` — amend D3 with the verified-additional-email fallback (same commit, doc-drift rule)
+- [x] `infrastructure/test/unit/pre-signup.test.ts` — RED first: mock pg client; cases = happy link (verified+email_verified → AdminLinkProviderForUser with owner's username), unverified row, email_verified absent/'false', owner without cognito_user_id, fallback query throws → still auto-confirms
+- [x] `infrastructure/lib/lambda/triggers/pre-signup.ts` — after empty primary-match result: if `email_verified === 'true'` (case-insensitive), query `SELECT u.cognito_user_id, u.username FROM user_additional_emails ae JOIN user_profiles u ON u.id = ae.user_id WHERE LOWER(ae.email) = LOWER($1) AND ae.verified_at IS NOT NULL`; on hit with `cognito_user_id` → same AdminLink block as primary path + new metric; on hit without → log, fall through; reuse the single client/finally-release
+- [x] `services/company-user-management-service/.../repository/UserAdditionalEmailRepository.java` — `Optional<UserAdditionalEmail> findVerifiedByEmailIgnoreCase(String email)` via `@Query` with `JOIN FETCH ae.user`
+- [x] `services/company-user-management-service/.../interceptor/JITUserProvisioningInterceptor.java` — before JIT-create: if JWT email matches a verified additional email → skip creation, WARN (masked email) referencing pre-signup linking; never touch owner's `cognito_user_id`
+- [x] `services/company-user-management-service/src/test/...JITUserProvisioning*IntegrationTest` — RED first: duplicate-guard case (no user row created), unverified case (existing create behaviour unchanged)
+- [x] `docs/architecture/ADR-010-federated-identity-via-cognito.md` — amend D3 with the verified-additional-email fallback (same commit, doc-drift rule)
 
 **Acceptance Criteria:**
 - Given user X with verified additional email g@gmail.com and a Cognito-linked profile, when a Google sign-in for g@gmail.com fires PreSignUp_ExternalProvider, then AdminLinkProviderForUser is called with X as destination and no new user is provisioned
@@ -73,3 +74,34 @@ JIT guard deliberately does NOT resolve the request to the owning user: granting
 **Commands:**
 - `cd infrastructure && set -o pipefail; npx jest test/unit/pre-signup.test.ts 2>&1 | tee /tmp/presignup-test.log` — expected: green, new cases included
 - `set -o pipefail; ./gradlew :services:company-user-management-service:test 2>&1 | tee /tmp/cums-test-b.log` — expected: BUILD SUCCESSFUL
+
+## Suggested Review Order
+
+**Lambda fallback — the linking core**
+
+- Double-gated fallback: runs only when primary match is empty AND IdP asserts email_verified
+  [`pre-signup.ts:135`](../../infrastructure/lib/lambda/triggers/pre-signup.ts#L135)
+- SQL gate: verified additional emails only, joined to the owning profile
+  [`pre-signup.ts:145`](../../infrastructure/lib/lambda/triggers/pre-signup.ts#L145)
+- Shared AdminLink helper — primary path refactored, behavior byte-identical
+  [`pre-signup.ts:240`](../../infrastructure/lib/lambda/triggers/pre-signup.ts#L240)
+- Cognito string-attribute semantics ('true'/'false', case-insensitive)
+  [`pre-signup.ts:229`](../../infrastructure/lib/lambda/triggers/pre-signup.ts#L229)
+
+**JIT duplicate guard — defensive twin**
+
+- Skip creation when email is someone's verified additional email; never touch owner's sub
+  [`JITUserProvisioningInterceptor.java:170`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/interceptor/JITUserProvisioningInterceptor.java#L170)
+- Primary lookup aligned to case-insensitive (review patch — was findByEmail)
+  [`JITUserProvisioningInterceptor.java:147`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/interceptor/JITUserProvisioningInterceptor.java#L147)
+- Verified-only finder with JOIN FETCH
+  [`UserAdditionalEmailRepository.java:48`](../../services/company-user-management-service/src/main/java/ch/batbern/companyuser/repository/UserAdditionalEmailRepository.java#L48)
+
+**Peripherals — tests, docs**
+
+- 18 handler-level Lambda tests (happy link, gates, fail-open, metric coverage)
+  [`pre-signup.test.ts:229`](../../infrastructure/test/unit/lambda/pre-signup.test.ts#L229)
+- Testcontainers guard tests (no duplicate row, owner untouched)
+  [`JITAdditionalEmailGuardIntegrationTest.java:46`](../../services/company-user-management-service/src/test/java/ch/batbern/companyuser/integration/JITAdditionalEmailGuardIntegrationTest.java#L46)
+- ADR-010 D3 amendment (doc-drift rule, same commit)
+  [`ADR-010-federated-identity-via-cognito.md:59`](../../docs/architecture/ADR-010-federated-identity-via-cognito.md#L59)

--- a/_bmad-output/implementation-artifacts/spec-sso-link-verified-additional-email.md
+++ b/_bmad-output/implementation-artifacts/spec-sso-link-verified-additional-email.md
@@ -1,0 +1,75 @@
+---
+title: 'Google SSO login via verified additional email (Epic 12 follow-up)'
+type: 'feature'
+created: '2026-06-06'
+status: 'draft'
+context:
+  - '{project-root}/_bmad-output/project-context.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** A user whose private Gmail is registered (and now verifiable, per Story A) as an *additional* email cannot "Continue with Google" — the PreSignUp linker only matches `user_profiles.email`, so Google sign-in JIT-creates a duplicate ATTENDEE user instead of logging into the existing account.
+
+**Approach:** Extend Epic 12 account linking with a fallback lookup on `user_additional_emails`, gated on `verified_at IS NOT NULL` AND the IdP's `email_verified=true` attribute. On match, `AdminLinkProviderForUser` to the owning user — identical to the primary-email path. Defensive twin in the JIT interceptor prevents duplicate creation if linking didn't happen.
+
+## Boundaries & Constraints
+
+**Always:** `pre-signup.ts` must never throw on the federated path (a throw 503s ALL sign-ins) — preserve the existing catch-all + metric pattern. The fallback runs ONLY when the primary `user_profiles.email` match found nothing. Both gates required in the Lambda: DB `verified_at IS NOT NULL` AND `event.request.userAttributes.email_verified === 'true'` (case-insensitive). Lambda handler unit tests that import and run the handler (CDK Template tests don't count). CUMS integration tests via `AbstractIntegrationTest`.
+
+**Ask First:** Any change to the linking destination logic of the existing primary-email path. Any new Cognito API call other than the existing `AdminLinkProviderForUser`. Any schema/migration change.
+
+**Never:** Don't link on UNverified additional emails. In JIT, never overwrite an existing `cognito_user_id` (would break the owner's native login). Don't modify Story A's verification endpoints. No frontend changes. No OpenAPI changes.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Happy link | Google sign-in; gmail = verified additional email of user X | AdminLinkProviderForUser → X; metric `FederatedUserLinkedViaAdditionalEmail` | n/a |
+| Unverified | gmail = additional email, `verified_at IS NULL` | NO link; falls through to existing new-user path (JIT provisions separate user) | n/a |
+| IdP unverified | `email_verified` attr ≠ 'true' (or absent) | NO additional-email fallback (primary path unchanged) | n/a |
+| Primary wins | gmail = some user's PRIMARY email | existing path links as today; fallback never queried | n/a |
+| Owner has no Cognito | additional-email owner row has `cognito_user_id NULL` | NO link (no destination); log + existing pending-JIT metric pattern | n/a |
+| DB error in fallback | query throws | caught; sign-in proceeds (never throw); `PreSignUpFailure` metric | log error |
+| JIT duplicate guard | first API call, JWT email = verified additional email of X (linking didn't happen) | NO new user created; WARN log; request proceeds unresolved | n/a |
+| JIT unverified | JWT email = unverified additional email | existing behaviour: JIT creates new user (unchanged) | n/a |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `infrastructure/lib/lambda/triggers/pre-signup.ts:91-205` — `handleFederated()`: primary match at 120-125, three-outcome branch at 128-189, never-throw at 191-204; insert fallback between outcome 1 and 2
+- `infrastructure/test/unit/pre-signup.test.ts` — existing handler-level tests to extend (imports + runs handler)
+- `services/company-user-management-service/.../interceptor/JITUserProvisioningInterceptor.java:112-160` — `findByCognitoUserId` → `findByEmail` linking → JIT-create; insert guard before create
+- `services/company-user-management-service/.../repository/UserAdditionalEmailRepository.java` — add `@Query` finder (JOIN FETCH user) by email ignore-case + verified
+- `docs/architecture/ADR-010-federated-identity-via-cognito.md` D3 — linking decision doc; needs an amendment note (doc-drift rule)
+
+## Tasks & Acceptance
+
+**Execution:**
+- [ ] `infrastructure/test/unit/pre-signup.test.ts` — RED first: mock pg client; cases = happy link (verified+email_verified → AdminLinkProviderForUser with owner's username), unverified row, email_verified absent/'false', owner without cognito_user_id, fallback query throws → still auto-confirms
+- [ ] `infrastructure/lib/lambda/triggers/pre-signup.ts` — after empty primary-match result: if `email_verified === 'true'` (case-insensitive), query `SELECT u.cognito_user_id, u.username FROM user_additional_emails ae JOIN user_profiles u ON u.id = ae.user_id WHERE LOWER(ae.email) = LOWER($1) AND ae.verified_at IS NOT NULL`; on hit with `cognito_user_id` → same AdminLink block as primary path + new metric; on hit without → log, fall through; reuse the single client/finally-release
+- [ ] `services/company-user-management-service/.../repository/UserAdditionalEmailRepository.java` — `Optional<UserAdditionalEmail> findVerifiedByEmailIgnoreCase(String email)` via `@Query` with `JOIN FETCH ae.user`
+- [ ] `services/company-user-management-service/.../interceptor/JITUserProvisioningInterceptor.java` — before JIT-create: if JWT email matches a verified additional email → skip creation, WARN (masked email) referencing pre-signup linking; never touch owner's `cognito_user_id`
+- [ ] `services/company-user-management-service/src/test/...JITUserProvisioning*IntegrationTest` — RED first: duplicate-guard case (no user row created), unverified case (existing create behaviour unchanged)
+- [ ] `docs/architecture/ADR-010-federated-identity-via-cognito.md` — amend D3 with the verified-additional-email fallback (same commit, doc-drift rule)
+
+**Acceptance Criteria:**
+- Given user X with verified additional email g@gmail.com and a Cognito-linked profile, when a Google sign-in for g@gmail.com fires PreSignUp_ExternalProvider, then AdminLinkProviderForUser is called with X as destination and no new user is provisioned
+- Given the same row but `verified_at IS NULL`, when the same sign-in fires, then no link occurs and behaviour equals today's new-user path
+- Given the fallback DB query throws, when a federated sign-in fires, then the handler still returns auto-confirmed (never throws)
+- Given a JWT whose email is X's verified additional email and no `cognito_user_id` match, when the first API call hits CUMS, then no duplicate user row is created
+
+## Spec Change Log
+
+## Design Notes
+
+JIT guard deliberately does NOT resolve the request to the owning user: granting the unlinked federated session X's identity at service level only (Cognito still split, `JwtRolesConverter` lookups by sub would disagree) creates a half-linked state worse than a degraded session. The guard's only job is preventing the duplicate row; the real link belongs to PreSignUp. Lambda gate uses Cognito's string attribute semantics (`email_verified` arrives as `'true'`/`'false'` strings).
+
+## Verification
+
+**Commands:**
+- `cd infrastructure && set -o pipefail; npx jest test/unit/pre-signup.test.ts 2>&1 | tee /tmp/presignup-test.log` — expected: green, new cases included
+- `set -o pipefail; ./gradlew :services:company-user-management-service:test 2>&1 | tee /tmp/cums-test-b.log` — expected: BUILD SUCCESSFUL

--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -1,10 +1,10 @@
 ---
 project_name: BATbern
 user_name: Nissim
-date: 2026-02-24
+date: 2026-06-06
 sections_completed: [technology_stack, language_rules, framework_rules, testing_rules, code_quality, workflow_rules, critical_rules]
 status: complete
-rule_count: 65
+rule_count: 84
 optimized_for_llm: true
 ---
 
@@ -25,7 +25,7 @@ Focus on unobvious details that agents otherwise miss._
 - Zustand 5.x — client state
 - React Router 7.x
 - react-hook-form 7.x + zod 4.x — forms & validation
-- i18next 25.x + react-i18next 16.x — i18n (en + de)
+- i18next 25.x + react-i18next 16.x — i18n (10 locales: de, en, fr, it, rm, es, fi, nl, ja, gsw-BE)
 - Tailwind CSS 4.x + Vite 7.x
 - aws-amplify 6.x — Cognito auth
 
@@ -108,6 +108,18 @@ Focus on unobvious details that agents otherwise miss._
 - Shared-kernel types (`ErrorResponse`, `PaginationMetadata`) are imported via
   `importMappings` in Gradle — never re-generated.
 
+### Architecture: Unified Speaker Workflow (ADR-009 — Epic 11)
+- `SpeakerWorkflowState` has exactly **8 states**: `IDENTIFIED → CONTACTED → READY → INVITED
+  → ACCEPTED → CONTENT_SUBMITTED → QUALITY_REVIEWED` (+ `DECLINED`, reachable from any state).
+- **Sole status writer**: `SpeakerWorkflowService.transition(...)`. NEVER set
+  `speaker_pool.status` directly (no `setStatus(...)` outside the service, no raw UPDATE).
+- `READY` is the **provisioning gate**: User lookup-or-create + Cognito provisioning + SPEAKER
+  role + `PRIMARY_SPEAKER` `session_users` row happen at the transition INTO ready, only via
+  `POST /api/v1/events/{code}/speakers/{speakerId}/promote`.
+- `speaker_pool.username`/`email` columns are GONE (V103). Canonical speaker identity =
+  `PrimarySpeakerResolver.resolve(pool)` (primary `session_users` row + CUMS-backed email).
+- Magic-link auth was torn down (Story 11.F.1) — speakers authenticate via Cognito only.
+
 ### Backend Layered Architecture
 ```
 Controller  →  implements generated *Api interface, delegates to Service
@@ -118,6 +130,24 @@ Entity      →  JPA annotations, UUID PK + meaningful ID alternate key (ADR-003
 ```
 - `GlobalExceptionHandler` MUST have an explicit `@ExceptionHandler(MethodArgumentNotValidException.class)` —
   the catch-all `@ExceptionHandler(Exception.class)` silently shadows Spring's default 400 handler.
+
+### Bundle Boundary: NO MUI on Public Pages (perf-critical)
+- Public routes (homepage, `/archive`, `/about`, `/privacy`, `/unsubscribe`, `/verify-email`, …)
+  are **Tailwind-only** — they must NEVER import MUI. MUI (~158 KB vendor chunk) lives behind
+  the lazy `<MuiLayout>` ThemeProvider boundary in `App.tsx` (auth/organizer/speaker/partner
+  routes). Public routes are declared as SIBLINGS after that boundary (React Router ranks by
+  path specificity, not source order).
+- Adding a new public page: build it with Tailwind + plain elements, register it as a sibling
+  of the boundary. Adding one MUI import to an eagerly-loaded public component drags the whole
+  MUI vendor chunk into the homepage bundle.
+
+### i18n / Localization (narrowed rule, 2026-05-17)
+- **Frontend UI keys: ALL 10 locales required** (`de, en, fr, it, rm, es, fi, nl, ja, gsw-BE`)
+  in `web-frontend/public/locales/{locale}/*.json`. EN + DE first-class copy; other 8 may be
+  straight translations.
+- **Backend email templates: DE + EN ONLY** (`services/*/src/main/resources/email-templates/
+  {key}-{de|en}.html`). Other locales fall back to EN at render time. Do NOT create 10-locale
+  email templates. Locale matching: treat any `de*` language pref as German.
 
 ### React Patterns
 - Roles determine which component tree renders — check role before rendering, not inside.
@@ -161,6 +191,13 @@ Entity      →  JPA annotations, UUID PK + meaningful ID alternate key (ADR-003
 - Auth state stored per role: `.playwright-auth-{role}.json` (written by `global-setup.ts`).
 - Partner tests live in `e2e/partner/`, speaker tests in `e2e/speaker/`.
 - Run Bruno API contract tests first: `./scripts/ci/run-bruno-tests.sh`.
+
+### Bruno `.bru` Files
+- **NO free-floating `#` comments** between blocks — the parser silently SKIPS the whole file
+  (`Warning: Skipping invalid file`) while `bru run` still exits 0. Prose goes in a `docs { }`
+  block at the end of the file. After any Bruno run, grep output for `Skipping invalid file`.
+- Staging IS production: no Bruno/E2E test may trigger real outbound communications
+  (invites, cancellations, reminders) or leave test data behind — always add cleanup steps.
 
 ### Coverage Requirements
 - Unit tests (business logic): ≥ 90%
@@ -280,6 +317,39 @@ type(scope): description
 - Never call `refreshJWT()` on 401 inside a sync/service loop — triggers infinite auth retry
   (401 → refresh → onChange → sync → 401 → …). JWT refresh is handled only by AuthManager timer.
 
+### Federated Identity / Google SSO (ADR-010 — Epic 12)
+- **Cognito Lambda triggers (pre-signup, pre-token-generation, post-authentication) must NEVER
+  throw** — a throw 503s EVERY sign-in. Wrap everything in try/catch, emit a CloudWatch metric,
+  return the event. Test this fail-open behavior explicitly.
+- PreSignUp (`PreSignUp_ExternalProvider`) links a federated identity to an existing account by
+  **case-insensitive email match** via `AdminLinkProviderForUser` (destination = native user,
+  `sub` preserved). Fallback (2026-06-06 amendment): verified additional emails
+  (`user_additional_emails.verified_at IS NOT NULL` AND IdP attribute `email_verified='true'`
+  — Cognito attributes are STRINGS). Never link on unverified emails.
+- JIT provisioning (`JITUserProvisioningInterceptor`, CUMS) creates the `user_profiles` row on
+  first authenticated API call (default role ATTENDEE); it must NEVER overwrite an existing
+  `cognito_user_id`, and it skips creation when the JWT email is someone's verified additional
+  email (duplicate guard).
+- Runtime kill-switch: `FEATURES_SSO_ENABLED` — SSO code paths must tolerate being disabled.
+- Lambda triggers need handler-level unit tests that import and RUN the handler — CDK
+  `Template.fromStack()` assertions do NOT count (they miss `Runtime.ImportModuleError`).
+- Lambda bundling: native deps (sharp, pg-native) require Docker bundling — the local
+  `tryBundle` must return `false` outside Jest so Linux x64 binaries are installed.
+
+### Additional Emails (Story 10.32 + verification flow 2026-06-06)
+- `user_additional_emails`: max 5/user, **globally unique case-insensitively across primary +
+  additional emails** — DB triggers reject collisions in both directions. Never assume an email
+  can belong to two users.
+- `verified_at` is set ONLY by the verification flow (signed stateless HMAC JWT link, 48h TTL,
+  claims bound to the row UUID so delete/re-add invalidates). SSO linking and the JIT guard gate
+  on `verified_at IS NOT NULL`. Do not gate email fan-out/CC on it (deliberate).
+- Token-credentialed public endpoints (verification, unsubscribe, registration confirm): the
+  token IS the credential → `permitAll` required in **BOTH** the api-gateway SecurityConfig AND
+  the owning service's SecurityConfig — and the service config has MULTIPLE profile chains
+  (local + prod + test): add to ALL of them.
+- Email-link confirm endpoints are **POST-only** — mail scanners prefetch GET links, so a GET
+  must never mutate state (GET = read-only check, POST = confirm).
+
 ### Backend Gotchas
 - `GlobalExceptionHandler`: ALWAYS add explicit `@ExceptionHandler(MethodArgumentNotValidException.class)`.
   Without it, `@ExceptionHandler(Exception.class)` returns 500 instead of 400 for validation failures.
@@ -287,6 +357,10 @@ type(scope): description
 - Never use `findAll()` then filter/paginate in memory — always paginate at the DB level.
 - Flyway migration filenames must be strictly sequential: `V{n}__{description}.sql`.
   Out-of-order versions cause `flywayMigrate` to fail — run `flywayRepair` first.
+- **NEVER edit an already-applied migration** (staging = production). A changed checksum makes
+  Flyway validation fail on boot → service crash-loops → ECS rolls back to a stale image and
+  deploys silently stop advancing. Fix data/schema with a NEW higher-numbered migration. Always
+  exclude `**/db/migration/**` from repo-wide find-and-replace sweeps (the #669 incident).
 - Cross-service HTTP clients must propagate the JWT from `SecurityContext` — do not make
   unauthenticated service-to-service calls.
 
@@ -295,8 +369,8 @@ type(scope): description
   async Task/Promise — otherwise multiple tab swipes all see the old timestamp and all fire.
 - MUI `<Collapse unmountOnExit>` removes DOM nodes asynchronously — always `waitFor()` on
   `.not.toBeInTheDocument()` assertions.
-- i18n: ALL user-visible strings go through `useTranslation()`. Add keys to both `en` and `de`
-  translation files. Missing keys silently fall back to the key string.
+- i18n: ALL user-visible strings go through `useTranslation()`. Add keys to ALL 10 locale
+  files (see i18n/Localization rule). Missing keys silently fall back to the key string.
 - Never import directly from `src/types/generated/` in test files when testing with MSW —
   mock the service layer instead.
 
@@ -329,4 +403,7 @@ type(scope): description
 - Review quarterly for outdated rules
 - Remove rules that become obvious over time
 
-_Last Updated: 2026-02-24_
+_Last Updated: 2026-06-06 (folded in: ADR-009, ADR-010 + verified-additional-email amendment,
+Epics 11/12 outcomes, narrowed email-localization rule, additional-emails + verification flow,
+no-MUI-on-public-pages bundle boundary, Bruno docs{} rule, Flyway never-edit-applied rule,
+Lambda handler-test + Docker-bundling rules)_

--- a/api-gateway/src/main/java/ch/batbern/gateway/config/SecurityConfig.java
+++ b/api-gateway/src/main/java/ch/batbern/gateway/config/SecurityConfig.java
@@ -286,6 +286,11 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/newsletter/unsubscribe/verify").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/newsletter/unsubscribe").permitAll()
 
+                        // Additional-email verification (v2): public token-credentialed verify
+                        // endpoints (GET-check / POST-confirm). The token IS the credential.
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/additional-emails/verify").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/users/additional-emails/verify").permitAll()
+
                         // Story 10.12: Self-service deregistration (token-protected)
                         .requestMatchers(HttpMethod.GET, "/api/v1/registrations/deregister/verify").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/registrations/deregister").permitAll()

--- a/docs/api/users-api.openapi.yml
+++ b/docs/api/users-api.openapi.yml
@@ -997,6 +997,134 @@ paths:
       security:
         - BearerAuth: []
 
+  /users/me/additional-emails/{email}/resend-verification:
+    post:
+      tags:
+        - User Account
+      summary: Resend the verification email for an additional email address
+      description: |
+        Additional-email verification v2 — re-dispatch the signed verification
+        link to one of the caller's own (still unverified) additional emails.
+        Idempotent in effect: a 204 means a fresh email was queued. The token is
+        regenerated on each call (stateless HMAC JWT, 48h TTL).
+      operationId: resendAdditionalEmailVerification
+      parameters:
+        - name: email
+          in: path
+          required: true
+          description: |
+            URL-encoded email address. Case-insensitive match against the caller's
+            additional emails.
+          schema:
+            type: string
+            format: email
+          example: info@berner-architekten-treffen.ch
+      responses:
+        '204':
+          description: A fresh verification email was dispatched.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: No matching additional email on the caller's profile.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: |
+            The email is already verified. Error code: `ALREADY_VERIFIED`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - BearerAuth: []
+
+  /users/additional-emails/verify:
+    get:
+      tags:
+        - User Account
+      summary: Check an additional-email verification token (no mutation)
+      description: |
+        Additional-email verification v2 — public, token-credentialed pre-flight
+        check used by the `/verify-email` landing page. Validates the token's
+        signature + expiry and returns the (masked) email and its current
+        verification status WITHOUT mutating any state. Mail-scanner prefetches
+        of the link land here (GET) and never confirm; the actual confirm is a
+        separate POST. No JWT — the token IS the credential.
+      operationId: checkAdditionalEmailVerification
+      security: []
+      parameters:
+        - name: token
+          in: query
+          required: true
+          description: The signed verification token from the email link.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Token is valid; returns masked email + status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdditionalEmailVerificationCheckResponse'
+        '400':
+          description: |
+            Token is invalid (`TOKEN_INVALID`) or expired (`TOKEN_EXPIRED`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    post:
+      tags:
+        - User Account
+      summary: Confirm an additional-email verification token (mutates)
+      description: |
+        Additional-email verification v2 — public, token-credentialed confirm.
+        POST-only so mail-scanner prefetches (GET) cannot accidentally verify.
+        On success sets `verified_at` and returns the masked email. Idempotent:
+        a token for an already-verified row returns 200 with
+        `alreadyVerified: true`. If the underlying row was deleted (or re-added
+        with a new id) since the token was issued, returns 404. No JWT — the
+        token IS the credential.
+      operationId: confirmAdditionalEmailVerification
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmAdditionalEmailVerificationRequest'
+      responses:
+        '200':
+          description: Email verified (or already verified).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdditionalEmailVerificationConfirmResponse'
+        '400':
+          description: |
+            Token is invalid (`TOKEN_INVALID`) or expired (`TOKEN_EXPIRED`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: |
+            The additional-email row referenced by the token no longer exists
+            (deleted or re-added with a new id since issuance).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /users/{username}/roles:
     get:
       tags:
@@ -2089,6 +2217,59 @@ components:
           nullable: true
           maxLength: 100
           example: Hostpoint shared
+
+    AdditionalEmailVerificationCheckResponse:
+      type: object
+      description: |
+        Additional-email verification v2 — GET-check response. Returns the masked
+        email and current verification status without mutating state.
+      required:
+        - email
+        - verified
+      properties:
+        email:
+          type: string
+          description: |
+            Masked form of the additional email (e.g. `in***@example.com`). The
+            full address is never returned on the public verify path.
+          example: in***@berner-architekten-treffen.ch
+        verified:
+          type: boolean
+          description: True if the row's verified_at is already set.
+          example: false
+
+    ConfirmAdditionalEmailVerificationRequest:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          description: The signed verification token from the email link.
+
+    AdditionalEmailVerificationConfirmResponse:
+      type: object
+      description: |
+        Additional-email verification v2 — POST-confirm response.
+      required:
+        - email
+        - verified
+        - alreadyVerified
+      properties:
+        email:
+          type: string
+          description: Masked form of the additional email.
+          example: in***@berner-architekten-treffen.ch
+        verified:
+          type: boolean
+          description: Always true after a successful confirm.
+          example: true
+        alreadyVerified:
+          type: boolean
+          description: |
+            True when the row was already verified before this call (idempotent
+            re-confirm); false when this call set verified_at.
+          example: false
 
     UserPreferences:
       type: object

--- a/docs/architecture/ADR-010-federated-identity-via-cognito.md
+++ b/docs/architecture/ADR-010-federated-identity-via-cognito.md
@@ -56,6 +56,19 @@ company, and history all remain intact. The user can subsequently sign in with *
 **or** Google. Without this, Cognito's email sign-in alias would raise `AliasExistsException` or
 orphan the user's roles under a new `sub`.
 
+**Amendment (2026-06-06) — link via verified additional email.** The email match above
+extends to **verified additional emails** (`user_additional_emails.verified_at IS NOT NULL`,
+Story A). When the primary `user_profiles.email` lookup finds nothing, `PreSignUp_ExternalProvider`
+falls back to a verified additional-email lookup; on a hit whose owner has a `cognito_user_id`, the
+**same `AdminLinkProviderForUser`** merge runs (metric `FederatedUserLinkedViaAdditionalEmail`).
+The fallback is **double-gated**: the DB row must be verified **and** the IdP must assert
+`email_verified='true'` (Cognito sends this as a string). An owner with no `cognito_user_id` is
+not linked (no destination) and falls through. As before, the federated path **never throws**.
+A defensive twin in `JITUserProvisioningInterceptor` guards against a missed link: before
+JIT-creating a user it checks `findVerifiedByEmailIgnoreCase`, and on a hit **skips creation**
+(WARN, masked email) rather than producing a duplicate — without resolving the request to the
+owner or touching the owner's `cognito_user_id` (the real link belongs to PreSignUp).
+
 ### D4 — Brand-new Google users auto-provision as ATTENDEE
 A Google identity with no matching account is created with the default **ATTENDEE** role
 (consistent with existing self-registration). Organizers promote via the existing role workflows.

--- a/infrastructure/lib/constructs/cognito-user-sync-triggers.ts
+++ b/infrastructure/lib/constructs/cognito-user-sync-triggers.ts
@@ -215,6 +215,20 @@ export class CognitoUserSyncTriggers extends Construct {
       })
     );
 
+    // PR #745: the PostAuthentication trigger restores the canonical primary email
+    // after a federated sign-in of a linked user — Cognito re-syncs mapped IdP
+    // attributes (incl. email) into the destination user on every sign-in, which
+    // for additional-email-linked accounts overwrites the native email and breaks
+    // the email sign-in alias. Same wildcard-resource rationale as the grant above
+    // (scoping to the pool ARN would be a circular dependency).
+    this.postAuthenticationTrigger.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['cognito-idp:AdminUpdateUserAttributes'],
+        resources: [`arn:aws:cognito-idp:${region}:${account}:userpool/*`],
+      })
+    );
+
     // Note: Database security group ingress rule is configured in VpcConstruct
     // to avoid cyclic dependency (Network -> CompanyManagement -> Network)
 

--- a/infrastructure/lib/lambda/triggers/post-authentication.ts
+++ b/infrastructure/lib/lambda/triggers/post-authentication.ts
@@ -20,9 +20,18 @@
 import { PostAuthenticationTriggerEvent, PostAuthenticationTriggerHandler } from 'aws-lambda';
 import { getDbClient, executeTransaction } from './common/database';
 import { CloudWatchClient, PutMetricDataCommand } from '@aws-sdk/client-cloudwatch';
+import {
+  CognitoIdentityProviderClient,
+  AdminUpdateUserAttributesCommand,
+} from '@aws-sdk/client-cognito-identity-provider';
 
 // CloudWatch client for metrics
 const cloudWatchClient = new CloudWatchClient({ region: process.env.AWS_REGION || 'eu-central-1' });
+
+// Cognito client for the canonical-email restore (see restoreCanonicalEmailIfDrifted)
+const cognitoClient = new CognitoIdentityProviderClient({
+  region: process.env.AWS_REGION || 'eu-central-1',
+});
 
 /**
  * User attributes from Cognito event
@@ -128,6 +137,81 @@ async function linkAnonymousUserProfile(
 }
 
 /**
+ * Restore the canonical primary email onto the Cognito user when a federated
+ * sign-in has drifted it.
+ *
+ * Cognito re-syncs mapped IdP attributes (including `email`) into the LINKED
+ * destination user on EVERY federated sign-in. For accounts linked via a
+ * verified ADDITIONAL email (PR #745), that overwrites the native user's
+ * primary email with the Gmail address — breaking the email sign-in alias and
+ * redirecting password-reset mails (observed live 2026-06-06 on the first
+ * production link). Cognito has no per-attribute sync opt-out, so this trigger
+ * restores `user_profiles.email` (the canonical source of truth — primary-email
+ * change is not a platform feature) right after each authentication.
+ *
+ * No-ops when: no DB row for the sub (new federated user pre-JIT), or the
+ * emails already match case-insensitively (native sign-ins, primary-email
+ * links). Never throws — a failure here must not block the login.
+ */
+async function restoreCanonicalEmailIfDrifted(
+  userPoolId: string,
+  sub: string,
+  eventEmail: string
+): Promise<boolean> {
+  const client = await getDbClient();
+  try {
+    const result = await client.query(
+      `SELECT email FROM user_profiles WHERE cognito_user_id = $1 LIMIT 1`,
+      [sub]
+    );
+    if (result.rows.length === 0) {
+      return false;
+    }
+    const canonicalEmail: string = result.rows[0].email;
+    if (!canonicalEmail || canonicalEmail.toLowerCase() === eventEmail.toLowerCase()) {
+      return false;
+    }
+
+    await cognitoClient.send(
+      new AdminUpdateUserAttributesCommand({
+        UserPoolId: userPoolId,
+        Username: sub,
+        UserAttributes: [
+          { Name: 'email', Value: canonicalEmail },
+          { Name: 'email_verified', Value: 'true' },
+        ],
+      })
+    );
+
+    console.info('Restored canonical email after federated attribute sync drift', {
+      sub,
+      driftedEmail: eventEmail,
+      restoredEmail: canonicalEmail,
+    });
+    await publishMetric('FederatedEmailRestored');
+    return true;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Publish a simple count metric (never throws)
+ */
+async function publishMetric(metricName: string): Promise<void> {
+  try {
+    await cloudWatchClient.send(
+      new PutMetricDataCommand({
+        Namespace: 'BATbern/UserManagement',
+        MetricData: [{ MetricName: metricName, Value: 1, Unit: 'Count', Timestamp: new Date() }],
+      })
+    );
+  } catch (error) {
+    console.error('Failed to publish CloudWatch metric', { metricName, error });
+  }
+}
+
+/**
  * Publish CloudWatch metric for account linking
  */
 async function publishAccountLinkingMetric(durationMs: number): Promise<void> {
@@ -178,6 +262,21 @@ export const handler: PostAuthenticationTriggerHandler = async (event) => {
       email: userAttributes.email,
       emailVerified: userAttributes.email_verified,
     });
+
+    // Restore the canonical primary email if a federated sign-in drifted it
+    // (runs first: linkAnonymousUserProfile matches by the event email, which is
+    // exactly the value that may have drifted — but anonymous rows have no
+    // cognito_user_id, so the two concerns never overlap on the same row).
+    const restored = await restoreCanonicalEmailIfDrifted(
+      event.userPoolId,
+      userAttributes.sub,
+      userAttributes.email
+    );
+    if (restored) {
+      console.info('Canonical email restored for linked federated user', {
+        sub: userAttributes.sub,
+      });
+    }
 
     // Attempt to link anonymous user profile
     const linkResult = await linkAnonymousUserProfile(userAttributes.sub, userAttributes.email);

--- a/infrastructure/lib/lambda/triggers/pre-signup.ts
+++ b/infrastructure/lib/lambda/triggers/pre-signup.ts
@@ -197,8 +197,13 @@ async function handleFederated(event: PreSignUpTriggerEvent): Promise<PreSignUpT
     } else {
       // No row at all → brand-new federated user. Do NOT link; canonical JIT
       // (Story 12.3) creates the user_profiles row lazily on the first API call.
+      // Log the raw email_verified attribute: when it is anything but 'true', the
+      // verified-additional-email fallback above was gate-blocked. Found live
+      // 2026-06-06 — the IdP attributeMapping lacked email_verified, Cognito
+      // defaulted it to "false", and the only symptom was this branch firing.
       console.log('New federated user (no native account to link); JIT will provision', {
         email,
+        emailVerified: event.request.userAttributes.email_verified,
       });
       publishMetric('FederatedNewUser', 1).catch((err) =>
         console.error('Metric publish failed', err)

--- a/infrastructure/lib/lambda/triggers/pre-signup.ts
+++ b/infrastructure/lib/lambda/triggers/pre-signup.ts
@@ -126,39 +126,56 @@ async function handleFederated(event: PreSignUpTriggerEvent): Promise<PreSignUpT
 
     const existing = result.rows[0];
     if (existing && existing.cognito_user_id) {
-      // Parse "Google_<sub>" → provider name + the Google subject. Split on the FIRST
-      // underscore (Google subjects are numeric, but be robust to any provider prefix).
-      const sep = event.userName.indexOf('_');
-      const providerName = sep > 0 ? event.userName.substring(0, sep) : 'Google';
-      const providerUserId = sep > 0 ? event.userName.substring(sep + 1) : event.userName;
-
-      await cognitoClient.send(
-        new AdminLinkProviderForUserCommand({
-          UserPoolId: event.userPoolId,
-          // Destination = the existing native Cognito user (its username IS the sub for
-          // an email-alias pool), so the sub is preserved on link.
-          DestinationUser: {
-            ProviderName: 'Cognito',
-            ProviderAttributeValue: existing.cognito_user_id,
-          },
-          // Source = the incoming external (Google) identity.
-          SourceUser: {
-            ProviderName: providerName,
-            ProviderAttributeName: 'Cognito_Subject',
-            ProviderAttributeValue: providerUserId,
-          },
-        })
+      await linkFederatedIdentity(
+        event,
+        existing.cognito_user_id,
+        existing.username,
+        'FederatedUserLinked'
+      );
+    } else if (!existing && isIdpEmailVerified(event)) {
+      // Primary user_profiles.email match found nothing. Epic 12 follow-up: fall back to a
+      // VERIFIED additional email (Story A's verified_at), gated on BOTH the DB row being
+      // verified AND the IdP asserting email_verified='true' — so a Google sign-in for a
+      // user's verified private Gmail links into the existing account instead of JIT-creating
+      // a duplicate ATTENDEE. This runs ONLY on the zero-primary-rows path, BEFORE the
+      // brand-new-user outcome. Reuses the same client/try/finally (an error here hits the
+      // existing catch → never throws → never 503s the sign-in).
+      const fallback = await client.query(
+        `SELECT u.cognito_user_id, u.username
+         FROM user_additional_emails ae
+         JOIN user_profiles u ON u.id = ae.user_id
+         WHERE LOWER(ae.email) = LOWER($1) AND ae.verified_at IS NOT NULL`,
+        [email]
       );
 
-      console.log('Linked federated identity to existing native user', {
-        email,
-        destinationSub: existing.cognito_user_id,
-        username: existing.username,
-        providerName,
-      });
-      publishMetric('FederatedUserLinked', 1).catch((err) =>
-        console.error('Metric publish failed', err)
-      );
+      const owner = fallback.rows[0];
+      if (owner && owner.cognito_user_id) {
+        await linkFederatedIdentity(
+          event,
+          owner.cognito_user_id,
+          owner.username,
+          'FederatedUserLinkedViaAdditionalEmail'
+        );
+      } else if (owner) {
+        // Owner found via verified additional email but has NO cognito_user_id yet (no
+        // Cognito DESTINATION to link to). Do NOT link; fall through to the brand-new-user
+        // outcome — canonical JIT will reconcile once the owner has a sub.
+        console.log(
+          'Verified additional email matches an owner without a Cognito sub; cannot link, deferring',
+          { email, username: owner.username }
+        );
+        publishMetric('FederatedAnonymousPendingJit', 1).catch((err) =>
+          console.error('Metric publish failed', err)
+        );
+      } else {
+        // No verified additional-email owner either → genuinely a brand-new federated user.
+        console.log('New federated user (no native or additional-email account to link); JIT will provision', {
+          email,
+        });
+        publishMetric('FederatedNewUser', 1).catch((err) =>
+          console.error('Metric publish failed', err)
+        );
+      }
     } else if (existing) {
       // A user_profiles row exists for this email but has NO cognito_user_id — i.e. an
       // anonymous event registrant (ADR-005, V11__Make_cognito_id_nullable_for_anonymous_users).
@@ -202,6 +219,62 @@ async function handleFederated(event: PreSignUpTriggerEvent): Promise<PreSignUpT
   }
 
   return event;
+}
+
+/**
+ * Whether the IdP asserted a verified email. Cognito delivers external-provider
+ * attributes as STRINGS, so {@code email_verified} arrives as 'true'/'false' (not a
+ * boolean). Compare case-insensitively against 'true'; absent/any-other value → false.
+ */
+function isIdpEmailVerified(event: PreSignUpTriggerEvent): boolean {
+  const raw = event.request.userAttributes.email_verified;
+  return typeof raw === 'string' && raw.toLowerCase() === 'true';
+}
+
+/**
+ * Merge the incoming external (Google) identity into an existing native Cognito user via
+ * AdminLinkProviderForUser (DESTINATION sub preserved → user_profiles.cognito_user_id stays
+ * stable). Shared by the primary-email match and the verified-additional-email fallback; the
+ * caller passes the distinguishing CloudWatch metric name.
+ */
+async function linkFederatedIdentity(
+  event: PreSignUpTriggerEvent,
+  destinationSub: string,
+  username: string,
+  metricName: string
+): Promise<void> {
+  // Parse "Google_<sub>" → provider name + the Google subject. Split on the FIRST
+  // underscore (Google subjects are numeric, but be robust to any provider prefix).
+  const sep = event.userName.indexOf('_');
+  const providerName = sep > 0 ? event.userName.substring(0, sep) : 'Google';
+  const providerUserId = sep > 0 ? event.userName.substring(sep + 1) : event.userName;
+
+  await cognitoClient.send(
+    new AdminLinkProviderForUserCommand({
+      UserPoolId: event.userPoolId,
+      // Destination = the existing native Cognito user (its username IS the sub for
+      // an email-alias pool), so the sub is preserved on link.
+      DestinationUser: {
+        ProviderName: 'Cognito',
+        ProviderAttributeValue: destinationSub,
+      },
+      // Source = the incoming external (Google) identity.
+      SourceUser: {
+        ProviderName: providerName,
+        ProviderAttributeName: 'Cognito_Subject',
+        ProviderAttributeValue: providerUserId,
+      },
+    })
+  );
+
+  console.log('Linked federated identity to existing native user', {
+    email: event.request.userAttributes.email,
+    destinationSub,
+    username,
+    providerName,
+    metric: metricName,
+  });
+  publishMetric(metricName, 1).catch((err) => console.error('Metric publish failed', err));
 }
 
 /**

--- a/infrastructure/lib/stacks/cognito-stack.ts
+++ b/infrastructure/lib/stacks/cognito-stack.ts
@@ -232,6 +232,13 @@ export class CognitoStack extends cdk.Stack {
         // email is REQUIRED: it keys the Phase-2 account-linking (AdminLinkProviderForUser)
         // and resolves the email sign-in alias.
         email: cognito.ProviderAttribute.GOOGLE_EMAIL,
+        // email_verified MUST be mapped explicitly — without this mapping Cognito defaults
+        // the federated user's email_verified to "false" even though Google asserts true,
+        // which blocks the PreSignUp verified-additional-email linking gate (found live
+        // 2026-06-06: orphan Google_* shell user + JIT duplicate-guard wedge → blank
+        // dashboard). Applied to the live pool via update-identity-provider the same day;
+        // this line makes CDK converge with that state.
+        emailVerified: cognito.ProviderAttribute.GOOGLE_EMAIL_VERIFIED,
         // Names fold to standard attributes (see standardAttributes above). The canonical
         // JIT path (Story 12.3) reads these for federated users — the federated counterpart
         // of how post-confirmation.ts reads firstName/lastName from custom:preferences for

--- a/infrastructure/lib/stacks/company-management-stack.ts
+++ b/infrastructure/lib/stacks/company-management-stack.ts
@@ -75,12 +75,24 @@ export class CompanyManagementStack extends cdk.Stack {
       ...(props.eventBus && {
         EVENT_BUS_NAME: props.eventBus.eventBusName,
       }),
+      // Additional-email verification (v2): public base URL used to build the
+      // {{baseUrl}}/verify-email?token= link in verification emails. Must match
+      // the frontend domain so the link resolves to the SPA verify page.
+      ...(props.config.domain && {
+        APP_BASE_URL: `https://${props.config.domain.frontendDomain}`,
+      }),
     };
 
     // Secrets from Secrets Manager
     const additionalSecrets: Record<string, ecs.Secret> = {};
     if (props.watchJwtSecret) {
       additionalSecrets.WATCH_JWT_SECRET = ecs.Secret.fromSecretsManager(props.watchJwtSecret);
+      // JWT_SECRET provides a stable HMAC key for AdditionalEmailVerificationTokenService
+      // (additional-email verification links). Without it the service generates a random
+      // key on each start, invalidating all in-flight verification tokens whenever ECS
+      // replaces a Fargate Spot task or a new deployment lands. Reuses the WATCH_JWT_SECRET
+      // secret (same pattern as event-management-stack).
+      additionalSecrets.JWT_SECRET = ecs.Secret.fromSecretsManager(props.watchJwtSecret);
     }
 
     // Create domain service using reusable helper function
@@ -157,6 +169,24 @@ export class CompanyManagementStack extends cdk.Stack {
         resources: [props.eventBus.eventBusArn],
       }));
     }
+
+    // Additional-email verification (v2): grant SES send permissions so the
+    // shared-kernel EmailService can dispatch verification emails to additional
+    // addresses. Mirrors the partner-coordination-stack SES grant (same
+    // isProdTraffic domain selection + scoped identity ARNs).
+    const isProdTraffic = props.config.isProduction ?? (envName === 'production');
+    const sesFromDomain = isProdTraffic ? 'batbern.ch' : 'berner-architekten-treffen.ch';
+    this.service.taskDefinition.taskRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['ses:SendEmail', 'ses:SendRawEmail'],
+        resources: [
+          `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:identity/${sesFromDomain}`,
+          `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:identity/*@${sesFromDomain}`,
+          `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:identity/*`,
+        ],
+      }),
+    );
 
     // Story 11.E.1 / AR30 / cherry-pick d5cf0fcc: Grant Cognito admin perms for speaker provisioning (Story 11.E.2).
     // Scope: this service's task role only. Resource: the BATbern User Pool ARN (no wildcard).

--- a/infrastructure/test/unit/lambda/post-authentication.test.ts
+++ b/infrastructure/test/unit/lambda/post-authentication.test.ts
@@ -23,6 +23,12 @@ jest.mock('@aws-sdk/client-cloudwatch', () => ({
   PutMetricDataCommand: jest.fn().mockImplementation((input) => input),
 }));
 
+const mockCognitoSend = jest.fn<(...args: any[]) => Promise<any>>();
+jest.mock('@aws-sdk/client-cognito-identity-provider', () => ({
+  CognitoIdentityProviderClient: jest.fn().mockImplementation(() => ({ send: mockCognitoSend })),
+  AdminUpdateUserAttributesCommand: jest.fn().mockImplementation((input) => ({ __type: 'AdminUpdateUserAttributes', ...(input as object) })),
+}));
+
 jest.mock('../../../lib/lambda/triggers/common/database', () => ({
   getDbClient: mockGetDbClient,
   executeTransaction: jest.fn(),
@@ -71,6 +77,7 @@ describe('post-authentication Lambda handler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCloudWatchSend.mockResolvedValue({});
+    mockCognitoSend.mockResolvedValue({});
   });
 
   it('module loads without crashing (CloudWatchClient initialized at module level)', () => {
@@ -79,7 +86,9 @@ describe('post-authentication Lambda handler', () => {
 
   it('should_returnEvent_when_noAnonymousUserExists', async () => {
     mockGetDbClient.mockResolvedValue(makeDbClient());
-    // First query: find anonymous user — returns nothing
+    // Restore-check query: no user_profiles row for the sub -> no drift handling
+    mockDbQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    // Find anonymous user — returns nothing
     mockDbQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
     const event = makeEvent();
@@ -89,7 +98,9 @@ describe('post-authentication Lambda handler', () => {
 
   it('should_linkAnonymousUser_when_matchingEmailFound', async () => {
     mockGetDbClient.mockResolvedValue(makeDbClient());
-    // First query: find anonymous user
+    // Restore-check query: no row -> no drift handling
+    mockDbQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    // Find anonymous user
     mockDbQuery.mockResolvedValueOnce({
       rows: [{ id: 'anon-id-1', username: 'anon_user', cognito_user_id: null }],
       rowCount: 1,
@@ -103,8 +114,8 @@ describe('post-authentication Lambda handler', () => {
     const event = makeEvent();
     const result = await handler(event, {} as any, jest.fn() as any);
 
-    expect(mockDbQuery).toHaveBeenCalledTimes(2);
-    const updateCall = mockDbQuery.mock.calls[1] as [string, string[]];
+    expect(mockDbQuery).toHaveBeenCalledTimes(3);
+    const updateCall = mockDbQuery.mock.calls[2] as [string, string[]];
     expect(updateCall[0]).toContain('UPDATE user_profiles');
     expect(updateCall[1]).toContain('cognito-sub-123');
     expect(result).toEqual(event);
@@ -113,6 +124,7 @@ describe('post-authentication Lambda handler', () => {
   it('should_publishCloudWatchMetric_when_userLinkedSuccessfully', async () => {
     mockGetDbClient.mockResolvedValue(makeDbClient());
     mockDbQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // restore-check: no row
       .mockResolvedValueOnce({ rows: [{ id: 'id', username: 'u', cognito_user_id: null }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ username: 'u' }], rowCount: 1 });
 
@@ -134,6 +146,7 @@ describe('post-authentication Lambda handler', () => {
   it('should_returnEventWithoutThrowing_when_updateQueryFails', async () => {
     mockGetDbClient.mockResolvedValue(makeDbClient());
     mockDbQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // restore-check: no row
       .mockResolvedValueOnce({ rows: [{ id: 'id', username: 'u', cognito_user_id: null }], rowCount: 1 })
       .mockRejectedValueOnce(new Error('Deadlock'));
 
@@ -149,5 +162,65 @@ describe('post-authentication Lambda handler', () => {
     const result = await handler(event, {} as any, jest.fn() as any);
     // Still returns event (fail-open)
     expect(result).toEqual(event);
+  });
+
+  // PR #745: canonical-email restore after federated attribute-sync drift
+  describe('canonical email restore (federated sync drift)', () => {
+    it('should_restoreCanonicalEmail_when_eventEmailDriftedFromDbEmail', async () => {
+      mockGetDbClient.mockResolvedValue(makeDbClient());
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [{ email: 'native@example.ch' }], rowCount: 1 }) // restore-check: drifted
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // anonymous lookup: none
+
+      const event = makeEvent({ email: 'gmail-additional@gmail.com' });
+      const result = await handler(event, {} as any, jest.fn() as any);
+
+      expect(mockCognitoSend).toHaveBeenCalledTimes(1);
+      const cmd = mockCognitoSend.mock.calls[0][0] as any;
+      expect(cmd.UserPoolId).toBe('eu-central-1_TEST');
+      expect(cmd.Username).toBe('cognito-sub-123');
+      expect(cmd.UserAttributes).toEqual([
+        { Name: 'email', Value: 'native@example.ch' },
+        { Name: 'email_verified', Value: 'true' },
+      ]);
+      expect(result).toEqual(event);
+    });
+
+    it('should_notTouchCognito_when_emailsMatchCaseInsensitively', async () => {
+      mockGetDbClient.mockResolvedValue(makeDbClient());
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [{ email: 'User@Example.COM' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const event = makeEvent({ email: 'user@example.com' });
+      const result = await handler(event, {} as any, jest.fn() as any);
+
+      expect(mockCognitoSend).not.toHaveBeenCalled();
+      expect(result).toEqual(event);
+    });
+
+    it('should_notTouchCognito_when_noProfileRowForSub', async () => {
+      mockGetDbClient.mockResolvedValue(makeDbClient());
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const event = makeEvent();
+      await handler(event, {} as any, jest.fn() as any);
+
+      expect(mockCognitoSend).not.toHaveBeenCalled();
+    });
+
+    it('should_returnEventWithoutThrowing_when_adminUpdateFails', async () => {
+      mockGetDbClient.mockResolvedValue(makeDbClient());
+      mockDbQuery.mockResolvedValueOnce({ rows: [{ email: 'native@example.ch' }], rowCount: 1 });
+      mockCognitoSend.mockRejectedValue(new Error('AccessDenied'));
+
+      const event = makeEvent({ email: 'drifted@gmail.com' });
+      const result = await handler(event, {} as any, jest.fn() as any);
+
+      // Fail-open: login must proceed
+      expect(result).toEqual(event);
+    });
   });
 });

--- a/infrastructure/test/unit/lambda/pre-signup.test.ts
+++ b/infrastructure/test/unit/lambda/pre-signup.test.ts
@@ -221,6 +221,240 @@ describe('pre-signup Lambda handler', () => {
     expect(result.response.autoVerifyEmail).toBe(true);
   });
 
+  // ----------------------------------------------------------------
+  // Verified-additional-email fallback (Epic 12 follow-up)
+  // Runs ONLY on the zero-rows primary-match path, BEFORE the brand-new-user outcome.
+  // ----------------------------------------------------------------
+
+  it('should_linkViaAdditionalEmail_when_primaryMissesAndAdditionalEmailVerifiedAndIdpVerified', async () => {
+    mockGetDbClient.mockResolvedValue(makeDbClient());
+    // 1st query (primary user_profiles match) → empty; 2nd query (additional-email fallback) → hit.
+    mockDbQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({
+        rows: [{ cognito_user_id: 'owner-sub-uuid', username: 'jane.owner' }],
+        rowCount: 1,
+      });
+
+    const event = makeEvent(
+      'PreSignUp_ExternalProvider',
+      { email: 'gmail-private@gmail.com', email_verified: 'true' },
+      'Google_700abc'
+    );
+    const result = await handler(event, {} as any, jest.fn() as any);
+
+    const linkCalls = mockCognitoSend.mock.calls.filter(
+      (c: any[]) => c[0]?.__type === 'AdminLinkProviderForUser'
+    );
+    expect(linkCalls).toHaveLength(1);
+    const input = linkCalls[0][0];
+    expect(input.UserPoolId).toBe('eu-central-1_TEST');
+    expect(input.DestinationUser).toEqual({
+      ProviderName: 'Cognito',
+      ProviderAttributeValue: 'owner-sub-uuid',
+    });
+    expect(input.SourceUser).toEqual({
+      ProviderName: 'Google',
+      ProviderAttributeName: 'Cognito_Subject',
+      ProviderAttributeValue: '700abc',
+    });
+
+    expect(result.response.autoConfirmUser).toBe(true);
+    expect(result.response.autoVerifyEmail).toBe(true);
+    expect(mockDbRelease).toHaveBeenCalled();
+
+    // The fallback query joins user_additional_emails and gates on verified_at + LOWER(email).
+    const fallbackSql = mockDbQuery.mock.calls[1][0] as string;
+    expect(fallbackSql).toMatch(/user_additional_emails/i);
+    expect(fallbackSql).toMatch(/verified_at\s+is\s+not\s+null/i);
+    expect(fallbackSql).toMatch(/lower\(\s*ae\.email\s*\)\s*=\s*lower\(\s*\$1\s*\)/i);
+
+    // Distinct metric so the additional-email link is observable separately.
+    const metricNames = mockCloudWatchSend.mock.calls.map(
+      (c: any[]) => c[0]?.MetricData?.[0]?.MetricName
+    );
+    expect(metricNames).toContain('FederatedUserLinkedViaAdditionalEmail');
+  });
+
+  it('should_notQueryAdditionalEmail_when_emailVerifiedAttributeIsFalse', async () => {
+    mockGetDbClient.mockResolvedValue(makeDbClient());
+    mockDbQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const event = makeEvent(
+      'PreSignUp_ExternalProvider',
+      { email: 'gmail-private@gmail.com', email_verified: 'false' },
+      'Google_700abc'
+    );
+    const result = await handler(event, {} as any, jest.fn() as any);
+
+    // Only the primary query ran — the IdP-unverified gate blocks the fallback entirely.
+    expect(mockDbQuery).toHaveBeenCalledTimes(1);
+    const linkCalls = mockCognitoSend.mock.calls.filter(
+      (c: any[]) => c[0]?.__type === 'AdminLinkProviderForUser'
+    );
+    expect(linkCalls).toHaveLength(0);
+    // Falls through to the existing brand-new-user outcome.
+    expect(result.response.autoConfirmUser).toBe(true);
+    const metricNames = mockCloudWatchSend.mock.calls.map(
+      (c: any[]) => c[0]?.MetricData?.[0]?.MetricName
+    );
+    expect(metricNames).toContain('FederatedNewUser');
+  });
+
+  it('should_notQueryAdditionalEmail_when_emailVerifiedAttributeAbsent', async () => {
+    mockGetDbClient.mockResolvedValue(makeDbClient());
+    mockDbQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const event = makeEvent(
+      'PreSignUp_ExternalProvider',
+      { email: 'gmail-private@gmail.com' },
+      'Google_700abc'
+    );
+    await handler(event, {} as any, jest.fn() as any);
+
+    expect(mockDbQuery).toHaveBeenCalledTimes(1);
+    const linkCalls = mockCognitoSend.mock.calls.filter(
+      (c: any[]) => c[0]?.__type === 'AdminLinkProviderForUser'
+    );
+    expect(linkCalls).toHaveLength(0);
+  });
+
+  it('should_treatEmailVerifiedCaseInsensitively_when_attributeIsUpperTrue', async () => {
+    mockGetDbClient.mockResolvedValue(makeDbClient());
+    mockDbQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({
+        rows: [{ cognito_user_id: 'owner-sub-uuid', username: 'jane.owner' }],
+        rowCount: 1,
+      });
+
+    const event = makeEvent(
+      'PreSignUp_ExternalProvider',
+      { email: 'gmail-private@gmail.com', email_verified: 'TRUE' },
+      'Google_700abc'
+    );
+    await handler(event, {} as any, jest.fn() as any);
+
+    const linkCalls = mockCognitoSend.mock.calls.filter(
+      (c: any[]) => c[0]?.__type === 'AdminLinkProviderForUser'
+    );
+    expect(linkCalls).toHaveLength(1);
+  });
+
+  it('should_notLinkAndFallThrough_when_additionalEmailOwnerHasNoCognitoId', async () => {
+    mockGetDbClient.mockResolvedValue(makeDbClient());
+    mockDbQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({
+        rows: [{ cognito_user_id: null, username: 'jane.owner' }],
+        rowCount: 1,
+      });
+
+    const event = makeEvent(
+      'PreSignUp_ExternalProvider',
+      { email: 'gmail-private@gmail.com', email_verified: 'true' },
+      'Google_700abc'
+    );
+    const result = await handler(event, {} as any, jest.fn() as any);
+
+    // No destination Cognito user → no link; falls through, still auto-confirmed.
+    const linkCalls = mockCognitoSend.mock.calls.filter(
+      (c: any[]) => c[0]?.__type === 'AdminLinkProviderForUser'
+    );
+    expect(linkCalls).toHaveLength(0);
+    expect(result.response.autoConfirmUser).toBe(true);
+    expect(result.response.autoVerifyEmail).toBe(true);
+    expect(mockDbRelease).toHaveBeenCalled();
+
+    // Owner found via a verified additional email but with no Cognito sub yet → the
+    // deferred-adoption outcome, observable via FederatedAnonymousPendingJit (canonical
+    // JIT reconciles once the owner has a sub).
+    const metricNames = mockCloudWatchSend.mock.calls.map(
+      (c: any[]) => c[0]?.MetricData?.[0]?.MetricName
+    );
+    expect(metricNames).toContain('FederatedAnonymousPendingJit');
+  });
+
+  it('should_treatAsNewUser_when_primaryMissesAndFallbackReturnsZeroRowsBecauseAdditionalEmailUnverified', async () => {
+    mockGetDbClient.mockResolvedValue(makeDbClient());
+    // 1st query (primary user_profiles match) → empty.
+    // 2nd query (additional-email fallback) → ZERO rows: the additional email exists but is
+    // UNVERIFIED (verified_at IS NULL), so the SQL `verified_at IS NOT NULL` gate excludes it.
+    // This documents that an unverified additional email must NOT link a federated identity.
+    mockDbQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const event = makeEvent(
+      'PreSignUp_ExternalProvider',
+      { email: 'gmail-private@gmail.com', email_verified: 'true' },
+      'Google_700abc'
+    );
+    const result = await handler(event, {} as any, jest.fn() as any);
+
+    // Fallback ran (IdP verified + primary missed) but matched nothing → no link.
+    expect(mockDbQuery).toHaveBeenCalledTimes(2);
+    const linkCalls = mockCognitoSend.mock.calls.filter(
+      (c: any[]) => c[0]?.__type === 'AdminLinkProviderForUser'
+    );
+    expect(linkCalls).toHaveLength(0);
+
+    // Genuinely a brand-new federated user → FederatedNewUser outcome, auto-confirmed.
+    expect(result.response.autoConfirmUser).toBe(true);
+    expect(result.response.autoVerifyEmail).toBe(true);
+    expect(mockDbRelease).toHaveBeenCalled();
+    const metricNames = mockCloudWatchSend.mock.calls.map(
+      (c: any[]) => c[0]?.MetricData?.[0]?.MetricName
+    );
+    expect(metricNames).toContain('FederatedNewUser');
+  });
+
+  it('should_notQueryAdditionalEmail_when_primaryMatchAlreadyLinked', async () => {
+    mockGetDbClient.mockResolvedValue(makeDbClient());
+    mockDbQuery.mockResolvedValueOnce({
+      rows: [{ cognito_user_id: 'native-sub-uuid', username: 'john.doe' }],
+      rowCount: 1,
+    });
+
+    const event = makeEvent(
+      'PreSignUp_ExternalProvider',
+      { email: 'john@example.com', email_verified: 'true' },
+      'Google_117xyz'
+    );
+    await handler(event, {} as any, jest.fn() as any);
+
+    // Primary path wins — the fallback is never queried.
+    expect(mockDbQuery).toHaveBeenCalledTimes(1);
+    const metricNames = mockCloudWatchSend.mock.calls.map(
+      (c: any[]) => c[0]?.MetricData?.[0]?.MetricName
+    );
+    expect(metricNames).toContain('FederatedUserLinked');
+    expect(metricNames).not.toContain('FederatedUserLinkedViaAdditionalEmail');
+  });
+
+  it('should_returnEventAndNotThrow_when_additionalEmailFallbackQueryThrows', async () => {
+    mockGetDbClient.mockResolvedValue(makeDbClient());
+    mockDbQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockRejectedValueOnce(new Error('fallback query exploded'));
+
+    const event = makeEvent(
+      'PreSignUp_ExternalProvider',
+      { email: 'gmail-private@gmail.com', email_verified: 'true' },
+      'Google_700abc'
+    );
+    const result = await handler(event, {} as any, jest.fn() as any);
+
+    // Never throws; auto-confirm preserved; failure surfaced as PreSignUpFailure metric.
+    expect(result.response.autoConfirmUser).toBe(true);
+    expect(result.response.autoVerifyEmail).toBe(true);
+    expect(mockDbRelease).toHaveBeenCalled();
+    const metricNames = mockCloudWatchSend.mock.calls.map(
+      (c: any[]) => c[0]?.MetricData?.[0]?.MetricName
+    );
+    expect(metricNames).toContain('PreSignUpFailure');
+  });
+
   // AC5.5 — missing-email guard
   it('should_notLinkAndNotThrow_when_federatedEventHasNoEmail', async () => {
     const event = makeEvent('PreSignUp_ExternalProvider', { email: '' }, 'Google_555');

--- a/services/company-user-management-service/build.gradle
+++ b/services/company-user-management-service/build.gradle
@@ -38,6 +38,11 @@ dependencies {
     implementation 'com.amazonaws:aws-xray-recorder-sdk-aws-sdk-v2:2.15.1'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 
+    // Additional-email verification (v2): JWT for stateless signed verification tokens
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
     // Service-specific: Testing
     testImplementation 'io.rest-assured:rest-assured:5.5.6'
     testImplementation 'org.awaitility:awaitility:4.2.0'

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/config/SecurityConfig.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/config/SecurityConfig.java
@@ -88,6 +88,9 @@ public class SecurityConfig {
                 .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/v1/public/users/*").permitAll()
                 // Story 10.8a: Public presentation settings (moderator page)
                 .requestMatchers(HttpMethod.GET, "/api/v1/public/settings/presentation").permitAll()
+                // Additional-email verification (v2): public token-credentialed verify endpoints
+                .requestMatchers(HttpMethod.GET, "/api/v1/users/additional-emails/verify").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/users/additional-emails/verify").permitAll()
                 // Public user profile endpoint (GET only for service-to-service calls from localhost)
                 .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/v1/users/*").permitAll()
                 // W2.2: Watch pairing endpoints — unauthenticated (code/token IS the credential)
@@ -132,6 +135,13 @@ public class SecurityConfig {
                 .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/v1/public/users/*").permitAll()
                 // Story 10.8a: Public presentation settings (moderator page)
                 .requestMatchers(HttpMethod.GET, "/api/v1/public/settings/presentation").permitAll()
+                // Additional-email verification (v2): public token-credentialed verify endpoints.
+                // MUST precede both the /api/v1/users/me authenticated rule and the
+                // /api/v1/users/* VPC rule (the path has two segments after /users/, so it
+                // would not match the single-segment "*" wildcard anyway — but listed first
+                // to be unambiguous and immune to future matcher reordering).
+                .requestMatchers(HttpMethod.GET, "/api/v1/users/additional-emails/verify").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/users/additional-emails/verify").permitAll()
                 // Current user endpoint always requires authentication (even from VPC)
                 .requestMatchers("/api/v1/users/me").authenticated()
                 // Service-to-service: Allow user profile lookups from VPC internal network
@@ -194,6 +204,9 @@ public class SecurityConfig {
                 .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/v1/public/users/*").permitAll()
                 // Story 10.8a: Public presentation settings (moderator page)
                 .requestMatchers(HttpMethod.GET, "/api/v1/public/settings/presentation").permitAll()
+                // Additional-email verification (v2): public token-credentialed verify endpoints
+                .requestMatchers(HttpMethod.GET, "/api/v1/users/additional-emails/verify").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/users/additional-emails/verify").permitAll()
                 // Current user endpoint always requires authentication (even from VPC)
                 .requestMatchers("/api/v1/users/me").authenticated()
                 // Test environment: Enforce authentication for all user endpoints

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/config/SecurityConfig.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/config/SecurityConfig.java
@@ -76,6 +76,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(authz -> authz
                 .requestMatchers("/actuator/health/**", "/actuator/info").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                // Local-dev email inbox (DevEmailController, @Profile("local") only)
+                .requestMatchers("/dev/emails/**").permitAll()
                 // Story 4.1.5: Anonymous registration - allow get-or-create user endpoint
                 .requestMatchers("/api/v1/users/get-or-create").permitAll()
                 // Story 4.1.5: Public company search for registration autocomplete

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/controller/DevEmailController.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/controller/DevEmailController.java
@@ -1,0 +1,99 @@
+package ch.batbern.companyuser.controller;
+
+import ch.batbern.shared.service.CapturedEmail;
+import ch.batbern.shared.service.LocalEmailCapture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Development-only REST controller for inspecting captured emails from the
+ * company-user-management service (e.g. additional-email verification mails).
+ * Active only on the 'local' Spring profile — never registered in staging/production.
+ *
+ * Endpoints:
+ *   GET    /dev/emails                              — list all captured emails (JSON, newest first)
+ *   GET    /dev/emails/{id}                         — get single email metadata (JSON)
+ *   GET    /dev/emails/{id}/preview                 — render full HTML body in browser
+ *   GET    /dev/emails/{id}/attachments/{filename}  — download raw attachment bytes
+ *   DELETE /dev/emails                              — clear all captured emails
+ *
+ * CUMS direct URL: http://localhost:8001/dev/emails
+ */
+@RestController
+@RequestMapping("/dev/emails")
+@Profile("local")
+@RequiredArgsConstructor
+@CrossOrigin
+public class DevEmailController {
+
+    private final LocalEmailCapture localEmailCapture;
+
+    @GetMapping
+    public List<CapturedEmail> listEmails() {
+        return localEmailCapture.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CapturedEmail> getEmail(@PathVariable UUID id) {
+        return localEmailCapture.getAll().stream()
+            .filter(e -> e.id().equals(id))
+            .findFirst()
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping(value = "/{id}/preview", produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<String> previewEmail(@PathVariable UUID id) {
+        return localEmailCapture.getAll().stream()
+            .filter(e -> e.id().equals(id))
+            .findFirst()
+            .map(e -> ResponseEntity.ok()
+                .contentType(MediaType.TEXT_HTML)
+                .body(e.htmlBody()))
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}/attachments/{filename}")
+    public ResponseEntity<byte[]> downloadAttachment(
+            @PathVariable UUID id,
+            @PathVariable String filename) {
+        return localEmailCapture.getAll().stream()
+            .filter(e -> e.id().equals(id))
+            .findFirst()
+            .flatMap(email -> {
+                String mimeType = email.attachments().stream()
+                    .filter(a -> a.filename().equals(filename))
+                    .findFirst()
+                    .map(CapturedEmail.AttachmentInfo::mimeType)
+                    .orElse(MediaType.APPLICATION_OCTET_STREAM_VALUE);
+                return localEmailCapture.getAttachmentBytes(id, filename)
+                    .map(bytes -> {
+                        HttpHeaders headers = new HttpHeaders();
+                        headers.setContentType(MediaType.parseMediaType(mimeType));
+                        headers.setContentDisposition(
+                            ContentDisposition.attachment().filename(filename).build());
+                        return ResponseEntity.ok().headers(headers).body(bytes);
+                    });
+            })
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> clearInbox() {
+        localEmailCapture.clear();
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/controller/UserController.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/controller/UserController.java
@@ -10,6 +10,9 @@ import ch.batbern.companyuser.dto.ReconciliationReportDTO;
 import ch.batbern.companyuser.dto.SyncStatusDTO;
 import ch.batbern.companyuser.dto.generated.AddAdditionalEmailRequest;
 import ch.batbern.companyuser.dto.generated.AdditionalEmail;
+import ch.batbern.companyuser.dto.generated.AdditionalEmailVerificationCheckResponse;
+import ch.batbern.companyuser.dto.generated.AdditionalEmailVerificationConfirmResponse;
+import ch.batbern.companyuser.dto.generated.ConfirmAdditionalEmailVerificationRequest;
 import ch.batbern.companyuser.dto.generated.CreateUserRequest;
 import ch.batbern.companyuser.dto.generated.GetOrCreateUserRequest;
 import ch.batbern.companyuser.dto.generated.GetOrCreateUserResponse;
@@ -576,6 +579,58 @@ public class UserController {
         log.info("Removing additional email for current user");
         userService.deleteAdditionalEmail(email);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Additional-email verification (v2) — resend the verification email for one of
+     * the caller's own (still unverified) additional emails.
+     *
+     * <p>204 on success; 404 if the email is not the caller's; 409
+     * ({@code ALREADY_VERIFIED}) if it is already verified.
+     *
+     * <p>The {@code {email:.+}} regex is required for the same reason as the
+     * delete endpoint above — Spring would otherwise strip a trailing {@code .com}.
+     */
+    @PostMapping("/me/additional-emails/{email:.+}/resend-verification")
+    @Timed(value = "users.additionalEmails.resendVerification",
+            description = "Time to resend an additional-email verification email",
+            percentiles = {0.5, 0.95, 0.99})
+    public ResponseEntity<Void> resendAdditionalEmailVerification(@PathVariable String email) {
+        log.info("Resending additional-email verification for current user");
+        userService.resendVerification(email);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Additional-email verification (v2) — public GET-check of a verification token.
+     * Validates the token and returns the masked email + status WITHOUT mutating
+     * state (mail-scanner prefetches land here). The token IS the credential — no
+     * JWT. Permitted in both SecurityConfig layers (CUMS + api-gateway).
+     */
+    @GetMapping("/additional-emails/verify")
+    @Timed(value = "users.additionalEmails.verifyCheck",
+            description = "Time to check an additional-email verification token",
+            percentiles = {0.5, 0.95, 0.99})
+    public ResponseEntity<AdditionalEmailVerificationCheckResponse> checkAdditionalEmailVerification(
+            @RequestParam String token) {
+        log.info("Checking additional-email verification token");
+        return ResponseEntity.ok(userService.checkVerificationToken(token));
+    }
+
+    /**
+     * Additional-email verification (v2) — public POST-confirm of a verification
+     * token. POST-only so mail-scanner GET prefetches cannot verify. Sets
+     * {@code verified_at}; idempotent ({@code alreadyVerified}). The token IS the
+     * credential — no JWT.
+     */
+    @PostMapping("/additional-emails/verify")
+    @Timed(value = "users.additionalEmails.verifyConfirm",
+            description = "Time to confirm an additional-email verification token",
+            percentiles = {0.5, 0.95, 0.99})
+    public ResponseEntity<AdditionalEmailVerificationConfirmResponse> confirmAdditionalEmailVerification(
+            @Valid @RequestBody ConfirmAdditionalEmailVerificationRequest request) {
+        log.info("Confirming additional-email verification token");
+        return ResponseEntity.ok(userService.confirmVerificationToken(request.getToken()));
     }
 
     /**

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/domain/UserAdditionalEmail.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/domain/UserAdditionalEmail.java
@@ -35,9 +35,12 @@ import java.util.UUID;
  *       when the registration belongs to a known user.</li>
  * </ul>
  *
- * <p>Ownership verification is intentionally not implemented in v1 — the
- * {@code verifiedAt} column is reserved for a future verification flow
- * (Story 10.32 Resolved Decision #1).
+ * <p>Ownership is verified via the additional-email verification flow (Story A,
+ * 2026-06-06): the user receives a signed 48h verification link and, on confirmation,
+ * {@code verifiedAt} is stamped. SSO account-linking (the PreSignUp Lambda) and the JIT
+ * duplicate guard ({@link ch.batbern.companyuser.interceptor.JITUserProvisioningInterceptor})
+ * both rely on {@code verifiedAt} being non-null — only a VERIFIED additional email links
+ * a federated identity into an existing account / blocks a duplicate-ATTENDEE JIT create.
  */
 @Entity
 @Table(
@@ -82,7 +85,10 @@ public class UserAdditionalEmail {
     private Instant createdAt;
 
     /**
-     * Reserved for the v2 verification flow. v1 always writes {@code null}.
+     * Timestamp the owner confirmed control of this address via the additional-email
+     * verification flow (Story A, 2026-06-06 — signed 48h verification link). Null until
+     * confirmed. SSO account-linking (PreSignUp Lambda) and the JIT duplicate guard gate on
+     * this being non-null before they treat the address as belonging to the owning user.
      */
     @Column(name = "verified_at")
     private Instant verifiedAt;

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/exception/AdditionalEmailAlreadyVerifiedException.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/exception/AdditionalEmailAlreadyVerifiedException.java
@@ -1,0 +1,11 @@
+package ch.batbern.companyuser.exception;
+
+/**
+ * Additional-email verification (v2) — resend was requested for an email that is
+ * already verified. Maps to HTTP 409 with error code {@code ALREADY_VERIFIED}.
+ */
+public class AdditionalEmailAlreadyVerifiedException extends RuntimeException {
+    public AdditionalEmailAlreadyVerifiedException(String email) {
+        super("Additional email is already verified: " + email);
+    }
+}

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/exception/GlobalExceptionHandler.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/exception/GlobalExceptionHandler.java
@@ -118,6 +118,72 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Additional-email verification (v2) — malformed / bad-signature / wrong-type
+     * token. Maps to 400 with errorCode {@code TOKEN_INVALID}. Never a 500.
+     */
+    @ExceptionHandler(VerificationTokenInvalidException.class)
+    public ResponseEntity<ErrorResponse> handleVerificationTokenInvalidException(
+            VerificationTokenInvalidException ex,
+            HttpServletRequest request) {
+        log.warn("Verification token invalid: {}", ex.getMessage());
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(Instant.now())
+                .path(request.getRequestURI())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .error("Bad Request")
+                .errorCode("TOKEN_INVALID")
+                .message(ex.getMessage())
+                .correlationId(CorrelationIdGenerator.generate())
+                .severity("LOW")
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    /**
+     * Additional-email verification (v2) — expired token. Maps to 400 with
+     * errorCode {@code TOKEN_EXPIRED}. Never a 500.
+     */
+    @ExceptionHandler(VerificationTokenExpiredException.class)
+    public ResponseEntity<ErrorResponse> handleVerificationTokenExpiredException(
+            VerificationTokenExpiredException ex,
+            HttpServletRequest request) {
+        log.warn("Verification token expired: {}", ex.getMessage());
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(Instant.now())
+                .path(request.getRequestURI())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .error("Bad Request")
+                .errorCode("TOKEN_EXPIRED")
+                .message(ex.getMessage())
+                .correlationId(CorrelationIdGenerator.generate())
+                .severity("LOW")
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    /**
+     * Additional-email verification (v2) — resend requested for an
+     * already-verified email. Maps to 409 with errorCode {@code ALREADY_VERIFIED}.
+     */
+    @ExceptionHandler(AdditionalEmailAlreadyVerifiedException.class)
+    public ResponseEntity<ErrorResponse> handleAdditionalEmailAlreadyVerifiedException(
+            AdditionalEmailAlreadyVerifiedException ex,
+            HttpServletRequest request) {
+        log.warn("Additional email already verified: {}", ex.getMessage());
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(Instant.now())
+                .path(request.getRequestURI())
+                .status(HttpStatus.CONFLICT.value())
+                .error("Conflict")
+                .errorCode("ALREADY_VERIFIED")
+                .message(ex.getMessage())
+                .correlationId(CorrelationIdGenerator.generate())
+                .severity("LOW")
+                .build();
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+    }
+
+    /**
      * Story 10.32 (P1-1 from 2026-05-22 review) — translate Spring's
      * {@link DataIntegrityViolationException} into the same 409 envelope as
      * {@link AdditionalEmailDuplicateException} when the underlying SQLState

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/exception/VerificationTokenExpiredException.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/exception/VerificationTokenExpiredException.java
@@ -1,0 +1,12 @@
+package ch.batbern.companyuser.exception;
+
+/**
+ * Additional-email verification (v2) — the verification token has expired
+ * (issued more than the configured TTL ago, default 48h). Maps to HTTP 400 with
+ * error code {@code TOKEN_EXPIRED}. Never a 500.
+ */
+public class VerificationTokenExpiredException extends RuntimeException {
+    public VerificationTokenExpiredException() {
+        super("Verification token has expired");
+    }
+}

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/exception/VerificationTokenInvalidException.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/exception/VerificationTokenInvalidException.java
@@ -1,0 +1,12 @@
+package ch.batbern.companyuser.exception;
+
+/**
+ * Additional-email verification (v2) — the verification token is malformed,
+ * has a bad signature, or carries the wrong type. Maps to HTTP 400 with error
+ * code {@code TOKEN_INVALID}. Never a 500.
+ */
+public class VerificationTokenInvalidException extends RuntimeException {
+    public VerificationTokenInvalidException() {
+        super("Verification token is invalid");
+    }
+}

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/interceptor/JITUserProvisioningInterceptor.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/interceptor/JITUserProvisioningInterceptor.java
@@ -3,8 +3,10 @@ package ch.batbern.companyuser.interceptor;
 import ch.batbern.companyuser.domain.Role;
 import ch.batbern.companyuser.domain.User;
 import ch.batbern.companyuser.domain.UserPreferences;
+import ch.batbern.companyuser.repository.UserAdditionalEmailRepository;
 import ch.batbern.companyuser.repository.UserRepository;
 import ch.batbern.companyuser.event.UserCreatedEvent;
+import ch.batbern.shared.utils.LoggingUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -62,6 +64,7 @@ public class JITUserProvisioningInterceptor implements HandlerInterceptor {
             JITUserProvisioningInterceptor.class.getName() + ".resolvedUser";
 
     private final UserRepository userRepository;
+    private final UserAdditionalEmailRepository userAdditionalEmailRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     /** For parsing the `custom:preferences` JSON blob set by the signup form. */
@@ -141,7 +144,7 @@ public class JITUserProvisioningInterceptor implements HandlerInterceptor {
             // before the user self-registered in Cognito). If so, link the Cognito ID to that record
             // instead of creating a duplicate.
             if (email != null && !email.isEmpty()) {
-                Optional<User> existingByEmail = userRepository.findByEmail(email);
+                Optional<User> existingByEmail = userRepository.findByEmailIgnoreCase(email);
                 if (existingByEmail.isPresent()) {
                     User existing = existingByEmail.get();
                     existing.setCognitoUserId(cognitoUserId);
@@ -151,6 +154,24 @@ public class JITUserProvisioningInterceptor implements HandlerInterceptor {
                             mapOf("cognitoUserId", cognitoUserId, "username", existing.getUsername(), "email", email));
                     return true;
                 }
+            }
+
+            // Epic 12 follow-up — duplicate guard. Before JIT-creating a brand-new user, check
+            // whether this email is a VERIFIED additional email (Story A {@code verified_at}) of
+            // an existing user. If so, the PreSignUp Lambda should have linked this federated
+            // identity into that owner; reaching here means linking did not happen. Creating a
+            // user now would produce a duplicate ATTENDEE for an email that already belongs to a
+            // real account, so we skip creation entirely. We deliberately do NOT resolve the
+            // request to the owner (that would grant the unlinked session the owner's identity at
+            // service level only — Cognito still split — a half-linked state worse than a
+            // degraded session; the real link belongs to PreSignUp) and we NEVER touch the
+            // owner's cognito_user_id.
+            if (email != null && !email.isEmpty()
+                    && userAdditionalEmailRepository.findVerifiedByEmailIgnoreCase(email).isPresent()) {
+                log.warn("Skipping JIT creation: email is a verified additional email of an existing "
+                                + "user; PreSignUp account-linking should have linked this identity",
+                        mapOf("cognitoUserId", cognitoUserId, "email", LoggingUtils.maskEmail(email)));
+                return true;
             }
 
             // No record at all — perform JIT provisioning (create new user)

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/repository/UserAdditionalEmailRepository.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/repository/UserAdditionalEmailRepository.java
@@ -3,6 +3,8 @@ package ch.batbern.companyuser.repository;
 import ch.batbern.companyuser.domain.User;
 import ch.batbern.companyuser.domain.UserAdditionalEmail;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -31,4 +33,17 @@ public interface UserAdditionalEmailRepository extends JpaRepository<UserAdditio
      * Count additional emails for a given user — used by the cap check.
      */
     long countByUser(User user);
+
+    /**
+     * Look up a VERIFIED additional email (Story A {@code verified_at}) case-insensitively,
+     * eagerly fetching the owning user. Used by the JIT duplicate guard
+     * ({@code JITUserProvisioningInterceptor}): a federated sign-in whose email is a user's
+     * verified additional email should have been linked by the PreSignUp Lambda — if it
+     * reaches JIT unresolved, we must NOT create a duplicate user. The {@code JOIN FETCH}
+     * avoids a LazyInitializationException when the caller reads {@code getUser()} outside
+     * the persistence context.
+     */
+    @Query("SELECT ae FROM UserAdditionalEmail ae JOIN FETCH ae.user "
+            + "WHERE LOWER(ae.email) = LOWER(:email) AND ae.verifiedAt IS NOT NULL")
+    Optional<UserAdditionalEmail> findVerifiedByEmailIgnoreCase(@Param("email") String email);
 }

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/AdditionalEmailVerificationEmailService.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/AdditionalEmailVerificationEmailService.java
@@ -1,0 +1,88 @@
+package ch.batbern.companyuser.service;
+
+import ch.batbern.shared.service.EmailService;
+import ch.batbern.shared.utils.LoggingUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Additional-email verification (v2): renders and sends the signed
+ * verification link to a newly-added (or resent) additional email address.
+ *
+ * <p>Templates live on the classpath at
+ * {@code email-templates/additional-email-verification-{locale}.html}. Per the
+ * project's email-template localization rule, only {@code de} + {@code en}
+ * templates exist; any other requested locale falls back to {@code en}.
+ *
+ * <p>The verification link is {@code {{baseUrl}}/verify-email?token={{token}}}.
+ * Rendering uses {@link EmailService#replaceVariables} ({@code {{var}}} syntax).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdditionalEmailVerificationEmailService {
+
+    private final EmailService emailService;
+
+    @Value("${app.base-url:https://www.batbern.ch}")
+    private String baseUrl;
+
+    /**
+     * Render and send the verification email. This method itself does NOT swallow
+     * exceptions on the send path — callers that must tolerate send failures (the
+     * add flow) wrap the call in their own try/catch. The resend endpoint lets
+     * exceptions propagate so the caller can react.
+     *
+     * @param email   recipient additional-email address
+     * @param token   signed verification token
+     * @param locale  user language preference (de/en); anything else falls back to en
+     */
+    public void sendVerificationEmail(String email, String token, String locale) {
+        String resolvedLocale = resolveLocale(locale);
+        String html = loadHtml(resolvedLocale);
+        if (html.isBlank()) {
+            log.warn("additional-email-verification template not found — skipping email to: {}",
+                    LoggingUtils.maskEmail(email));
+            return;
+        }
+        Map<String, String> vars = new java.util.HashMap<>();
+        vars.put("baseUrl", baseUrl != null ? baseUrl : "https://www.batbern.ch");
+        vars.put("token", token != null ? token : "");
+        html = emailService.replaceVariables(html, vars);
+        String subject = "de".equals(resolvedLocale)
+                ? "Bestätigen Sie Ihre BATbern E-Mail-Adresse"
+                : "Confirm your BATbern email address";
+        emailService.sendHtmlEmail(email, subject, html);
+        log.info("ADDITIONAL_EMAIL_VERIFICATION_SENT email={} locale={}",
+                LoggingUtils.maskEmail(email), resolvedLocale);
+    }
+
+    /**
+     * Email templates exist only in de + en. Any German variant (de, de-DE,
+     * de-CH, …) resolves to de; any other locale (including null and gsw-BE)
+     * resolves to en.
+     */
+    private String resolveLocale(String requestedLocale) {
+        return requestedLocale != null
+                && requestedLocale.toLowerCase(java.util.Locale.ROOT).startsWith("de")
+                ? "de" : "en";
+    }
+
+    private String loadHtml(String locale) {
+        String classpathPath = "email-templates/additional-email-verification-" + locale + ".html";
+        try {
+            ClassPathResource resource = new ClassPathResource(classpathPath);
+            return resource.getContentAsString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.warn("Email template classpath resource not found: {}", classpathPath);
+            return "";
+        }
+    }
+}

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/AdditionalEmailVerificationTokenService.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/AdditionalEmailVerificationTokenService.java
@@ -1,0 +1,143 @@
+package ch.batbern.companyuser.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * Additional-email verification (v2): generates and validates signed verification
+ * tokens for the additional-email ownership-proof flow.
+ *
+ * <p>Tokens are stateless HMAC-SHA256 JWTs — no database row stores them. The
+ * {@code additionalEmailId} claim binds each token to the exact
+ * {@code user_additional_emails} row UUID it was issued for, so deleting (or
+ * deleting-then-re-adding, which mints a fresh UUID) the row hard-invalidates the
+ * token without any server-side bookkeeping. The {@code email} claim is a defence
+ * in depth so a confirm only succeeds if the row still carries the same address.
+ *
+ * <p>Validity is configurable via
+ * {@code batbern.user.additional-emails.verification.token-validity-hours}
+ * (default 48h). Mirrors the JJWT pattern in event-management-service's
+ * {@code ConfirmationTokenService}.
+ */
+@Service
+@Slf4j
+public class AdditionalEmailVerificationTokenService {
+
+    /** Default token validity: 48 hours. */
+    public static final long DEFAULT_VALIDITY_HOURS = 48;
+
+    private static final String TOKEN_TYPE = "additional-email-verification";
+
+    private final SecretKey signingKey;
+    private final long validityMs;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public AdditionalEmailVerificationTokenService(
+            @Value("${jwt.secret}") String secret,
+            @Value("${batbern.user.additional-emails.verification.token-validity-hours:48}")
+                    long validityHours) {
+        this.validityMs = validityHours * 60L * 60L * 1000L;
+        // Use provided secret or generate a secure random key for dev/test.
+        if (secret == null || secret.isEmpty() || "changeme".equals(secret)) {
+            this.signingKey = Jwts.SIG.HS256.key().build();
+            log.warn("Using randomly generated JWT secret for additional-email verification. "
+                    + "Configure jwt.secret in production!");
+        } else {
+            this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    /**
+     * Convenience constructor using the default 48h validity. Intended for unit tests.
+     */
+    public AdditionalEmailVerificationTokenService(String secret) {
+        this(secret, DEFAULT_VALIDITY_HOURS);
+    }
+
+    /**
+     * Generate a verification token for a given additional-email row.
+     *
+     * @param additionalEmailId UUID of the {@code user_additional_emails} row
+     * @param email             the additional email address (lower-cased)
+     * @return signed JWT string valid for the configured window (default 48h)
+     */
+    public String generateToken(UUID additionalEmailId, String email) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + validityMs);
+
+        return Jwts.builder()
+                .claim("additionalEmailId", additionalEmailId.toString())
+                .claim("email", email)
+                .claim("type", TOKEN_TYPE)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(signingKey)
+                .compact();
+    }
+
+    /**
+     * Validate and parse a verification token.
+     *
+     * @param token JWT token from the email link
+     * @return parsed claims (additionalEmailId, email, type)
+     * @throws io.jsonwebtoken.ExpiredJwtException if the token is expired
+     * @throws io.jsonwebtoken.JwtException        if the signature is invalid or malformed
+     * @throws IllegalArgumentException            if the token type does not match, or the
+     *                                             {@code additionalEmailId} / {@code email}
+     *                                             claims are missing or malformed
+     */
+    public Claims validateToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        String type = claims.get("type", String.class);
+        if (!TOKEN_TYPE.equals(type)) {
+            throw new IllegalArgumentException("Invalid token type: " + type);
+        }
+
+        // Validate the payload claims here (inside the parse path) so a signed-but-malformed
+        // token — missing/non-UUID additionalEmailId or missing email — surfaces as an
+        // IllegalArgumentException that the caller maps to a 400 TOKEN_INVALID, rather than
+        // blowing up later as a generic 500 during getAdditionalEmailId()/getEmail() extraction.
+        getAdditionalEmailId(claims);
+        String email = getEmail(claims);
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("Missing email claim in verification token");
+        }
+
+        return claims;
+    }
+
+    /**
+     * Extract the additional-email row UUID from validated claims.
+     *
+     * @throws IllegalArgumentException if the claim is absent or not a valid UUID
+     *                                  (a null claim would otherwise NPE inside UUID.fromString)
+     */
+    public UUID getAdditionalEmailId(Claims claims) {
+        String value = claims.get("additionalEmailId", String.class);
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Missing additionalEmailId claim in verification token");
+        }
+        return UUID.fromString(value);
+    }
+
+    /**
+     * Extract the email from validated claims.
+     */
+    public String getEmail(Claims claims) {
+        return claims.get("email", String.class);
+    }
+}

--- a/services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/UserService.java
+++ b/services/company-user-management-service/src/main/java/ch/batbern/companyuser/service/UserService.java
@@ -5,6 +5,8 @@ import ch.batbern.companyuser.domain.User;
 import ch.batbern.companyuser.domain.UserAdditionalEmail;
 import ch.batbern.companyuser.dto.generated.AddAdditionalEmailRequest;
 import ch.batbern.companyuser.dto.generated.AdditionalEmail;
+import ch.batbern.companyuser.dto.generated.AdditionalEmailVerificationCheckResponse;
+import ch.batbern.companyuser.dto.generated.AdditionalEmailVerificationConfirmResponse;
 import ch.batbern.companyuser.dto.generated.GetOrCreateUserRequest;
 import ch.batbern.companyuser.dto.generated.GetOrCreateUserResponse;
 import ch.batbern.companyuser.dto.generated.InvitationCredentialsResponse;
@@ -17,10 +19,13 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.UserStatusT
 import ch.batbern.companyuser.events.UserCreatedEvent;
 import ch.batbern.companyuser.events.UserDeletedEvent;
 import ch.batbern.companyuser.events.UserUpdatedEvent;
+import ch.batbern.companyuser.exception.AdditionalEmailAlreadyVerifiedException;
 import ch.batbern.companyuser.exception.AdditionalEmailDuplicateException;
 import ch.batbern.companyuser.exception.AdditionalEmailLimitReachedException;
 import ch.batbern.companyuser.exception.AdditionalEmailNotFoundException;
 import ch.batbern.companyuser.exception.UnprocessableInvitationStateException;
+import ch.batbern.companyuser.exception.VerificationTokenExpiredException;
+import ch.batbern.companyuser.exception.VerificationTokenInvalidException;
 import ch.batbern.companyuser.exception.UserNotFoundException;
 import ch.batbern.companyuser.exception.UserValidationException;
 import ch.batbern.companyuser.repository.UserAdditionalEmailRepository;
@@ -29,6 +34,9 @@ import ch.batbern.companyuser.security.SecurityContextHelper;
 import ch.batbern.shared.events.DomainEventPublisher;
 import ch.batbern.shared.service.SlugGenerationService;
 import ch.batbern.shared.utils.LoggingUtils;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.micrometer.core.annotation.Counted;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -70,6 +78,9 @@ public class UserService {
     private final RoleService roleService;
     // Story 11.E.2: throwaway temp passwords at READY, fresh temp passwords at INVITED.
     private final PasswordGenerator passwordGenerator;
+    // Additional-email verification (v2): stateless token + verification email.
+    private final AdditionalEmailVerificationTokenService verificationTokenService;
+    private final AdditionalEmailVerificationEmailService verificationEmailService;
 
     /**
      * Story 10.32: per-user cap on additional emails (Resolved Decision #3).
@@ -1383,7 +1394,13 @@ public class UserService {
                 .createdAt(java.time.Instant.now())
                 .build();
         user.addAdditionalEmail(entity);
-        userRepository.save(user);
+        // `user` is the managed entity returned by findByUsernameForUpdate, so the
+        // collection mutation is cascade-persisted directly on flush — assigning the
+        // generated UUID to THIS `entity` instance (the verification token below binds
+        // to entity.getId()). We deliberately avoid userRepository.save(user) here:
+        // save() on an already-managed entity is a merge, which persists a managed
+        // *copy* of the new child and leaves this `entity` transient with a null id.
+        userRepository.flush();
 
         // Audit: persistent audit table is reserved infra (activity_history has
         // no JPA entity yet — see Story 10.32 Dev Notes; AC19 deferred per the
@@ -1396,7 +1413,152 @@ public class UserService {
                 LoggingUtils.maskEmail(user.getEmail()),
                 LoggingUtils.maskEmail(emailNormalized));
 
+        // Additional-email verification (v2): dispatch a signed verification link.
+        // Send is failure-tolerant — a mail failure (SES outage, template missing,
+        // reserved-domain recipient) must NEVER fail or roll back the add. We only
+        // WARN-log (with a masked email) and still return 201.
+        sendVerificationEmailSafely(entity, user);
+
         return UserResponseMapper.mapAdditionalEmailToDto(entity);
+    }
+
+    /**
+     * Additional-email verification (v2) — best-effort dispatch of the verification
+     * email. Swallows all exceptions (logged as WARN with masked email) so the add
+     * flow always succeeds.
+     */
+    private void sendVerificationEmailSafely(UserAdditionalEmail entity, User user) {
+        try {
+            String token = verificationTokenService.generateToken(entity.getId(), entity.getEmail());
+            String locale = resolveUserLocale(user);
+            verificationEmailService.sendVerificationEmail(entity.getEmail(), token, locale);
+        } catch (Exception e) {
+            log.warn("Failed to send additional-email verification to: {} — {}",
+                    LoggingUtils.maskEmail(entity.getEmail()), e.getMessage());
+        }
+    }
+
+    /**
+     * Resolve the user's language preference (de/en) for verification email
+     * locale selection. Anything other than 'de' resolves to 'en' (the email
+     * templates only exist in de + en per the project localization rule).
+     */
+    private String resolveUserLocale(User user) {
+        if (user.getPreferences() != null && user.getPreferences().getLanguage() != null) {
+            String language = user.getPreferences().getLanguage();
+            // Any German variant (de, de-DE, de-CH, …) gets the German template; everything
+            // else (including gsw-BE per the email-template DE+EN-only rule) falls back to en.
+            return language.toLowerCase(Locale.ROOT).startsWith("de") ? "de" : "en";
+        }
+        return "en";
+    }
+
+    /**
+     * Additional-email verification (v2) — resend the verification email for one of
+     * the caller's own additional emails.
+     *
+     * @throws AdditionalEmailNotFoundException        if the email is not on the caller's profile (404)
+     * @throws AdditionalEmailAlreadyVerifiedException if the email is already verified (409)
+     */
+    public void resendVerification(String email) {
+        String username = securityContext.getCurrentUsername();
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserNotFoundException("Current user profile not found"));
+
+        String emailNormalized = email.trim().toLowerCase(Locale.ROOT);
+        UserAdditionalEmail row = additionalEmailRepository
+                .findByUserAndEmailIgnoreCase(user, emailNormalized)
+                .orElseThrow(() -> new AdditionalEmailNotFoundException(emailNormalized));
+
+        if (row.getVerifiedAt() != null) {
+            throw new AdditionalEmailAlreadyVerifiedException(emailNormalized);
+        }
+
+        String token = verificationTokenService.generateToken(row.getId(), row.getEmail());
+        String locale = resolveUserLocale(user);
+        verificationEmailService.sendVerificationEmail(row.getEmail(), token, locale);
+
+        log.info("ADDITIONAL_EMAIL_VERIFICATION_RESENT user={} email={}",
+                LoggingUtils.maskEmail(user.getEmail()),
+                LoggingUtils.maskEmail(emailNormalized));
+    }
+
+    /**
+     * Additional-email verification (v2) — GET-check path. Validates the token and
+     * returns the (masked) email + current verification status WITHOUT mutating
+     * any state. Mail-scanner prefetches land here.
+     *
+     * @throws VerificationTokenExpiredException if the token has expired (400)
+     * @throws VerificationTokenInvalidException if the token is malformed/forged (400)
+     */
+    @Transactional(readOnly = true)
+    public AdditionalEmailVerificationCheckResponse checkVerificationToken(String token) {
+        Claims claims = parseVerificationToken(token);
+        java.util.UUID rowId = verificationTokenService.getAdditionalEmailId(claims);
+        String claimEmail = verificationTokenService.getEmail(claims);
+
+        // The check path does not 404 on a missing row — it reports the token's
+        // email + a "not verified" status so the landing page can still render a
+        // sensible prompt. The actual confirm (POST) is the one that 404s.
+        boolean verified = additionalEmailRepository.findById(rowId)
+                .filter(r -> r.getEmail().equalsIgnoreCase(claimEmail))
+                .map(r -> r.getVerifiedAt() != null)
+                .orElse(false);
+
+        return new AdditionalEmailVerificationCheckResponse()
+                .email(LoggingUtils.maskEmail(claimEmail))
+                .verified(verified);
+    }
+
+    /**
+     * Additional-email verification (v2) — POST-confirm path. Validates the token,
+     * loads the row by UUID, confirms the email claim matches, and sets
+     * {@code verified_at} if not already set. Idempotent: a token for an
+     * already-verified row returns {@code alreadyVerified = true}.
+     *
+     * @throws VerificationTokenExpiredException if the token has expired (400)
+     * @throws VerificationTokenInvalidException if the token is malformed/forged (400)
+     * @throws AdditionalEmailNotFoundException  if the row was deleted/re-added since issuance (404)
+     */
+    @Transactional
+    public AdditionalEmailVerificationConfirmResponse confirmVerificationToken(String token) {
+        Claims claims = parseVerificationToken(token);
+        java.util.UUID rowId = verificationTokenService.getAdditionalEmailId(claims);
+        String claimEmail = verificationTokenService.getEmail(claims);
+
+        UserAdditionalEmail row = additionalEmailRepository.findById(rowId)
+                .filter(r -> r.getEmail().equalsIgnoreCase(claimEmail))
+                .orElseThrow(() -> new AdditionalEmailNotFoundException(claimEmail));
+
+        boolean alreadyVerified = row.getVerifiedAt() != null;
+        if (!alreadyVerified) {
+            row.setVerifiedAt(java.time.Instant.now());
+            additionalEmailRepository.save(row);
+            log.info("ADDITIONAL_EMAIL_VERIFIED email={}", LoggingUtils.maskEmail(row.getEmail()));
+        }
+
+        return new AdditionalEmailVerificationConfirmResponse()
+                .email(LoggingUtils.maskEmail(row.getEmail()))
+                .verified(true)
+                .alreadyVerified(alreadyVerified);
+    }
+
+    /**
+     * Parse + validate a verification token, mapping JJWT exceptions to the
+     * service-level 400 exceptions. Never throws a raw runtime exception that
+     * would surface as a 500.
+     */
+    private Claims parseVerificationToken(String token) {
+        if (token == null || token.isBlank()) {
+            throw new VerificationTokenInvalidException();
+        }
+        try {
+            return verificationTokenService.validateToken(token);
+        } catch (ExpiredJwtException e) {
+            throw new VerificationTokenExpiredException();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new VerificationTokenInvalidException();
+        }
     }
 
     /**

--- a/services/company-user-management-service/src/main/resources/application.yml
+++ b/services/company-user-management-service/src/main/resources/application.yml
@@ -83,6 +83,24 @@ cognito:
     after-hours: ${COGNITO_RESEND_AFTER_HOURS:48} # nudge once unconfirmed >= 2 days
     window-hours: ${COGNITO_RESEND_WINDOW_HOURS:48} # only nudge within [after, after+window) of signup
 
+# Additional-email verification (v2): stateless HMAC-signed verification token.
+# Secret is injected from Secrets Manager (WATCH_JWT_SECRET → JWT_SECRET) in
+# production; the 'changeme' default triggers a random-key fallback for local/test.
+jwt:
+  secret: ${JWT_SECRET:changeme}
+
+# Public base URL used to build the {{baseUrl}}/verify-email?token= link in
+# additional-email verification emails. Defaults to production www.
+app:
+  base-url: ${APP_BASE_URL:https://www.batbern.ch}
+
+batbern:
+  user:
+    additional-emails:
+      verification:
+        # 48h TTL on the signed verification link.
+        token-validity-hours: ${ADDITIONAL_EMAIL_VERIFICATION_TOKEN_VALIDITY_HOURS:48}
+
 # Server Configuration
 server:
   port: 8080

--- a/services/company-user-management-service/src/main/resources/email-templates/additional-email-verification-de.html
+++ b/services/company-user-management-service/src/main/resources/email-templates/additional-email-verification-de.html
@@ -1,0 +1,16 @@
+<p>Guten Tag,</p>
+<p>
+  Diese E-Mail-Adresse wurde als zusätzliche Adresse zu einem
+  <strong>BATbern</strong>-Konto hinzugefügt. Um zu bestätigen, dass sie Ihnen
+  gehört, und um BATbern-Nachrichten an dieser Adresse zu empfangen, bestätigen
+  Sie diese bitte unten.
+</p>
+<p>
+  <a href="{{baseUrl}}/verify-email?token={{token}}">E-Mail-Adresse bestätigen</a>
+</p>
+<p>Dieser Link ist 48 Stunden gültig.</p>
+<p>
+  Falls Sie diese E-Mail nicht erwartet haben, können Sie sie ignorieren — es
+  wird keine Adresse bestätigt, solange Sie nicht auf den obigen Link klicken.
+</p>
+<p>Freundliche Grüsse<br />Ihr BATbern-Team</p>

--- a/services/company-user-management-service/src/main/resources/email-templates/additional-email-verification-en.html
+++ b/services/company-user-management-service/src/main/resources/email-templates/additional-email-verification-en.html
@@ -1,0 +1,15 @@
+<p>Hello,</p>
+<p>
+  This email address was added as an additional address on a
+  <strong>BATbern</strong> account. To confirm that you own it and start
+  receiving BATbern mail at this address, please confirm below.
+</p>
+<p>
+  <a href="{{baseUrl}}/verify-email?token={{token}}">Confirm this email address</a>
+</p>
+<p>This link is valid for 48 hours.</p>
+<p>
+  If you did not expect this email, you can safely ignore it — no address is
+  confirmed unless you click the link above.
+</p>
+<p>Kind regards,<br />The BATbern Team</p>

--- a/services/company-user-management-service/src/test/java/ch/batbern/companyuser/controller/AdditionalEmailVerificationIntegrationTest.java
+++ b/services/company-user-management-service/src/test/java/ch/batbern/companyuser/controller/AdditionalEmailVerificationIntegrationTest.java
@@ -1,0 +1,396 @@
+package ch.batbern.companyuser.controller;
+
+import ch.batbern.companyuser.config.TestAwsConfig;
+import ch.batbern.companyuser.domain.Role;
+import ch.batbern.companyuser.domain.User;
+import ch.batbern.companyuser.domain.UserAdditionalEmail;
+import ch.batbern.companyuser.repository.UserAdditionalEmailRepository;
+import ch.batbern.companyuser.repository.UserRepository;
+import ch.batbern.companyuser.service.AdditionalEmailVerificationTokenService;
+import ch.batbern.shared.service.EmailService;
+import ch.batbern.shared.test.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Additional-email verification (v2) — integration tests for the verification
+ * flow: send-on-add, resend, GET-check, POST-confirm. Covers the spec's full
+ * I/O &amp; Edge-Case Matrix.
+ *
+ * <p>{@link EmailService} is mocked via {@link TestAwsConfig} ({@code @Primary}).
+ * Each test resets the mock and stubs {@code replaceVariables} to call the real
+ * implementation so the captured HTML body contains the rendered token link. No
+ * real outbound email is ever sent.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestAwsConfig.class)
+@DisplayName("Additional-email verification (v2) — endpoints")
+class AdditionalEmailVerificationIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserAdditionalEmailRepository additionalEmailRepository;
+
+    @Autowired
+    private EmailService emailService; // Mockito mock from TestAwsConfig
+
+    @Autowired
+    private AdditionalEmailVerificationTokenService tokenService;
+
+    @jakarta.persistence.PersistenceContext
+    private jakarta.persistence.EntityManager entityManager;
+
+    private User caller;
+    private User other;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(emailService);
+        // Real template rendering so the captured HTML carries the token link.
+        Mockito.when(emailService.replaceVariables(anyString(), any())).thenCallRealMethod();
+
+        caller = userRepository.save(User.builder()
+                .username("john.doe")
+                .email("john.doe@example.com")
+                .firstName("John")
+                .lastName("Doe")
+                .cognitoUserId("john.doe")
+                .roles(new HashSet<>(Set.of(Role.ORGANIZER)))
+                .build());
+
+        other = userRepository.save(User.builder()
+                .username("mary.smith")
+                .email("mary.smith@example.com")
+                .firstName("Mary")
+                .lastName("Smith")
+                .cognitoUserId("mary.smith")
+                .roles(new HashSet<>(Set.of(Role.ATTENDEE)))
+                .build());
+    }
+
+    // ---------------------- add → sends verification email ----------------------
+
+    @Test
+    @WithMockUser(username = "john.doe")
+    @DisplayName("should_sendVerificationEmailWithTokenLink_when_additionalEmailAdded")
+    void should_sendVerificationEmailWithTokenLink_when_additionalEmailAdded() throws Exception {
+        mockMvc.perform(post("/api/v1/users/me/additional-emails")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"email\": \"box@example.com\" }"))
+                .andExpect(status().isCreated());
+
+        ArgumentCaptor<String> to = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> html = ArgumentCaptor.forClass(String.class);
+        verify(emailService, times(1)).sendHtmlEmail(to.capture(), subject.capture(), html.capture());
+
+        assertThat(to.getValue()).isEqualTo("box@example.com");
+        assertThat(html.getValue()).contains("/verify-email?token=");
+        // The rendered link must carry a non-empty token.
+        assertThat(html.getValue()).doesNotContain("token={{token}}");
+    }
+
+    @Test
+    @WithMockUser(username = "john.doe")
+    @DisplayName("should_still201AndWarn_when_emailServiceThrowsOnAdd")
+    void should_still201AndWarn_when_emailServiceThrowsOnAdd() throws Exception {
+        Mockito.doThrow(new RuntimeException("SES down"))
+                .when(emailService).sendHtmlEmail(anyString(), anyString(), anyString());
+
+        mockMvc.perform(post("/api/v1/users/me/additional-emails")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"email\": \"box@example.com\" }"))
+                .andExpect(status().isCreated());
+
+        // The row was still persisted despite the send failure.
+        assertThat(additionalEmailRepository.existsByEmailIgnoreCase("box@example.com")).isTrue();
+    }
+
+    @Test
+    @WithMockUser(username = "hans.mueller")
+    @DisplayName("should_useGermanSubject_when_userLanguagePreferenceIsDe")
+    void should_useGermanSubject_when_userLanguagePreferenceIsDe() throws Exception {
+        userRepository.save(User.builder()
+                .username("hans.mueller")
+                .email("hans.mueller@example.com")
+                .firstName("Hans")
+                .lastName("Mueller")
+                .cognitoUserId("hans.mueller")
+                .roles(new HashSet<>(Set.of(Role.ATTENDEE)))
+                .preferences(ch.batbern.companyuser.domain.UserPreferences.builder()
+                        .language("de")
+                        .build())
+                .build());
+
+        mockMvc.perform(post("/api/v1/users/me/additional-emails")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"email\": \"box-de@example.com\" }"))
+                .andExpect(status().isCreated());
+
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+        verify(emailService, times(1)).sendHtmlEmail(anyString(), subject.capture(), anyString());
+        assertThat(subject.getValue()).isEqualTo("Bestätigen Sie Ihre BATbern E-Mail-Adresse");
+    }
+
+    @Test
+    @WithMockUser(username = "pierre.dupont")
+    @DisplayName("should_useEnglishSubject_when_userLanguageIsNonGerman")
+    void should_useEnglishSubject_when_userLanguageIsNonGerman() throws Exception {
+        // A non-German language preference (fr) falls back to the English template/subject
+        // per the email-template DE+EN-only localization rule. (The User entity defaults a
+        // missing preferences row to language="de", so an explicit non-de language is the
+        // way to exercise the English fallback.)
+        userRepository.save(User.builder()
+                .username("pierre.dupont")
+                .email("pierre.dupont@example.com")
+                .firstName("Pierre")
+                .lastName("Dupont")
+                .cognitoUserId("pierre.dupont")
+                .roles(new HashSet<>(Set.of(Role.ATTENDEE)))
+                .preferences(ch.batbern.companyuser.domain.UserPreferences.builder()
+                        .language("fr")
+                        .build())
+                .build());
+
+        mockMvc.perform(post("/api/v1/users/me/additional-emails")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"email\": \"box-en@example.com\" }"))
+                .andExpect(status().isCreated());
+
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+        verify(emailService, times(1)).sendHtmlEmail(anyString(), subject.capture(), anyString());
+        assertThat(subject.getValue()).isEqualTo("Confirm your BATbern email address");
+    }
+
+    // ---------------------- GET verify (check) ----------------------
+
+    @Test
+    @DisplayName("should_returnMaskedEmailAndStatus_when_checkValidToken")
+    void should_returnMaskedEmailAndStatus_when_checkValidToken() throws Exception {
+        UserAdditionalEmail row = persistAdditional(caller, "box@example.com", null);
+        String token = tokenService.generateToken(row.getId(), row.getEmail());
+
+        mockMvc.perform(get("/api/v1/users/additional-emails/verify").param("token", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(org.hamcrest.Matchers.containsString("***")))
+                .andExpect(jsonPath("$.verified").value(false));
+    }
+
+    @Test
+    @DisplayName("should_return400TokenInvalid_when_checkTamperedToken")
+    void should_return400TokenInvalid_when_checkTamperedToken() throws Exception {
+        mockMvc.perform(get("/api/v1/users/additional-emails/verify").param("token", "not.a.jwt"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("TOKEN_INVALID"));
+    }
+
+    @Test
+    @DisplayName("should_return400AndNever500_when_checkEmptyToken")
+    void should_return400AndNever500_when_checkEmptyToken() throws Exception {
+        // An empty token must map to TOKEN_INVALID (400), never a 500.
+        // TOKEN_EXPIRED (real-key expiry) is exercised at the unit level in
+        // AdditionalEmailVerificationTokenServiceTest, since the production token
+        // bean uses a random key per instance and tokens cannot be cross-signed.
+        mockMvc.perform(get("/api/v1/users/additional-emails/verify").param("token", " "))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("TOKEN_INVALID"));
+    }
+
+    // ---------------------- POST verify (confirm) ----------------------
+
+    @Test
+    @DisplayName("should_setVerifiedAt_when_confirmValidToken")
+    void should_setVerifiedAt_when_confirmValidToken() throws Exception {
+        UserAdditionalEmail row = persistAdditional(caller, "box@example.com", null);
+        String token = tokenService.generateToken(row.getId(), row.getEmail());
+
+        mockMvc.perform(post("/api/v1/users/additional-emails/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"token\": \"" + token + "\" }"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.verified").value(true))
+                .andExpect(jsonPath("$.alreadyVerified").value(false));
+
+        UserAdditionalEmail reloaded = additionalEmailRepository.findById(row.getId()).orElseThrow();
+        assertThat(reloaded.getVerifiedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("should_returnAlreadyVerified_when_confirmAlreadyVerifiedRow")
+    void should_returnAlreadyVerified_when_confirmAlreadyVerifiedRow() throws Exception {
+        UserAdditionalEmail row = persistAdditional(caller, "box@example.com", Instant.now());
+        String token = tokenService.generateToken(row.getId(), row.getEmail());
+
+        mockMvc.perform(post("/api/v1/users/additional-emails/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"token\": \"" + token + "\" }"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.verified").value(true))
+                .andExpect(jsonPath("$.alreadyVerified").value(true));
+    }
+
+    @Test
+    @DisplayName("should_return404_when_confirmTokenForDeletedRow")
+    void should_return404_when_confirmTokenForDeletedRow() throws Exception {
+        UserAdditionalEmail row = persistAdditional(caller, "box@example.com", null);
+        // Sibling row on the same profile that must remain untouched by the 404.
+        UserAdditionalEmail sibling = persistAdditional(caller, "sibling@example.com", null);
+        UUID siblingId = sibling.getId();
+        // Token for the original (about-to-be-deleted) row id.
+        String token = tokenService.generateToken(row.getId(), row.getEmail());
+        UUID deletedId = row.getId();
+
+        // Detach everything first so the still-managed caller.additionalEmails
+        // collection cannot cascade-re-persist the row we are about to delete.
+        entityManager.clear();
+        additionalEmailRepository.deleteById(deletedId);
+        additionalEmailRepository.flush();
+        entityManager.clear();
+
+        mockMvc.perform(post("/api/v1/users/additional-emails/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"token\": \"" + token + "\" }"))
+                .andExpect(status().isNotFound());
+
+        // The unrelated sibling row must be unaffected — still present, still unverified.
+        UserAdditionalEmail reloadedSibling = additionalEmailRepository.findById(siblingId).orElseThrow();
+        assertThat(reloadedSibling.getVerifiedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("should_return404_when_confirmStaleTokenAfterReAdd")
+    void should_return404_when_confirmStaleTokenAfterReAdd() throws Exception {
+        UserAdditionalEmail original = persistAdditional(caller, "box@example.com", null);
+        String staleToken = tokenService.generateToken(original.getId(), original.getEmail());
+        UUID originalId = original.getId();
+
+        // Detach first so the managed caller.additionalEmails collection cannot
+        // cascade-re-persist the deleted row, then delete + flush the removal so the
+        // re-insert below does not collide on the LOWER(email) unique index.
+        entityManager.clear();
+        additionalEmailRepository.deleteById(originalId);
+        additionalEmailRepository.flush();
+        entityManager.clear();
+
+        caller = userRepository.findByUsername("john.doe").orElseThrow();
+        UserAdditionalEmail readded = persistAdditional(caller, "box@example.com", null);
+        assertThat(readded.getId()).isNotEqualTo(originalId);
+
+        // The stale token (old UUID) must 404 — row-UUID binding invalidation.
+        mockMvc.perform(post("/api/v1/users/additional-emails/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"token\": \"" + staleToken + "\" }"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("should_return400TokenInvalid_when_confirmTamperedToken")
+    void should_return400TokenInvalid_when_confirmTamperedToken() throws Exception {
+        mockMvc.perform(post("/api/v1/users/additional-emails/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"token\": \"garbage\" }"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("TOKEN_INVALID"));
+    }
+
+    // ---------------------- resend ----------------------
+
+    @Test
+    @WithMockUser(username = "john.doe")
+    @DisplayName("should_return204AndSendEmail_when_resendForUnverifiedOwnEmail")
+    void should_return204AndSendEmail_when_resendForUnverifiedOwnEmail() throws Exception {
+        persistAdditional(caller, "box@example.com", null);
+
+        mockMvc.perform(post("/api/v1/users/me/additional-emails/{email}/resend-verification",
+                        "box@example.com"))
+                .andExpect(status().isNoContent());
+
+        verify(emailService, times(1)).sendHtmlEmail(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @WithMockUser(username = "john.doe")
+    @DisplayName("should_return404_when_resendForEmailNotOwned")
+    void should_return404_when_resendForEmailNotOwned() throws Exception {
+        // belongs to mary.smith, not john.doe
+        persistAdditional(other, "shared@example.com", null);
+
+        mockMvc.perform(post("/api/v1/users/me/additional-emails/{email}/resend-verification",
+                        "shared@example.com"))
+                .andExpect(status().isNotFound());
+
+        verify(emailService, never()).sendHtmlEmail(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @WithMockUser(username = "john.doe")
+    @DisplayName("should_return409AlreadyVerified_when_resendForVerifiedEmail")
+    void should_return409AlreadyVerified_when_resendForVerifiedEmail() throws Exception {
+        persistAdditional(caller, "box@example.com", Instant.now());
+
+        mockMvc.perform(post("/api/v1/users/me/additional-emails/{email}/resend-verification",
+                        "box@example.com"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("ALREADY_VERIFIED"));
+
+        verify(emailService, never()).sendHtmlEmail(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("should_return401_when_resendNotAuthenticated")
+    void should_return401_when_resendNotAuthenticated() throws Exception {
+        mockMvc.perform(post("/api/v1/users/me/additional-emails/{email}/resend-verification",
+                        "box@example.com"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ---------------------- helpers ----------------------
+
+    private UserAdditionalEmail persistAdditional(User owner, String email, Instant verifiedAt) {
+        UserAdditionalEmail row = UserAdditionalEmail.builder()
+                .email(email)
+                .createdAt(Instant.now())
+                .verifiedAt(verifiedAt)
+                .build();
+        owner.addAdditionalEmail(row);
+        userRepository.save(owner);
+        userRepository.flush();
+        // Re-fetch so the generated UUID id is reliably populated on the returned
+        // instance (the builder-created reference may not carry it back).
+        return additionalEmailRepository.findByUserAndEmailIgnoreCase(owner, email).orElseThrow();
+    }
+}

--- a/services/company-user-management-service/src/test/java/ch/batbern/companyuser/controller/CompanyControllerTest.java
+++ b/services/company-user-management-service/src/test/java/ch/batbern/companyuser/controller/CompanyControllerTest.java
@@ -71,6 +71,10 @@ class CompanyControllerTest {
     @MockitoBean
     private ch.batbern.companyuser.repository.UserRepository userRepository;
 
+    // Required by WebMvcConfig -> JITUserProvisioningInterceptor (verified-additional-email guard)
+    @MockitoBean
+    private ch.batbern.companyuser.repository.UserAdditionalEmailRepository userAdditionalEmailRepository;
+
     // Required by WebMvcConfig -> FederatedAvatarImportInterceptor (Story 12.12)
     @MockitoBean
     private ch.batbern.companyuser.service.FederatedAvatarImportService federatedAvatarImportService;

--- a/services/company-user-management-service/src/test/java/ch/batbern/companyuser/controller/LogoControllerTest.java
+++ b/services/company-user-management-service/src/test/java/ch/batbern/companyuser/controller/LogoControllerTest.java
@@ -66,6 +66,10 @@ class LogoControllerTest {
     @MockitoBean
     private UserRepository userRepository; // Required by WebMvcConfig -> JITUserProvisioningInterceptor
 
+    // Required by WebMvcConfig -> JITUserProvisioningInterceptor (verified-additional-email guard)
+    @MockitoBean
+    private ch.batbern.companyuser.repository.UserAdditionalEmailRepository userAdditionalEmailRepository;
+
     // Required by WebMvcConfig -> FederatedAvatarImportInterceptor (Story 12.12)
     @MockitoBean
     private ch.batbern.companyuser.service.FederatedAvatarImportService federatedAvatarImportService;

--- a/services/company-user-management-service/src/test/java/ch/batbern/companyuser/integration/JITAdditionalEmailGuardIntegrationTest.java
+++ b/services/company-user-management-service/src/test/java/ch/batbern/companyuser/integration/JITAdditionalEmailGuardIntegrationTest.java
@@ -1,0 +1,143 @@
+package ch.batbern.companyuser.integration;
+
+import ch.batbern.companyuser.config.TestAwsConfig;
+import ch.batbern.companyuser.domain.Role;
+import ch.batbern.companyuser.domain.User;
+import ch.batbern.companyuser.domain.UserAdditionalEmail;
+import ch.batbern.companyuser.repository.UserRepository;
+import ch.batbern.shared.test.AbstractIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Epic 12 follow-up — JIT duplicate guard for verified additional emails.
+ *
+ * <p>The PreSignUp Lambda links a Google sign-in for a user's VERIFIED additional email into
+ * the owning account. If that linking did not happen (e.g. the Lambda gate was not met at the
+ * time, or a pre-existing federated identity), the first authenticated API call must NOT
+ * JIT-create a duplicate user for that email. These Testcontainers tests drive a real
+ * authenticated request through {@code /api/**} (so {@code JITUserProvisioningInterceptor}
+ * actually runs) and prove, against real PostgreSQL:
+ * <ul>
+ *   <li>a JWT email matching a VERIFIED additional email of an existing Cognito-linked user X
+ *       creates NO new {@code user_profiles} row and leaves X's {@code cognito_user_id}
+ *       untouched;</li>
+ *   <li>a JWT email matching an UNVERIFIED additional email still JIT-creates a new user
+ *       (existing behaviour, unchanged).</li>
+ * </ul>
+ */
+@Transactional
+@Import(TestAwsConfig.class)
+@DisplayName("Epic 12 follow-up — JIT verified-additional-email duplicate guard")
+class JITAdditionalEmailGuardIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("JWT email = VERIFIED additional email of X → no duplicate row, X's sub untouched")
+    void should_notCreateDuplicate_when_jwtEmailIsVerifiedAdditionalEmailOfExistingUser()
+            throws Exception {
+        String ownerSub = "owner-native-sub-111";
+        String additionalEmail = "private.gmail@gmail.com";
+
+        User owner = User.builder()
+                .username("jane.owner")
+                .email("jane.owner@company.ch")
+                .firstName("Jane")
+                .lastName("Owner")
+                .cognitoUserId(ownerSub)
+                .roles(new HashSet<>(Set.of(Role.ORGANIZER)))
+                .build();
+        owner.addAdditionalEmail(UserAdditionalEmail.builder()
+                .email(additionalEmail)
+                .createdAt(Instant.now())
+                .verifiedAt(Instant.now())
+                .build());
+        userRepository.saveAndFlush(owner);
+
+        long usersBefore = userRepository.count();
+
+        // A federated identity that was NOT linked at PreSignUp time: unknown sub, JWT email
+        // is the owner's verified additional email.
+        String unlinkedSub = "unlinked-federated-sub-222";
+        mockMvc.perform(get("/api/v1/users")
+                        .with(jwt()
+                                .jwt(j -> j.subject(unlinkedSub)
+                                        .claim("email", additionalEmail))
+                                .authorities(Collections.emptyList())))
+                .andExpect(status().isOk());
+
+        // No new row created.
+        assertThat(userRepository.count()).isEqualTo(usersBefore);
+        // No row carries the unlinked sub.
+        assertThat(userRepository.findByCognitoUserId(unlinkedSub)).isEmpty();
+        // No row exists for the additional email as a PRIMARY email.
+        assertThat(userRepository.findByEmail(additionalEmail)).isEmpty();
+        // The owner's cognito_user_id is untouched.
+        User reloaded = userRepository.findByCognitoUserId(ownerSub).orElseThrow();
+        assertThat(reloaded.getCognitoUserId()).isEqualTo(ownerSub);
+        assertThat(reloaded.getUsername()).isEqualTo("jane.owner");
+    }
+
+    @Test
+    @DisplayName("guard is transparent when no verified additional email matches → fresh user JIT-provisions")
+    void should_jitCreateNewUser_when_noVerifiedAdditionalEmailMatches() throws Exception {
+        // An existing owner with an UNVERIFIED additional email — findVerifiedByEmailIgnoreCase
+        // returns nothing for it, so the guard is transparent. (Note: a brand-new user_profiles
+        // row whose PRIMARY email equals an existing additional email is independently rejected
+        // by the enforce_primary_email_not_other_additional DB trigger, so we provision a fresh
+        // identity with its OWN distinct email to prove the guard does not interfere with the
+        // unchanged JIT-create path.)
+        String ownerSub = "owner-native-sub-333";
+        User owner = User.builder()
+                .username("bob.owner")
+                .email("bob.owner@company.ch")
+                .firstName("Bob")
+                .lastName("Owner")
+                .cognitoUserId(ownerSub)
+                .roles(new HashSet<>(Set.of(Role.ATTENDEE)))
+                .build();
+        owner.addAdditionalEmail(UserAdditionalEmail.builder()
+                .email("unverified.box@gmail.com")
+                .createdAt(Instant.now())
+                .verifiedAt(null) // UNVERIFIED → the verified-only guard never sees it.
+                .build());
+        userRepository.saveAndFlush(owner);
+
+        String freshSub = "fresh-federated-sub-444";
+        String freshEmail = "carla.fresh@example.ch";
+        mockMvc.perform(get("/api/v1/users")
+                        .with(jwt()
+                                .jwt(j -> j.subject(freshSub)
+                                        .claim("email", freshEmail)
+                                        .claim("given_name", "Carla")
+                                        .claim("family_name", "Fresh"))
+                                .authorities(Collections.emptyList())))
+                .andExpect(status().isOk());
+
+        // Existing behaviour preserved: a new user IS JIT-created.
+        User created = userRepository.findByCognitoUserId(freshSub).orElseThrow();
+        assertThat(created.getEmail()).isEqualTo(freshEmail);
+        assertThat(created.getRoles()).containsExactly(Role.ATTENDEE);
+        // The owner's sub is untouched.
+        assertThat(userRepository.findByCognitoUserId(ownerSub).orElseThrow().getCognitoUserId())
+                .isEqualTo(ownerSub);
+    }
+}

--- a/services/company-user-management-service/src/test/java/ch/batbern/companyuser/interceptor/JITUserProvisioningInterceptorTest.java
+++ b/services/company-user-management-service/src/test/java/ch/batbern/companyuser/interceptor/JITUserProvisioningInterceptorTest.java
@@ -2,6 +2,7 @@ package ch.batbern.companyuser.interceptor;
 
 import ch.batbern.companyuser.domain.Role;
 import ch.batbern.companyuser.domain.User;
+import ch.batbern.companyuser.repository.UserAdditionalEmailRepository;
 import ch.batbern.companyuser.repository.UserRepository;
 import ch.batbern.companyuser.event.UserCreatedEvent;
 import jakarta.servlet.http.HttpServletRequest;
@@ -54,6 +55,9 @@ class JITUserProvisioningInterceptorTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock(lenient = true)
+    private UserAdditionalEmailRepository userAdditionalEmailRepository;
+
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
@@ -73,6 +77,11 @@ class JITUserProvisioningInterceptorTest {
     void setUp() {
         // Setup security context
         SecurityContextHolder.setContext(securityContext);
+        // Default: the JIT-create path's verified-additional-email duplicate guard finds nothing,
+        // so existing create/link tests are unaffected. Lenient so tests that never reach the
+        // guard (e.g. already-exists-by-cognito-id) do not trip unnecessary-stubbing strictness.
+        when(userAdditionalEmailRepository.findVerifiedByEmailIgnoreCase(anyString()))
+                .thenReturn(Optional.empty());
     }
 
     /**
@@ -255,7 +264,7 @@ class JITUserProvisioningInterceptorTest {
         User preExistingUser = createUser(null, "partner.user", email, Set.of(Role.PARTNER));
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(preExistingUser));
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.of(preExistingUser));
         when(userRepository.save(preExistingUser)).thenReturn(preExistingUser);
 
         // When
@@ -285,7 +294,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
 
         User savedUser = createUser(cognitoUserId, "jane.smith", email, Set.of(Role.ATTENDEE));
@@ -315,6 +324,72 @@ class JITUserProvisioningInterceptorTest {
     }
 
     // ============================================================================
+    // Epic 12 follow-up — verified-additional-email duplicate guard.
+    // Before JIT-creating a brand-new user, the interceptor checks whether the email is a
+    // VERIFIED additional email of an existing user (PreSignUp should have linked it). If so,
+    // it skips creation — without resolving the request to the owner or touching the owner's
+    // cognito_user_id. Unverified additional emails are transparent to the guard.
+    // ============================================================================
+
+    @Test
+    void should_skipUserCreation_when_emailIsVerifiedAdditionalEmailOfExistingUser() throws Exception {
+        String cognitoUserId = "unlinked-federated-sub-222";
+        String email = "private.gmail@gmail.com";
+        Jwt jwt = createJwt(cognitoUserId, email, "Anon", "Federated");
+        JwtAuthenticationToken authentication = createJwtAuthentication(
+                jwt,
+                List.of(new SimpleGrantedAuthority("ROLE_ATTENDEE"))
+        );
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
+        // The duplicate guard fires: this email is a verified additional email of an owner.
+        ch.batbern.companyuser.domain.UserAdditionalEmail verifiedRow =
+                ch.batbern.companyuser.domain.UserAdditionalEmail.builder()
+                        .email(email)
+                        .verifiedAt(Instant.now())
+                        .build();
+        when(userAdditionalEmailRepository.findVerifiedByEmailIgnoreCase(email))
+                .thenReturn(Optional.of(verifiedRow));
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        // Request continues, but NO new user is created and NO event is published.
+        assertThat(result).isTrue();
+        verify(userRepository, never()).save(any(User.class));
+        verify(eventPublisher, never()).publishEvent(any(UserCreatedEvent.class));
+    }
+
+    @Test
+    void should_createUser_when_emailIsUnverifiedAdditionalEmail() throws Exception {
+        String cognitoUserId = "fresh-federated-sub-444";
+        String email = "unverified.box@gmail.com";
+        Jwt jwt = createJwt(cognitoUserId, email, "Fresh", "User");
+        JwtAuthenticationToken authentication = createJwtAuthentication(
+                jwt,
+                List.of(new SimpleGrantedAuthority("ROLE_ATTENDEE"))
+        );
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
+        when(userRepository.existsByUsername(anyString())).thenReturn(false);
+        // Unverified → the verified-only finder returns empty → guard is transparent.
+        when(userAdditionalEmailRepository.findVerifiedByEmailIgnoreCase(email))
+                .thenReturn(Optional.empty());
+        User savedUser = createUser(cognitoUserId, "fresh.user", email, Set.of(Role.ATTENDEE));
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        // Existing behaviour preserved: a new user IS JIT-created.
+        assertThat(result).isTrue();
+        verify(userRepository).save(any(User.class));
+        verify(eventPublisher).publishEvent(any(UserCreatedEvent.class));
+    }
+
+    // ============================================================================
     // 2026-05-18 regression — JIT used to read first/last name only from JWT
     // given_name / family_name. The signup form actually packs those into a
     // single `custom:preferences` JSON attribute (per ADR-001), so JIT ended
@@ -333,7 +408,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
 
         when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
@@ -361,7 +436,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -383,7 +458,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -412,7 +487,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -441,7 +516,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -467,7 +542,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -500,7 +575,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -524,7 +599,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -548,7 +623,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -570,7 +645,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -594,7 +669,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail("organizer@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase("organizer@example.com")).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
 
         // When: Interceptor pre-handle is called
@@ -623,7 +698,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail("multi@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase("multi@example.com")).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
 
         // When: Interceptor pre-handle is called
@@ -646,7 +721,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail("norole@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase("norole@example.com")).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
 
         // When: Interceptor pre-handle is called
@@ -677,7 +752,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername("john.doe")).thenReturn(false);
 
         // When: Interceptor pre-handle is called
@@ -704,7 +779,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername("duplicate.user")).thenReturn(true);
         when(userRepository.existsByUsername("duplicate.user.2")).thenReturn(false);
 
@@ -775,7 +850,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase(email)).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
 
         User savedUser = createUser(cognitoUserId, "event", email, Set.of(Role.ATTENDEE));
@@ -836,7 +911,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail("saveerror@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase("saveerror@example.com")).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         when(userRepository.save(any(User.class)))
                 .thenThrow(new RuntimeException("Database constraint violation"));
@@ -860,7 +935,7 @@ class JITUserProvisioningInterceptorTest {
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(userRepository.findByCognitoUserId(cognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail("eventerror@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase("eventerror@example.com")).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
 
         User savedUser = createUser(cognitoUserId, "eventerror", "eventerror@example.com", Set.of(Role.ATTENDEE));
@@ -910,7 +985,7 @@ class JITUserProvisioningInterceptorTest {
         );
         when(securityContext.getAuthentication()).thenReturn(newAuthentication);
         when(userRepository.findByCognitoUserId(newCognitoUserId)).thenReturn(Optional.empty());
-        when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByEmailIgnoreCase("new@example.com")).thenReturn(Optional.empty());
         when(userRepository.existsByUsername(anyString())).thenReturn(false);
         assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
 

--- a/services/company-user-management-service/src/test/java/ch/batbern/companyuser/service/AdditionalEmailVerificationEmailServiceTest.java
+++ b/services/company-user-management-service/src/test/java/ch/batbern/companyuser/service/AdditionalEmailVerificationEmailServiceTest.java
@@ -1,0 +1,72 @@
+package ch.batbern.companyuser.service;
+
+import ch.batbern.shared.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AdditionalEmailVerificationEmailService}'s locale →
+ * template/subject selection. Any German variant ({@code de}, {@code de-CH}, …)
+ * must use the German template + subject; everything else (including {@code fr},
+ * {@code gsw-BE}, and {@code null}) falls back to English per the email-template
+ * DE+EN-only localization rule.
+ */
+@DisplayName("AdditionalEmailVerificationEmailService — locale resolution")
+class AdditionalEmailVerificationEmailServiceTest {
+
+    private static final String EN_SUBJECT = "Confirm your BATbern email address";
+
+    private EmailService emailService;
+    private AdditionalEmailVerificationEmailService service;
+
+    @BeforeEach
+    void setUp() {
+        emailService = mock(EmailService.class);
+        // Real variable substitution so the rendered body carries the token link.
+        when(emailService.replaceVariables(anyString(), any())).thenCallRealMethod();
+        service = new AdditionalEmailVerificationEmailService(emailService);
+        ReflectionTestUtils.setField(service, "baseUrl", "https://www.batbern.ch");
+    }
+
+    @ParameterizedTest(name = "locale=\"{0}\" → subject=\"{1}\"")
+    @CsvSource(delimiter = '|', value = {
+        "de     | Bestätigen Sie Ihre BATbern E-Mail-Adresse",
+        "de-CH  | Bestätigen Sie Ihre BATbern E-Mail-Adresse",
+        "de-DE  | Bestätigen Sie Ihre BATbern E-Mail-Adresse",
+        "DE     | Bestätigen Sie Ihre BATbern E-Mail-Adresse",
+        "fr     | Confirm your BATbern email address",
+        "gsw-BE | Confirm your BATbern email address",
+        "en     | Confirm your BATbern email address",
+    })
+    @DisplayName("should_selectSubjectByLocalePrefix")
+    void should_selectSubjectByLocalePrefix(String locale, String expectedSubject) {
+        service.sendVerificationEmail("box@example.com", "tok123", locale);
+
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+        verify(emailService, times(1)).sendHtmlEmail(anyString(), subject.capture(), anyString());
+        assertThat(subject.getValue()).isEqualTo(expectedSubject);
+    }
+
+    @Test
+    @DisplayName("should_fallBackToEnglish_when_localeIsNull")
+    void should_fallBackToEnglish_when_localeIsNull() {
+        service.sendVerificationEmail("box@example.com", "tok123", null);
+
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+        verify(emailService, times(1)).sendHtmlEmail(anyString(), subject.capture(), anyString());
+        assertThat(subject.getValue()).isEqualTo(EN_SUBJECT);
+    }
+}

--- a/services/company-user-management-service/src/test/java/ch/batbern/companyuser/service/AdditionalEmailVerificationTokenServiceTest.java
+++ b/services/company-user-management-service/src/test/java/ch/batbern/companyuser/service/AdditionalEmailVerificationTokenServiceTest.java
@@ -1,0 +1,72 @@
+package ch.batbern.companyuser.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link AdditionalEmailVerificationTokenService}. A fixed,
+ * &gt;=256-bit secret is used so generate/validate share the same signing key
+ * (the {@code "changeme"} sentinel would generate a random key per instance).
+ */
+@DisplayName("AdditionalEmailVerificationTokenService")
+class AdditionalEmailVerificationTokenServiceTest {
+
+    private static final String SECRET = "test-secret-key-that-is-long-enough-for-hs256-aaaa";
+
+    @Test
+    @DisplayName("should_roundTripClaims_when_validToken")
+    void should_roundTripClaims_when_validToken() {
+        AdditionalEmailVerificationTokenService service =
+                new AdditionalEmailVerificationTokenService(SECRET, 48L);
+        UUID id = UUID.randomUUID();
+
+        String token = service.generateToken(id, "box@example.com");
+        Claims claims = service.validateToken(token);
+
+        assertThat(service.getAdditionalEmailId(claims)).isEqualTo(id);
+        assertThat(service.getEmail(claims)).isEqualTo("box@example.com");
+    }
+
+    @Test
+    @DisplayName("should_throwExpired_when_tokenPastTtl")
+    void should_throwExpired_when_tokenPastTtl() {
+        AdditionalEmailVerificationTokenService service =
+                new AdditionalEmailVerificationTokenService(SECRET, 0L);
+        String token = service.generateToken(UUID.randomUUID(), "box@example.com");
+
+        assertThatThrownBy(() -> service.validateToken(token))
+                .isInstanceOf(ExpiredJwtException.class);
+    }
+
+    @Test
+    @DisplayName("should_throwJwt_when_signatureFromDifferentKey")
+    void should_throwJwt_when_signatureFromDifferentKey() {
+        AdditionalEmailVerificationTokenService issuer =
+                new AdditionalEmailVerificationTokenService(SECRET, 48L);
+        AdditionalEmailVerificationTokenService verifier =
+                new AdditionalEmailVerificationTokenService(
+                        "another-secret-key-that-is-also-long-enough-bbbb", 48L);
+        String token = issuer.generateToken(UUID.randomUUID(), "box@example.com");
+
+        assertThatThrownBy(() -> verifier.validateToken(token))
+                .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    @DisplayName("should_throwIllegalArgument_when_malformedToken")
+    void should_throwIllegalArgument_when_malformedToken() {
+        AdditionalEmailVerificationTokenService service =
+                new AdditionalEmailVerificationTokenService(SECRET, 48L);
+
+        assertThatThrownBy(() -> service.validateToken("not.a.jwt"))
+                .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/services/company-user-management-service/src/test/java/ch/batbern/companyuser/service/UserServiceTest.java
+++ b/services/company-user-management-service/src/test/java/ch/batbern/companyuser/service/UserServiceTest.java
@@ -77,6 +77,12 @@ class UserServiceTest {
     @Mock
     private ch.batbern.companyuser.repository.UserAdditionalEmailRepository additionalEmailRepository;
 
+    @Mock
+    private AdditionalEmailVerificationTokenService verificationTokenService;
+
+    @Mock
+    private AdditionalEmailVerificationEmailService verificationEmailService;
+
     private UserService userService;
 
     @BeforeEach
@@ -92,7 +98,9 @@ class UserServiceTest {
             responseMapper,
             companyService,
             roleService,
-            passwordGenerator
+            passwordGenerator,
+            verificationTokenService,
+            verificationEmailService
         );
     }
 

--- a/web-frontend/public/locales/de/userManagement.json
+++ b/web-frontend/public/locales/de/userManagement.json
@@ -229,7 +229,14 @@
       "additionalEmailRemoveConfirmCancel": "Abbrechen",
       "additionalEmailDeleteFailed": "Zusätzliche E-Mail konnte nicht entfernt werden. Bitte versuche es erneut.",
       "additionalEmailDeleteNotFound": "Diese zusätzliche E-Mail ist nicht mehr in deinem Profil.",
-      "additionalEmailDeleteAriaLabel": "Zusätzliche E-Mail {{email}} entfernen"
+      "additionalEmailDeleteAriaLabel": "Zusätzliche E-Mail {{email}} entfernen",
+      "additionalEmailVerifiedPill": "Bestätigt",
+      "additionalEmailResendButton": "Erneut senden",
+      "additionalEmailResendSuccess": "Bestätigungs-E-Mail gesendet.",
+      "additionalEmailResendFailed": "Die Bestätigungs-E-Mail konnte nicht gesendet werden. Bitte versuchen Sie es erneut.",
+      "additionalEmailResendAlreadyVerified": "Diese E-Mail-Adresse ist bereits bestätigt.",
+      "additionalEmailResendAriaLabel": "Bestätigungs-E-Mail erneut an {{email}} senden",
+      "additionalEmailVerifiedAriaLabel": "{{email}} ist bestätigt"
     },
     "notifications": {
       "title": "Benachrichtigungseinstellungen",
@@ -292,5 +299,16 @@
     "linked": "Cognito verknüpft",
     "notLinked": "Kein Cognito-Konto",
     "tooltip": "Cognito-Konto verknüpft"
+  },
+  "verifyEmail": {
+    "title": "Bestätigen Sie Ihre E-Mail-Adresse",
+    "loading": "Ihr Bestätigungslink wird geprüft…",
+    "confirmMessage": "Bestätigen Sie, dass {{email}} Ihre E-Mail-Adresse ist.",
+    "confirmButton": "E-Mail-Adresse bestätigen",
+    "success": "Ihre E-Mail-Adresse wurde bestätigt. Sie können diese Seite schliessen.",
+    "alreadyVerified": "Diese E-Mail-Adresse ist bereits bestätigt.",
+    "homeLink": "Zu batbern.ch",
+    "invalidToken": "Dieser Bestätigungslink ist ungültig oder abgelaufen. Bitte fordern Sie in Ihren Kontoeinstellungen einen neuen an.",
+    "notFound": "Diese E-Mail-Adresse befindet sich nicht mehr auf dem Profil, zu dem sie hinzugefügt wurde. Falls Sie sie erneut hinzugefügt haben, verwenden Sie den Link aus der neuesten Bestätigungs-E-Mail."
   }
 }

--- a/web-frontend/public/locales/en/userManagement.json
+++ b/web-frontend/public/locales/en/userManagement.json
@@ -203,7 +203,14 @@
       "additionalEmailRemoveConfirmCancel": "Cancel",
       "additionalEmailDeleteFailed": "Failed to remove this additional email. Please try again.",
       "additionalEmailDeleteNotFound": "This additional email is no longer on your profile.",
-      "additionalEmailDeleteAriaLabel": "Remove additional email {{email}}"
+      "additionalEmailDeleteAriaLabel": "Remove additional email {{email}}",
+      "additionalEmailVerifiedPill": "Verified",
+      "additionalEmailResendButton": "Resend",
+      "additionalEmailResendSuccess": "Verification email sent.",
+      "additionalEmailResendFailed": "Could not send the verification email. Please try again.",
+      "additionalEmailResendAlreadyVerified": "This email is already verified.",
+      "additionalEmailResendAriaLabel": "Resend verification email to {{email}}",
+      "additionalEmailVerifiedAriaLabel": "{{email}} is verified"
     },
     "notifications": {
       "title": "Notification Preferences",
@@ -292,5 +299,16 @@
         "WAITLISTED": "Waitlisted"
       }
     }
+  },
+  "verifyEmail": {
+    "title": "Confirm your email address",
+    "loading": "Checking your verification link…",
+    "confirmMessage": "Confirm that {{email}} is your email address.",
+    "confirmButton": "Confirm email address",
+    "success": "Your email address has been confirmed. You can close this page.",
+    "alreadyVerified": "This email address is already confirmed.",
+    "homeLink": "Go to batbern.ch",
+    "invalidToken": "This verification link is invalid or has expired. Please request a new one from your account settings.",
+    "notFound": "This email address is no longer on the profile it was added to. If you re-added it, use the link from the newest verification email."
   }
 }

--- a/web-frontend/public/locales/es/userManagement.json
+++ b/web-frontend/public/locales/es/userManagement.json
@@ -229,7 +229,14 @@
       "additionalEmailRemoveConfirmCancel": "Cancelar",
       "additionalEmailDeleteFailed": "No se ha podido eliminar este correo adicional. Inténtalo de nuevo.",
       "additionalEmailDeleteNotFound": "Este correo adicional ya no está en tu perfil.",
-      "additionalEmailDeleteAriaLabel": "Eliminar correo adicional {{email}}"
+      "additionalEmailDeleteAriaLabel": "Eliminar correo adicional {{email}}",
+      "additionalEmailVerifiedPill": "Verificado",
+      "additionalEmailResendButton": "Reenviar",
+      "additionalEmailResendSuccess": "Correo de verificación enviado.",
+      "additionalEmailResendFailed": "No se pudo enviar el correo de verificación. Inténtelo de nuevo.",
+      "additionalEmailResendAlreadyVerified": "Esta dirección de correo ya está verificada.",
+      "additionalEmailResendAriaLabel": "Reenviar el correo de verificación a {{email}}",
+      "additionalEmailVerifiedAriaLabel": "{{email}} está verificado"
     },
     "notifications": {
       "title": "Preferencias de notificación",
@@ -292,5 +299,16 @@
     "linked": "Cognito vinculado",
     "notLinked": "Sin cuenta Cognito",
     "tooltip": "Cuenta de Cognito vinculada"
+  },
+  "verifyEmail": {
+    "title": "Confirme su dirección de correo electrónico",
+    "loading": "Comprobando su enlace de verificación…",
+    "confirmMessage": "Confirme que {{email}} es su dirección de correo electrónico.",
+    "confirmButton": "Confirmar dirección de correo",
+    "success": "Su dirección de correo ha sido confirmada. Puede cerrar esta página.",
+    "alreadyVerified": "Esta dirección de correo ya está confirmada.",
+    "homeLink": "Ir a batbern.ch",
+    "invalidToken": "Este enlace de verificación no es válido o ha caducado. Solicite uno nuevo en la configuración de su cuenta.",
+    "notFound": "Esta dirección de correo ya no está en el perfil al que se añadió. Si la volvió a añadir, utilice el enlace del correo de verificación más reciente."
   }
 }

--- a/web-frontend/public/locales/fi/userManagement.json
+++ b/web-frontend/public/locales/fi/userManagement.json
@@ -229,7 +229,14 @@
       "additionalEmailRemoveConfirmCancel": "Peruuta",
       "additionalEmailDeleteFailed": "Lisäsähköpostin poistaminen epäonnistui. Yritä uudelleen.",
       "additionalEmailDeleteNotFound": "Tämä lisäsähköposti ei ole enää profiilissasi.",
-      "additionalEmailDeleteAriaLabel": "Poista lisäsähköposti {{email}}"
+      "additionalEmailDeleteAriaLabel": "Poista lisäsähköposti {{email}}",
+      "additionalEmailVerifiedPill": "Vahvistettu",
+      "additionalEmailResendButton": "Lähetä uudelleen",
+      "additionalEmailResendSuccess": "Vahvistusviesti lähetetty.",
+      "additionalEmailResendFailed": "Vahvistusviestin lähettäminen epäonnistui. Yritä uudelleen.",
+      "additionalEmailResendAlreadyVerified": "Tämä sähköpostiosoite on jo vahvistettu.",
+      "additionalEmailResendAriaLabel": "Lähetä vahvistusviesti uudelleen osoitteeseen {{email}}",
+      "additionalEmailVerifiedAriaLabel": "{{email}} on vahvistettu"
     },
     "notifications": {
       "title": "Ilmoitusasetukset",
@@ -292,5 +299,16 @@
     "linked": "Cognito yhdistetty",
     "notLinked": "Ei Cognito-tiliä",
     "tooltip": "Cognito-tili yhdistetty"
+  },
+  "verifyEmail": {
+    "title": "Vahvista sähköpostiosoitteesi",
+    "loading": "Tarkistetaan vahvistuslinkkiäsi…",
+    "confirmMessage": "Vahvista, että {{email}} on sähköpostiosoitteesi.",
+    "confirmButton": "Vahvista sähköpostiosoite",
+    "success": "Sähköpostiosoitteesi on vahvistettu. Voit sulkea tämän sivun.",
+    "alreadyVerified": "Tämä sähköpostiosoite on jo vahvistettu.",
+    "homeLink": "Siirry osoitteeseen batbern.ch",
+    "invalidToken": "Tämä vahvistuslinkki on virheellinen tai vanhentunut. Pyydä uusi tilisi asetuksista.",
+    "notFound": "Tätä sähköpostiosoitetta ei enää ole profiilissa, johon se lisättiin. Jos lisäsit sen uudelleen, käytä uusimman vahvistussähköpostin linkkiä."
   }
 }

--- a/web-frontend/public/locales/fr/userManagement.json
+++ b/web-frontend/public/locales/fr/userManagement.json
@@ -229,7 +229,14 @@
       "additionalEmailRemoveConfirmCancel": "Annuler",
       "additionalEmailDeleteFailed": "Impossible de supprimer cette adresse e-mail supplémentaire. Veuillez réessayer.",
       "additionalEmailDeleteNotFound": "Cette adresse e-mail supplémentaire n'est plus dans votre profil.",
-      "additionalEmailDeleteAriaLabel": "Supprimer l'adresse e-mail supplémentaire {{email}}"
+      "additionalEmailDeleteAriaLabel": "Supprimer l'adresse e-mail supplémentaire {{email}}",
+      "additionalEmailVerifiedPill": "Vérifié",
+      "additionalEmailResendButton": "Renvoyer",
+      "additionalEmailResendSuccess": "E-mail de vérification envoyé.",
+      "additionalEmailResendFailed": "Impossible d'envoyer l'e-mail de vérification. Veuillez réessayer.",
+      "additionalEmailResendAlreadyVerified": "Cette adresse e-mail est déjà vérifiée.",
+      "additionalEmailResendAriaLabel": "Renvoyer l'e-mail de vérification à {{email}}",
+      "additionalEmailVerifiedAriaLabel": "{{email}} est vérifié"
     },
     "notifications": {
       "title": "Préférences de notification",
@@ -292,5 +299,16 @@
     "linked": "Cognito lié",
     "notLinked": "Pas de compte Cognito",
     "tooltip": "Compte Cognito associé"
+  },
+  "verifyEmail": {
+    "title": "Confirmez votre adresse e-mail",
+    "loading": "Vérification de votre lien…",
+    "confirmMessage": "Confirmez que {{email}} est votre adresse e-mail.",
+    "confirmButton": "Confirmer l'adresse e-mail",
+    "success": "Votre adresse e-mail a été confirmée. Vous pouvez fermer cette page.",
+    "alreadyVerified": "Cette adresse e-mail est déjà confirmée.",
+    "homeLink": "Aller sur batbern.ch",
+    "invalidToken": "Ce lien de vérification est invalide ou a expiré. Veuillez en demander un nouveau dans les paramètres de votre compte.",
+    "notFound": "Cette adresse e-mail ne figure plus sur le profil auquel elle avait été ajoutée. Si vous l'avez ajoutée à nouveau, utilisez le lien du dernier e-mail de vérification."
   }
 }

--- a/web-frontend/public/locales/gsw-BE/userManagement.json
+++ b/web-frontend/public/locales/gsw-BE/userManagement.json
@@ -42,10 +42,28 @@
       "additionalEmailRemoveConfirmCancel": "Abbräche",
       "additionalEmailDeleteFailed": "D zuesätzlechi E-Mail het nid chöne entfernt wärde. Bitte versuechs nomal.",
       "additionalEmailDeleteNotFound": "Die zuesätzlechi E-Mail isch nümme i dym Profil.",
-      "additionalEmailDeleteAriaLabel": "Zuesätzlechi E-Mail {{email}} entferne"
+      "additionalEmailDeleteAriaLabel": "Zuesätzlechi E-Mail {{email}} entferne",
+      "additionalEmailVerifiedPill": "Bestätigt",
+      "additionalEmailResendButton": "No einisch schicke",
+      "additionalEmailResendSuccess": "Bestätigungs-E-Mail gschickt.",
+      "additionalEmailResendFailed": "D'Bestätigungs-E-Mail het nid chönne gschickt wärde. Probier's bitte nomal.",
+      "additionalEmailResendAlreadyVerified": "Die E-Mail-Adrässe isch scho bestätigt.",
+      "additionalEmailResendAriaLabel": "Bestätigungs-E-Mail no einisch a {{email}} schicke",
+      "additionalEmailVerifiedAriaLabel": "{{email}} isch bestätigt"
     }
   },
   "actions": {
     "openMenu": "Aktionsmenü ufmache"
+  },
+  "verifyEmail": {
+    "title": "Bestätig dini E-Mail-Adrässe",
+    "loading": "Dyy Bestätigungs-Link wird prüeft…",
+    "confirmMessage": "Bestätig, dass {{email}} dini E-Mail-Adrässe isch.",
+    "confirmButton": "E-Mail-Adrässe bestätige",
+    "success": "Dini E-Mail-Adrässe isch bestätigt. Du chasch die Syte zuemache.",
+    "alreadyVerified": "Die E-Mail-Adrässe isch scho bestätigt.",
+    "homeLink": "Uf batbern.ch ga",
+    "invalidToken": "Dä Bestätigungs-Link isch ungültig oder abgloffe. Bitte foddere i de Konto-Yystellige e neue a.",
+    "notFound": "Die E-Mail-Adrässe isch nümme uf em Profil, wo si derzue gleit worde isch. Wenn du si nomal derzue gleit hesch, bruuch dr Link us em neuste Bestätigungs-E-Mail."
   }
 }

--- a/web-frontend/public/locales/it/userManagement.json
+++ b/web-frontend/public/locales/it/userManagement.json
@@ -229,7 +229,14 @@
       "additionalEmailRemoveConfirmCancel": "Annulla",
       "additionalEmailDeleteFailed": "Impossibile rimuovere questo indirizzo email aggiuntivo. Riprova.",
       "additionalEmailDeleteNotFound": "Questo indirizzo email aggiuntivo non è più nel tuo profilo.",
-      "additionalEmailDeleteAriaLabel": "Rimuovi indirizzo email aggiuntivo {{email}}"
+      "additionalEmailDeleteAriaLabel": "Rimuovi indirizzo email aggiuntivo {{email}}",
+      "additionalEmailVerifiedPill": "Verificato",
+      "additionalEmailResendButton": "Invia di nuovo",
+      "additionalEmailResendSuccess": "E-mail di verifica inviata.",
+      "additionalEmailResendFailed": "Impossibile inviare l'e-mail di verifica. Riprovare.",
+      "additionalEmailResendAlreadyVerified": "Questo indirizzo e-mail è già verificato.",
+      "additionalEmailResendAriaLabel": "Invia di nuovo l'e-mail di verifica a {{email}}",
+      "additionalEmailVerifiedAriaLabel": "{{email}} è verificato"
     },
     "notifications": {
       "title": "Preferenze notifiche",
@@ -292,5 +299,16 @@
     "linked": "Cognito collegato",
     "notLinked": "Nessun account Cognito",
     "tooltip": "Account Cognito collegato"
+  },
+  "verifyEmail": {
+    "title": "Conferma il tuo indirizzo e-mail",
+    "loading": "Verifica del tuo link in corso…",
+    "confirmMessage": "Conferma che {{email}} è il tuo indirizzo e-mail.",
+    "confirmButton": "Conferma indirizzo e-mail",
+    "success": "Il tuo indirizzo e-mail è stato confermato. Puoi chiudere questa pagina.",
+    "alreadyVerified": "Questo indirizzo e-mail è già confermato.",
+    "homeLink": "Vai a batbern.ch",
+    "invalidToken": "Questo link di verifica non è valido o è scaduto. Richiedine uno nuovo nelle impostazioni del tuo account.",
+    "notFound": "Questo indirizzo e-mail non è più presente sul profilo a cui era stato aggiunto. Se lo hai aggiunto di nuovo, usa il link dell'e-mail di verifica più recente."
   }
 }

--- a/web-frontend/public/locales/ja/userManagement.json
+++ b/web-frontend/public/locales/ja/userManagement.json
@@ -229,7 +229,14 @@
       "additionalEmailRemoveConfirmCancel": "キャンセル",
       "additionalEmailDeleteFailed": "追加のメールアドレスを削除できませんでした。もう一度お試しください。",
       "additionalEmailDeleteNotFound": "この追加のメールアドレスはプロフィールにありません。",
-      "additionalEmailDeleteAriaLabel": "追加のメールアドレス {{email}} を削除"
+      "additionalEmailDeleteAriaLabel": "追加のメールアドレス {{email}} を削除",
+      "additionalEmailVerifiedPill": "確認済み",
+      "additionalEmailResendButton": "再送信",
+      "additionalEmailResendSuccess": "確認メールを送信しました。",
+      "additionalEmailResendFailed": "確認メールを送信できませんでした。もう一度お試しください。",
+      "additionalEmailResendAlreadyVerified": "このメールアドレスはすでに確認済みです。",
+      "additionalEmailResendAriaLabel": "{{email}} に確認メールを再送信",
+      "additionalEmailVerifiedAriaLabel": "{{email}} は確認済みです"
     },
     "notifications": {
       "title": "通知設定",
@@ -292,5 +299,16 @@
     "linked": "Cognito連携済み",
     "notLinked": "Cognitoアカウントなし",
     "tooltip": "Cognitoアカウントあり"
+  },
+  "verifyEmail": {
+    "title": "メールアドレスを確認してください",
+    "loading": "確認リンクを確認しています…",
+    "confirmMessage": "{{email}} があなたのメールアドレスであることを確認してください。",
+    "confirmButton": "メールアドレスを確認",
+    "success": "メールアドレスが確認されました。このページを閉じてかまいません。",
+    "alreadyVerified": "このメールアドレスはすでに確認済みです。",
+    "homeLink": "batbern.ch へ移動",
+    "invalidToken": "この確認リンクは無効または期限切れです。アカウント設定から新しいリンクをリクエストしてください。",
+    "notFound": "このメールアドレスは、追加された元のプロフィールにはもう登録されていません。再度追加した場合は、最新の確認メールのリンクをご利用ください。"
   }
 }

--- a/web-frontend/public/locales/nl/userManagement.json
+++ b/web-frontend/public/locales/nl/userManagement.json
@@ -229,7 +229,14 @@
       "additionalEmailRemoveConfirmCancel": "Annuleren",
       "additionalEmailDeleteFailed": "Kon dit extra e-mailadres niet verwijderen. Probeer het opnieuw.",
       "additionalEmailDeleteNotFound": "Dit extra e-mailadres staat niet meer in je profiel.",
-      "additionalEmailDeleteAriaLabel": "Extra e-mailadres {{email}} verwijderen"
+      "additionalEmailDeleteAriaLabel": "Extra e-mailadres {{email}} verwijderen",
+      "additionalEmailVerifiedPill": "Geverifieerd",
+      "additionalEmailResendButton": "Opnieuw verzenden",
+      "additionalEmailResendSuccess": "Verificatie-e-mail verzonden.",
+      "additionalEmailResendFailed": "Kan de verificatie-e-mail niet verzenden. Probeer het opnieuw.",
+      "additionalEmailResendAlreadyVerified": "Dit e-mailadres is al geverifieerd.",
+      "additionalEmailResendAriaLabel": "Verificatie-e-mail opnieuw verzenden naar {{email}}",
+      "additionalEmailVerifiedAriaLabel": "{{email}} is geverifieerd"
     },
     "notifications": {
       "title": "Meldingsvoorkeuren",
@@ -292,5 +299,16 @@
     "linked": "Cognito gekoppeld",
     "notLinked": "Geen Cognito-account",
     "tooltip": "Cognito-account gekoppeld"
+  },
+  "verifyEmail": {
+    "title": "Bevestig uw e-mailadres",
+    "loading": "Uw verificatielink wordt gecontroleerd…",
+    "confirmMessage": "Bevestig dat {{email}} uw e-mailadres is.",
+    "confirmButton": "E-mailadres bevestigen",
+    "success": "Uw e-mailadres is bevestigd. U kunt deze pagina sluiten.",
+    "alreadyVerified": "Dit e-mailadres is al bevestigd.",
+    "homeLink": "Ga naar batbern.ch",
+    "invalidToken": "Deze verificatielink is ongeldig of verlopen. Vraag een nieuwe aan in uw accountinstellingen.",
+    "notFound": "Dit e-mailadres staat niet meer op het profiel waaraan het was toegevoegd. Als u het opnieuw hebt toegevoegd, gebruik dan de link uit de nieuwste verificatie-e-mail."
   }
 }

--- a/web-frontend/public/locales/rm/userManagement.json
+++ b/web-frontend/public/locales/rm/userManagement.json
@@ -229,7 +229,14 @@
       "additionalEmailRemoveConfirmCancel": "Interrumper",
       "additionalEmailDeleteFailed": "Impussibel da stizzar questa e-mail supplementara. Empruvescha danovamain.",
       "additionalEmailDeleteNotFound": "Questa e-mail supplementara n'è betg pli en tes profil.",
-      "additionalEmailDeleteAriaLabel": "Stizzar e-mail supplementara {{email}}"
+      "additionalEmailDeleteAriaLabel": "Stizzar e-mail supplementara {{email}}",
+      "additionalEmailVerifiedPill": "Verifitgà",
+      "additionalEmailResendButton": "Trametter danovamain",
+      "additionalEmailResendSuccess": "E-mail da verificaziun tramessa.",
+      "additionalEmailResendFailed": "Impussibel da trametter l'e-mail da verificaziun. Empruvai anc ina giada.",
+      "additionalEmailResendAlreadyVerified": "Questa adressa d'e-mail è gia verifitgada.",
+      "additionalEmailResendAriaLabel": "Trametter danovamain l'e-mail da verificaziun a {{email}}",
+      "additionalEmailVerifiedAriaLabel": "{{email}} è verifitgà"
     },
     "notifications": {
       "title": "Preferenzas da notificaziun",
@@ -292,5 +299,16 @@
     "linked": "Cognito collià",
     "notLinked": "Nagin conto Cognito",
     "tooltip": "Conto Cognito collià"
+  },
+  "verifyEmail": {
+    "title": "Confermai Vossa adressa d'e-mail",
+    "loading": "Vossa colliaziun da verificaziun vegn controllada…",
+    "confirmMessage": "Confermai che {{email}} è Vossa adressa d'e-mail.",
+    "confirmButton": "Confermar l'adressa d'e-mail",
+    "success": "Vossa adressa d'e-mail è vegnida confermada. Vus pudais serrar questa pagina.",
+    "alreadyVerified": "Questa adressa d'e-mail è gia confermada.",
+    "homeLink": "Ir a batbern.ch",
+    "invalidToken": "Questa colliaziun da verificaziun è nunvalida u scadida. Dumandai per plaschair ina nova en Vossas configuraziuns dal conto.",
+    "notFound": "Questa adressa d'e-mail n'è betg pli sin il profil al qual ella è vegnida agiuntada. Sche Vus l'avais agiuntada danovamain, dovrai la colliaziun da l'ultim e-mail da verificaziun."
   }
 }

--- a/web-frontend/src/App.tsx
+++ b/web-frontend/src/App.tsx
@@ -160,6 +160,11 @@ const SpeakerDashboardPage = React.lazy(() => import('@pages/speaker-portal/Spea
 // Story 10.7: Newsletter unsubscribe page
 const UnsubscribePage = React.lazy(() => import('@pages/public/UnsubscribePage'));
 
+// Additional-email verification (v2): public token-credentialed verify page
+const VerifyAdditionalEmailPage = React.lazy(
+  () => import('@pages/public/VerifyAdditionalEmailPage')
+);
+
 // Story 10.12: Self-service deregistration page
 const DeregistrationPage = React.lazy(() => import('@pages/public/DeregistrationPage'));
 
@@ -344,6 +349,9 @@ function App() {
 
                     {/* Story 10.7: Newsletter unsubscribe */}
                     <Route path="/unsubscribe" element={<UnsubscribePage />} />
+
+                    {/* Additional-email verification (v2): public token-credentialed verify */}
+                    <Route path="/verify-email" element={<VerifyAdditionalEmailPage />} />
 
                     {/* Story 10.12: Self-service deregistration (token-protected, no auth required) */}
                     <Route path="/deregister" element={<DeregistrationPage />} />

--- a/web-frontend/src/App.tsx
+++ b/web-frontend/src/App.tsx
@@ -709,9 +709,9 @@ function App() {
                       }
                     />
 
-                    {/* User Account Page - Story 2.6 */}
+                    {/* User Account Page - Story 2.6; :tab? = profile (default) | settings */}
                     <Route
-                      path="/account"
+                      path="/account/:tab?"
                       element={
                         <ProtectedRoute>
                           <AuthLayout>

--- a/web-frontend/src/components/auth/RegistrationStep1/RegistrationStep1.test.tsx
+++ b/web-frontend/src/components/auth/RegistrationStep1/RegistrationStep1.test.tsx
@@ -12,12 +12,47 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { I18nextProvider } from 'react-i18next';
 import { FormProvider, useForm } from 'react-hook-form';
 import i18n from '@/i18n/config';
+import { ConfigProvider } from '@/contexts/ConfigContext';
+import type { AppConfig } from '@/config/runtime-config';
+
+// Mock authService (the Google SSO button calls authService.signInWithFederated).
+// vi.hoisted is required because the mock factory references the fn eagerly.
+const mockSignInWithFederated = vi.hoisted(() => vi.fn());
+vi.mock('@/services/auth/authService', () => ({
+  authService: { signInWithFederated: mockSignInWithFederated },
+}));
 
 // Create theme for MUI components
 const theme = createTheme();
 
-// Wrapper component for FormProvider
-const FormWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+// Mock config — `features.sso` gates the "Continue with Google" button
+const mockConfig: AppConfig = {
+  environment: 'development',
+  apiBaseUrl: 'http://localhost:8080/api/v1',
+  cognito: {
+    userPoolId: 'eu-central-1_XXXXXXXXX',
+    clientId: 'XXXXXXXXXXXXXXXXXXXXXXXXXX',
+    region: 'eu-central-1',
+  },
+  features: {
+    notifications: true,
+    analytics: false,
+    pwa: false,
+    turnstile: false,
+    sso: false,
+  },
+};
+
+const ssoOnConfig: AppConfig = {
+  ...mockConfig,
+  features: { ...mockConfig.features, sso: true },
+};
+
+// Wrapper component for FormProvider (+ ConfigProvider for the useFeature('sso') gate)
+const FormWrapper: React.FC<{ children: React.ReactNode; config?: AppConfig }> = ({
+  children,
+  config = mockConfig,
+}) => {
   const methods = useForm({
     defaultValues: {
       firstName: '',
@@ -30,11 +65,13 @@ const FormWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   });
 
   return (
-    <I18nextProvider i18n={i18n}>
-      <ThemeProvider theme={theme}>
-        <FormProvider {...methods}>{children}</FormProvider>
-      </ThemeProvider>
-    </I18nextProvider>
+    <ConfigProvider config={config}>
+      <I18nextProvider i18n={i18n}>
+        <ThemeProvider theme={theme}>
+          <FormProvider {...methods}>{children}</FormProvider>
+        </ThemeProvider>
+      </I18nextProvider>
+    </ConfigProvider>
   );
 };
 
@@ -456,5 +493,55 @@ describe('RegistrationStep1 Component', () => {
     expect(family.compareDocumentPosition(given) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     await i18n.changeLanguage('en');
+  });
+
+  // "Continue with Google" on the registration form, gated on features.sso —
+  // same entry point as LoginForm so registering does not require the 2-step wizard.
+  describe('Continue with Google button (features.sso)', () => {
+    it('should_renderGoogleButton_when_ssoFeatureEnabled', async () => {
+      await act(async () => {
+        render(
+          <FormWrapper config={ssoOnConfig}>
+            <RegistrationStep1 onContinue={mockOnContinue} />
+          </FormWrapper>
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('register-with-google')).toBeInTheDocument();
+      });
+    });
+
+    it('should_notRenderGoogleButton_when_ssoFeatureDisabled', async () => {
+      await act(async () => {
+        render(
+          <FormWrapper>
+            <RegistrationStep1 onContinue={mockOnContinue} />
+          </FormWrapper>
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('register-with-google')).not.toBeInTheDocument();
+    });
+
+    it('should_callSignInWithFederatedGoogle_when_googleButtonClicked', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(
+          <FormWrapper config={ssoOnConfig}>
+            <RegistrationStep1 onContinue={mockOnContinue} />
+          </FormWrapper>
+        );
+      });
+
+      const googleButton = await screen.findByTestId('register-with-google');
+      await user.click(googleButton);
+
+      expect(mockSignInWithFederated).toHaveBeenCalledTimes(1);
+      expect(mockSignInWithFederated).toHaveBeenCalledWith('Google');
+    });
   });
 });

--- a/web-frontend/src/components/auth/RegistrationStep1/RegistrationStep1.tsx
+++ b/web-frontend/src/components/auth/RegistrationStep1/RegistrationStep1.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { useFormContext } from 'react-hook-form';
 import {
   Box,
+  Divider,
   TextField,
   IconButton,
   InputAdornment,
@@ -26,7 +27,15 @@ import {
   LinearProgress,
   Button,
 } from '@mui/material';
-import { Visibility, VisibilityOff, CheckCircle, RadioButtonUnchecked } from '@mui/icons-material';
+import {
+  Visibility,
+  VisibilityOff,
+  CheckCircle,
+  RadioButtonUnchecked,
+  Google,
+} from '@mui/icons-material';
+import { useFeature } from '@/contexts/useFeature';
+import { authService } from '@/services/auth/authService';
 import * as passwordStrength from '../../../utils/passwordStrength/passwordStrength';
 
 const { checkPasswordRequirements, calculatePasswordStrength } = passwordStrength;
@@ -45,6 +54,9 @@ export const RegistrationStep1: React.FC<RegistrationStep1Props> = ({ onContinue
   const { t, i18n } = useTranslation('auth');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  // Story 12.9 follow-up: same flag-gated Google SSO entry as LoginForm — registering
+  // via Google skips the whole wizard (JIT provisioning + ToS consent gate handle the rest).
+  const ssoEnabled = useFeature('sso');
 
   const {
     register,
@@ -165,6 +177,22 @@ export const RegistrationStep1: React.FC<RegistrationStep1Props> = ({ onContinue
       <Typography variant="h5" gutterBottom>
         {t('register.step1.title')}
       </Typography>
+
+      {ssoEnabled && (
+        <>
+          <Button
+            variant="outlined"
+            fullWidth
+            startIcon={<Google />}
+            onClick={() => authService.signInWithFederated('Google')}
+            sx={{ mt: 1, mb: 1 }}
+            data-testid="register-with-google"
+          >
+            {t('login.continueWithGoogle')}
+          </Button>
+          <Divider sx={{ my: 2 }}>{t('login.orDivider')}</Divider>
+        </>
+      )}
 
       {familyNameFirst ? (
         <>

--- a/web-frontend/src/components/auth/RegistrationWizard/RegistrationWizard.test.tsx
+++ b/web-frontend/src/components/auth/RegistrationWizard/RegistrationWizard.test.tsx
@@ -13,9 +13,29 @@ import { I18nextProvider } from 'react-i18next';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import i18n from '@/i18n/config';
+import { ConfigProvider } from '@/contexts/ConfigContext';
+import type { AppConfig } from '@/config/runtime-config';
 
 // Create theme for MUI components
 const theme = createTheme();
+
+// Minimal config — Step1 reads useFeature('sso'); sso:false keeps the wizard DOM unchanged
+const mockConfig: AppConfig = {
+  environment: 'development',
+  apiBaseUrl: 'http://localhost:8080/api/v1',
+  cognito: {
+    userPoolId: 'eu-central-1_XXXXXXXXX',
+    clientId: 'XXXXXXXXXXXXXXXXXXXXXXXXXX',
+    region: 'eu-central-1',
+  },
+  features: {
+    notifications: true,
+    analytics: false,
+    pwa: false,
+    turnstile: false,
+    sso: false,
+  },
+};
 
 // Mock useNavigate
 const mockNavigate = vi.fn();
@@ -50,13 +70,15 @@ const AllProviders: React.FC<{ children: React.ReactNode; initialEntries?: strin
   });
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={initialEntries}>
-        <I18nextProvider i18n={i18n}>
-          <ThemeProvider theme={theme}>{children}</ThemeProvider>
-        </I18nextProvider>
-      </MemoryRouter>
-    </QueryClientProvider>
+    <ConfigProvider config={mockConfig}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <I18nextProvider i18n={i18n}>
+            <ThemeProvider theme={theme}>{children}</ThemeProvider>
+          </I18nextProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ConfigProvider>
   );
 };
 

--- a/web-frontend/src/components/shared/Navigation/UserMenuDropdown.test.tsx
+++ b/web-frontend/src/components/shared/Navigation/UserMenuDropdown.test.tsx
@@ -248,6 +248,7 @@ describe('UserMenuDropdown', () => {
       }
 
       await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/account/profile');
         expect(mockOnClose).toHaveBeenCalled();
       });
     });
@@ -273,6 +274,7 @@ describe('UserMenuDropdown', () => {
       }
 
       await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/account/settings');
         expect(mockOnClose).toHaveBeenCalled();
       });
     });

--- a/web-frontend/src/components/shared/Navigation/UserMenuDropdown.tsx
+++ b/web-frontend/src/components/shared/Navigation/UserMenuDropdown.tsx
@@ -43,15 +43,7 @@ const UserMenuDropdown: React.FC<UserMenuDropdownProps> = ({
   const { t, i18n } = useTranslation();
 
   const handleProfileClick = () => {
-    console.log('[UserMenuDropdown] Profile clicked, navigating to /account');
-    console.log('[UserMenuDropdown] navigate function:', navigate);
-    console.log('[UserMenuDropdown] Current location:', window.location.pathname);
-    try {
-      navigate('/account');
-      console.log('[UserMenuDropdown] Navigation called successfully');
-    } catch (error) {
-      console.error('[UserMenuDropdown] Navigation error:', error);
-    }
+    navigate('/account/profile');
     onClose();
   };
 
@@ -61,14 +53,7 @@ const UserMenuDropdown: React.FC<UserMenuDropdownProps> = ({
   };
 
   const handleSettingsClick = () => {
-    console.log('[UserMenuDropdown] Settings clicked, navigating to /account');
-    console.log('[UserMenuDropdown] navigate function:', navigate);
-    try {
-      navigate('/account');
-      console.log('[UserMenuDropdown] Navigation called successfully');
-    } catch (error) {
-      console.error('[UserMenuDropdown] Navigation error:', error);
-    }
+    navigate('/account/settings');
     onClose();
   };
 
@@ -136,6 +121,14 @@ const UserMenuDropdown: React.FC<UserMenuDropdownProps> = ({
         <ListItemText>{t('menu.profile')}</ListItemText>
       </MenuItem>
 
+      {/* Settings Menu Item */}
+      <MenuItem onClick={handleSettingsClick} role="menuitem">
+        <ListItemIcon>
+          <SettingsIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>{t('menu.settings')}</ListItemText>
+      </MenuItem>
+
       {/* Administration Menu Item - organizer only (Story 10.1; Story 11.E.3 multi-role aware) */}
       {(user.roles ?? (user.role ? [user.role] : [])).includes('organizer') && (
         <MenuItem
@@ -149,14 +142,6 @@ const UserMenuDropdown: React.FC<UserMenuDropdownProps> = ({
           <ListItemText>{t('menu.administration')}</ListItemText>
         </MenuItem>
       )}
-
-      {/* Settings Menu Item */}
-      <MenuItem onClick={handleSettingsClick} role="menuitem">
-        <ListItemIcon>
-          <SettingsIcon fontSize="small" />
-        </ListItemIcon>
-        <ListItemText>{t('menu.settings')}</ListItemText>
-      </MenuItem>
 
       {/* Language Switcher */}
       <Box sx={{ px: 2, py: 1.5 }}>

--- a/web-frontend/src/components/user/UserSettingsTab/UserSettingsTab.test.tsx
+++ b/web-frontend/src/components/user/UserSettingsTab/UserSettingsTab.test.tsx
@@ -26,6 +26,7 @@ vi.mock('react-i18next', () => ({
 
 const mockAddMutate = vi.fn();
 const mockDeleteMutate = vi.fn();
+const mockResendMutate = vi.fn();
 
 vi.mock('@/hooks/useUserAccount/useUserAccount', () => ({
   useUpdateUserPreferences: () => ({ mutateAsync: vi.fn(), isPending: false }),
@@ -36,6 +37,10 @@ vi.mock('@/hooks/useUserAccount/useUserAccount', () => ({
   }),
   useDeleteAdditionalEmail: () => ({
     mutateAsync: mockDeleteMutate,
+    isPending: false,
+  }),
+  useResendVerification: () => ({
+    mutateAsync: mockResendMutate,
     isPending: false,
   }),
 }));
@@ -58,6 +63,7 @@ describe('UserSettingsTab — Story 10.32 additional emails section', () => {
   beforeEach(() => {
     mockAddMutate.mockReset();
     mockDeleteMutate.mockReset();
+    mockResendMutate.mockReset();
   });
 
   test('should render the additional-emails section heading', () => {
@@ -248,5 +254,57 @@ describe('UserSettingsTab — responsive sub-tabs (organizer mobile)', () => {
     const accountTab = screen.getByRole('tab', { name: /settings\.tabs\.account/ });
     // Desktop shows the textual label alongside the icon.
     expect(accountTab).toHaveTextContent('settings.tabs.account');
+  });
+
+  // Additional-email verification (v2)
+
+  test('should render verified pill (no resend) for a verified additional email', () => {
+    renderWithProviders([
+      {
+        email: 'box@example.com',
+        label: null,
+        createdAt: '2026-06-06T10:00:00Z',
+        verifiedAt: '2026-06-06T11:00:00Z',
+      },
+    ]);
+    expect(screen.getByTestId('additional-email-verified-box@example.com')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('additional-email-unverified-box@example.com')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('additional-email-resend-box@example.com')).not.toBeInTheDocument();
+  });
+
+  test('should render unverified pill + resend link for an unverified additional email', () => {
+    renderWithProviders([
+      {
+        email: 'box@example.com',
+        label: null,
+        createdAt: '2026-06-06T10:00:00Z',
+        verifiedAt: null,
+      },
+    ]);
+    expect(screen.getByTestId('additional-email-unverified-box@example.com')).toBeInTheDocument();
+    expect(screen.getByTestId('additional-email-resend-box@example.com')).toBeInTheDocument();
+  });
+
+  test('should call resendVerification when the Resend link is clicked', async () => {
+    mockResendMutate.mockResolvedValueOnce(undefined);
+    renderWithProviders([
+      {
+        email: 'box@example.com',
+        label: null,
+        createdAt: '2026-06-06T10:00:00Z',
+        verifiedAt: null,
+      },
+    ]);
+
+    fireEvent.click(screen.getByTestId('additional-email-resend-box@example.com'));
+
+    await waitFor(() => {
+      expect(mockResendMutate).toHaveBeenCalledWith('box@example.com');
+    });
+    expect(
+      await screen.findByText('settings.account.additionalEmailResendSuccess')
+    ).toBeInTheDocument();
   });
 });

--- a/web-frontend/src/components/user/UserSettingsTab/UserSettingsTab.tsx
+++ b/web-frontend/src/components/user/UserSettingsTab/UserSettingsTab.tsx
@@ -43,6 +43,7 @@ import type { AdditionalEmail, UserPreferences, UserSettings } from '@/types/use
 import {
   useAddAdditionalEmail,
   useDeleteAdditionalEmail,
+  useResendVerification,
   useUpdateUserPreferences,
   useUpdateUserSettings,
 } from '@/hooks/useUserAccount/useUserAccount';
@@ -92,6 +93,7 @@ function AdditionalEmailsSection({ additionalEmails }: { additionalEmails: Addit
   const { isMobile } = useBreakpoints();
   const addMutation = useAddAdditionalEmail();
   const deleteMutation = useDeleteAdditionalEmail();
+  const resendMutation = useResendVerification();
   const [emailInput, setEmailInput] = useState('');
   const [labelInput, setLabelInput] = useState('');
   const [inlineError, setInlineError] = useState<string | null>(null);
@@ -198,6 +200,35 @@ function AdditionalEmailsSection({ additionalEmails }: { additionalEmails: Addit
     }
   }
 
+  async function handleResend(email: string) {
+    // MUI <Link component="button"> does not reliably honour the `disabled` prop, so a
+    // rapid double-click could fire two resend requests (and two emails). Guard the
+    // handler explicitly while a resend is in flight.
+    if (resendMutation.isPending) {
+      return;
+    }
+    try {
+      await resendMutation.mutateAsync(email);
+      setToast({
+        message: t('settings.account.additionalEmailResendSuccess'),
+        severity: 'success',
+      });
+    } catch (err) {
+      const code = readErrorCode(err);
+      if (code === 'ALREADY_VERIFIED') {
+        setToast({
+          message: t('settings.account.additionalEmailResendAlreadyVerified'),
+          severity: 'error',
+        });
+      } else {
+        setToast({
+          message: t('settings.account.additionalEmailResendFailed'),
+          severity: 'error',
+        });
+      }
+    }
+  }
+
   return (
     <Box sx={{ mt: 4 }} data-testid="additional-emails-section">
       <Typography variant="subtitle1" gutterBottom>
@@ -232,11 +263,42 @@ function AdditionalEmailsSection({ additionalEmails }: { additionalEmails: Addit
                 primary={
                   <Stack direction="row" spacing={1} alignItems="center">
                     <span>{entry.email}</span>
-                    {entry.verifiedAt === null && (
+                    {entry.verifiedAt === null ? (
+                      <>
+                        <Chip
+                          size="small"
+                          color="warning"
+                          label={t('settings.account.additionalEmailUnverifiedPill')}
+                          data-testid={`additional-email-unverified-${entry.email}`}
+                        />
+                        <Link
+                          component="button"
+                          type="button"
+                          variant="caption"
+                          underline="always"
+                          data-testid={`additional-email-resend-${entry.email}`}
+                          aria-label={t('settings.account.additionalEmailResendAriaLabel', {
+                            email: entry.email,
+                          })}
+                          aria-disabled={resendMutation.isPending}
+                          onClick={() => handleResend(entry.email)}
+                          sx={{
+                            pointerEvents: resendMutation.isPending ? 'none' : 'auto',
+                            opacity: resendMutation.isPending ? 0.5 : 1,
+                          }}
+                        >
+                          {t('settings.account.additionalEmailResendButton')}
+                        </Link>
+                      </>
+                    ) : (
                       <Chip
                         size="small"
-                        label={t('settings.account.additionalEmailUnverifiedPill')}
-                        data-testid={`additional-email-unverified-${entry.email}`}
+                        color="success"
+                        label={t('settings.account.additionalEmailVerifiedPill')}
+                        data-testid={`additional-email-verified-${entry.email}`}
+                        aria-label={t('settings.account.additionalEmailVerifiedAriaLabel', {
+                          email: entry.email,
+                        })}
                       />
                     )}
                   </Stack>

--- a/web-frontend/src/hooks/useAdditionalEmailVerification/useAdditionalEmailVerification.ts
+++ b/web-frontend/src/hooks/useAdditionalEmailVerification/useAdditionalEmailVerification.ts
@@ -1,0 +1,42 @@
+/**
+ * Additional-email verification (v2) hooks.
+ *
+ * React Query hooks for the public /verify-email landing page: GET-check the
+ * token (no mutation) and POST-confirm it. Mirrors the useNewsletter
+ * verify/unsubscribe pattern.
+ */
+
+import {
+  useMutation,
+  useQuery,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import * as userAccountApi from '@/services/api/userAccountApi';
+import type {
+  AdditionalEmailVerificationCheck,
+  AdditionalEmailVerificationConfirm,
+} from '@/services/api/userAccountApi';
+
+/** GET-check the verification token (no mutation) — returns masked email + status. */
+export function useCheckAdditionalEmailVerification(
+  token: string | null
+): UseQueryResult<AdditionalEmailVerificationCheck, Error> {
+  return useQuery({
+    queryKey: ['additional-email-verify', 'check', token],
+    queryFn: () => userAccountApi.checkAdditionalEmailVerification(token!),
+    enabled: !!token,
+    retry: false,
+  });
+}
+
+/** POST-confirm the verification token (mutates). */
+export function useConfirmAdditionalEmailVerification(): UseMutationResult<
+  AdditionalEmailVerificationConfirm,
+  Error,
+  string
+> {
+  return useMutation({
+    mutationFn: userAccountApi.confirmAdditionalEmailVerification,
+  });
+}

--- a/web-frontend/src/hooks/useUserAccount/useUserAccount.ts
+++ b/web-frontend/src/hooks/useUserAccount/useUserAccount.ts
@@ -179,3 +179,18 @@ export const useDeleteAdditionalEmail = () => {
     },
   });
 };
+
+/**
+ * Additional-email verification (v2) — resend the verification email for one of
+ * the caller's own unverified additional emails. Invalidates the user-profile
+ * cache so any status changes are reflected.
+ */
+export const useResendVerification = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (email: string) => userAccountApi.resendAdditionalEmailVerification(email),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-profile'] });
+    },
+  });
+};

--- a/web-frontend/src/pages/UserAccountPage/UserAccountPage.test.tsx
+++ b/web-frontend/src/pages/UserAccountPage/UserAccountPage.test.tsx
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import UserAccountPage from './UserAccountPage';
 
 // Mock the child components
@@ -71,7 +71,7 @@ vi.mock('@/hooks/useUserAccount/useUserAccount', () => ({
   }),
 }));
 
-const createWrapper = () => {
+const createWrapper = (initialEntry = '/account') => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -79,11 +79,16 @@ const createWrapper = () => {
     },
   });
 
+  // Mount behind the real route shape so useParams-driven tab state works
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
-      <BrowserRouter>
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      </BrowserRouter>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <QueryClientProvider client={queryClient}>
+          <Routes>
+            <Route path="/account/:tab?" element={children} />
+          </Routes>
+        </QueryClientProvider>
+      </MemoryRouter>
     );
   };
 };
@@ -111,6 +116,19 @@ describe('UserAccountPage', () => {
 
     // Profile content should be visible
     expect(screen.getByTestId('user-profile-tab')).toBeInTheDocument();
+  });
+
+  it('should_openSettingsTab_when_deepLinkedToAccountSettings', async () => {
+    // Tab state is URL-driven: /account/settings selects the Settings tab directly
+    render(<UserAccountPage />, { wrapper: createWrapper('/account/settings') });
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /settings/i })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+    expect(screen.getByTestId('user-settings-tab')).toBeInTheDocument();
   });
 
   it('should_switchToSettingsTab_when_settingsTabClicked', async () => {

--- a/web-frontend/src/pages/UserAccountPage/UserAccountPage.tsx
+++ b/web-frontend/src/pages/UserAccountPage/UserAccountPage.tsx
@@ -4,7 +4,8 @@
  * Main page container with Profile and Settings tabs
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Box, Tabs, Tab, Alert } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@hooks/useAuth';
@@ -49,7 +50,11 @@ const UserAccountPage: React.FC = () => {
   const { user } = useAuth();
   console.log('[UserAccountPage] User:', user);
   const { t } = useTranslation('common');
-  const [activeTab, setActiveTab] = useState(0);
+  const navigate = useNavigate();
+  // Tab state lives in the URL (/account/profile | /account/settings) so both
+  // tabs are deep-linkable from the user menu; unknown or missing → profile.
+  const { tab } = useParams<{ tab?: string }>();
+  const activeTab = tab === 'settings' ? 1 : 0;
 
   const { data: profileData, isLoading, isError, error } = useUserProfile(user?.userId || '');
   console.log('[UserAccountPage] Profile data:', { profileData, isLoading, isError, error });
@@ -62,7 +67,7 @@ const UserAccountPage: React.FC = () => {
   );
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
-    setActiveTab(newValue);
+    navigate(newValue === 1 ? '/account/settings' : '/account/profile', { replace: true });
   };
 
   if (isLoading) {

--- a/web-frontend/src/pages/public/VerifyAdditionalEmailPage.tsx
+++ b/web-frontend/src/pages/public/VerifyAdditionalEmailPage.tsx
@@ -1,0 +1,148 @@
+/**
+ * VerifyAdditionalEmailPage (Additional-email verification v2)
+ *
+ * Public page at /verify-email?token={token}.
+ * GET-checks the token (no mutation), shows the masked email, and confirms on
+ * button click (POST). Mirrors the newsletter UnsubscribePage verify→confirm
+ * landing-page pattern.
+ */
+
+import { useEffect, useState } from 'react';
+import { useSearchParams, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { isAxiosError } from 'axios';
+import { PublicLayout } from '@/components/public/PublicLayout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/public/ui/card';
+import { Button } from '@/components/public/ui/button';
+import {
+  useCheckAdditionalEmailVerification,
+  useConfirmAdditionalEmailVerification,
+} from '@/hooks/useAdditionalEmailVerification/useAdditionalEmailVerification';
+
+type PageState = 'verifying' | 'ready' | 'confirmed' | 'alreadyVerified' | 'invalid' | 'notFound';
+
+export default function VerifyAdditionalEmailPage() {
+  const { t } = useTranslation('userManagement');
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+  const [pageState, setPageState] = useState<PageState>('verifying');
+
+  const checkQuery = useCheckAdditionalEmailVerification(token);
+  const confirmMutation = useConfirmAdditionalEmailVerification();
+
+  const checkIsSuccess = checkQuery.isSuccess;
+  const checkIsError = checkQuery.isError;
+  const checkVerified = checkQuery.data?.verified;
+
+  // Drive the verifying → ready/alreadyVerified/invalid transition from an effect
+  // (keyed on the check-query result) rather than from the render body, so we never
+  // call setState during render and the behaviour is StrictMode double-invoke safe.
+  useEffect(() => {
+    if (pageState !== 'verifying') {
+      return;
+    }
+    if (!token || checkIsError) {
+      setPageState('invalid');
+    } else if (checkIsSuccess) {
+      setPageState(checkVerified ? 'alreadyVerified' : 'ready');
+    }
+  }, [pageState, token, checkIsSuccess, checkIsError, checkVerified]);
+
+  function handleConfirm() {
+    if (!token) {
+      return;
+    }
+    confirmMutation.mutate(token, {
+      onSuccess: (data) => setPageState(data.alreadyVerified ? 'alreadyVerified' : 'confirmed'),
+      onError: (error) => {
+        // 404 means the additional-email row was deleted (or deleted-then-re-added,
+        // minting a fresh token) since this link was issued — "request a new link" is
+        // misleading advice here, so branch to a distinct message. Everything else
+        // (400 invalid/expired token, network errors) falls through to the generic
+        // invalid state.
+        if (isAxiosError(error) && error.response?.status === 404) {
+          setPageState('notFound');
+        } else {
+          setPageState('invalid');
+        }
+      },
+    });
+  }
+
+  const email = checkQuery.data?.email;
+
+  return (
+    <PublicLayout>
+      <div className="flex min-h-[50vh] items-center justify-center px-4 py-12">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle>{t('verifyEmail.title')}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {pageState === 'verifying' && (
+              <p className="text-sm text-muted-foreground" data-testid="verify-email-loading">
+                {t('verifyEmail.loading')}
+              </p>
+            )}
+
+            {pageState === 'ready' && email && (
+              <>
+                <p className="text-sm" data-testid="verify-email-confirm-message">
+                  {t('verifyEmail.confirmMessage', { email })}
+                </p>
+                <Button
+                  onClick={handleConfirm}
+                  disabled={confirmMutation.isPending}
+                  className="w-full"
+                  data-testid="verify-email-confirm-button"
+                >
+                  {t('verifyEmail.confirmButton')}
+                </Button>
+              </>
+            )}
+
+            {pageState === 'confirmed' && (
+              <div className="space-y-2">
+                <p
+                  className="text-sm text-green-700 dark:text-green-400"
+                  data-testid="verify-email-success"
+                >
+                  {t('verifyEmail.success')}
+                </p>
+                <Link to="/" className="text-sm text-primary underline">
+                  {t('verifyEmail.homeLink')}
+                </Link>
+              </div>
+            )}
+
+            {pageState === 'alreadyVerified' && (
+              <div className="space-y-2">
+                <p
+                  className="text-sm text-green-700 dark:text-green-400"
+                  data-testid="verify-email-already-verified"
+                >
+                  {t('verifyEmail.alreadyVerified')}
+                </p>
+                <Link to="/" className="text-sm text-primary underline">
+                  {t('verifyEmail.homeLink')}
+                </Link>
+              </div>
+            )}
+
+            {pageState === 'invalid' && (
+              <p className="text-sm text-destructive" data-testid="verify-email-invalid">
+                {t('verifyEmail.invalidToken')}
+              </p>
+            )}
+
+            {pageState === 'notFound' && (
+              <p className="text-sm text-destructive" data-testid="verify-email-not-found">
+                {t('verifyEmail.notFound')}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </PublicLayout>
+  );
+}

--- a/web-frontend/src/pages/public/__tests__/VerifyAdditionalEmailPage.test.tsx
+++ b/web-frontend/src/pages/public/__tests__/VerifyAdditionalEmailPage.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * VerifyAdditionalEmailPage Tests (Additional-email verification v2)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import VerifyAdditionalEmailPage from '../VerifyAdditionalEmailPage';
+
+vi.mock('@/hooks/useAdditionalEmailVerification/useAdditionalEmailVerification', () => ({
+  useCheckAdditionalEmailVerification: vi.fn(),
+  useConfirmAdditionalEmailVerification: vi.fn(),
+}));
+
+vi.mock('@/components/public/PublicLayout', () => ({
+  PublicLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      const map: Record<string, string> = {
+        'verifyEmail.title': 'Confirm your email address',
+        'verifyEmail.loading': 'Checking your verification link…',
+        'verifyEmail.confirmMessage': 'Confirm that {{email}} is your email address.',
+        'verifyEmail.confirmButton': 'Confirm email address',
+        'verifyEmail.success': 'Your email address has been confirmed. You can close this page.',
+        'verifyEmail.alreadyVerified': 'This email address is already confirmed.',
+        'verifyEmail.homeLink': 'Go to batbern.ch',
+        'verifyEmail.invalidToken':
+          'This verification link is invalid or has expired. Please request a new one from your account settings.',
+        'verifyEmail.notFound':
+          'This email address is no longer on the profile it was added to. If you re-added it, use the link from the newest verification email.',
+      };
+      if (opts) {
+        return map[key]?.replace(/\{\{(\w+)\}\}/g, (_, k: string) => String(opts[k] ?? '')) ?? key;
+      }
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+import {
+  useCheckAdditionalEmailVerification,
+  useConfirmAdditionalEmailVerification,
+} from '@/hooks/useAdditionalEmailVerification/useAdditionalEmailVerification';
+
+function renderPage(token?: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const url = token ? `/verify-email?token=${token}` : '/verify-email';
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <QueryClientProvider client={queryClient}>
+        <VerifyAdditionalEmailPage />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('VerifyAdditionalEmailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the confirm button when the token check succeeds (unverified)', async () => {
+    vi.mocked(useCheckAdditionalEmailVerification).mockReturnValue({
+      isSuccess: true,
+      isError: false,
+      data: { email: 'in***@example.com', verified: false },
+    } as ReturnType<typeof useCheckAdditionalEmailVerification>);
+    vi.mocked(useConfirmAdditionalEmailVerification).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as ReturnType<typeof useConfirmAdditionalEmailVerification>);
+
+    renderPage('valid-token');
+
+    await waitFor(() => {
+      expect(screen.getByText('Confirm email address')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/in\*\*\*@example.com/)).toBeInTheDocument();
+  });
+
+  it('shows success after confirming', async () => {
+    let onSuccess: ((d: { alreadyVerified: boolean }) => void) | undefined;
+    const mockMutate = vi.fn(
+      (_token: string, opts?: { onSuccess?: (d: { alreadyVerified: boolean }) => void }) => {
+        onSuccess = opts?.onSuccess;
+      }
+    );
+    vi.mocked(useCheckAdditionalEmailVerification).mockReturnValue({
+      isSuccess: true,
+      isError: false,
+      data: { email: 'in***@example.com', verified: false },
+    } as ReturnType<typeof useCheckAdditionalEmailVerification>);
+    vi.mocked(useConfirmAdditionalEmailVerification).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    } as ReturnType<typeof useConfirmAdditionalEmailVerification>);
+
+    renderPage('valid-token');
+    await waitFor(() => {
+      expect(screen.getByText('Confirm email address')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Confirm email address'));
+    onSuccess?.({ alreadyVerified: false });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Your email address has been confirmed. You can close this page.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows the not-found message when confirm returns 404 (row deleted)', async () => {
+    let onError: ((e: unknown) => void) | undefined;
+    const mockMutate = vi.fn((_token: string, opts?: { onError?: (e: unknown) => void }) => {
+      onError = opts?.onError;
+    });
+    vi.mocked(useCheckAdditionalEmailVerification).mockReturnValue({
+      isSuccess: true,
+      isError: false,
+      data: { email: 'in***@example.com', verified: false },
+    } as ReturnType<typeof useCheckAdditionalEmailVerification>);
+    vi.mocked(useConfirmAdditionalEmailVerification).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    } as ReturnType<typeof useConfirmAdditionalEmailVerification>);
+
+    renderPage('valid-token');
+    await waitFor(() => {
+      expect(screen.getByText('Confirm email address')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Confirm email address'));
+    // Simulate the axios 404 the confirm endpoint returns once the row is gone.
+    onError?.({ isAxiosError: true, response: { status: 404 } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('verify-email-not-found')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('verify-email-invalid')).not.toBeInTheDocument();
+  });
+
+  it('shows the generic invalid message when confirm fails with a non-404 error', async () => {
+    let onError: ((e: unknown) => void) | undefined;
+    const mockMutate = vi.fn((_token: string, opts?: { onError?: (e: unknown) => void }) => {
+      onError = opts?.onError;
+    });
+    vi.mocked(useCheckAdditionalEmailVerification).mockReturnValue({
+      isSuccess: true,
+      isError: false,
+      data: { email: 'in***@example.com', verified: false },
+    } as ReturnType<typeof useCheckAdditionalEmailVerification>);
+    vi.mocked(useConfirmAdditionalEmailVerification).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    } as ReturnType<typeof useConfirmAdditionalEmailVerification>);
+
+    renderPage('valid-token');
+    await waitFor(() => {
+      expect(screen.getByText('Confirm email address')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Confirm email address'));
+    onError?.({ isAxiosError: true, response: { status: 400 } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('verify-email-invalid')).toBeInTheDocument();
+    });
+  });
+
+  it('shows already-verified state when the check reports verified', async () => {
+    vi.mocked(useCheckAdditionalEmailVerification).mockReturnValue({
+      isSuccess: true,
+      isError: false,
+      data: { email: 'in***@example.com', verified: true },
+    } as ReturnType<typeof useCheckAdditionalEmailVerification>);
+    vi.mocked(useConfirmAdditionalEmailVerification).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as ReturnType<typeof useConfirmAdditionalEmailVerification>);
+
+    renderPage('valid-token');
+
+    await waitFor(() => {
+      expect(screen.getByText('This email address is already confirmed.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows invalid state when the token check errors', async () => {
+    vi.mocked(useCheckAdditionalEmailVerification).mockReturnValue({
+      isSuccess: false,
+      isError: true,
+      data: undefined,
+    } as ReturnType<typeof useCheckAdditionalEmailVerification>);
+    vi.mocked(useConfirmAdditionalEmailVerification).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as ReturnType<typeof useConfirmAdditionalEmailVerification>);
+
+    renderPage('bad-token');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'This verification link is invalid or has expired. Please request a new one from your account settings.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows invalid state when no token is provided', async () => {
+    vi.mocked(useCheckAdditionalEmailVerification).mockReturnValue({
+      isSuccess: false,
+      isError: false,
+      data: undefined,
+    } as ReturnType<typeof useCheckAdditionalEmailVerification>);
+    vi.mocked(useConfirmAdditionalEmailVerification).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as ReturnType<typeof useConfirmAdditionalEmailVerification>);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'This verification link is invalid or has expired. Please request a new one from your account settings.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/web-frontend/src/services/api/userAccountApi.ts
+++ b/web-frontend/src/services/api/userAccountApi.ts
@@ -390,6 +390,60 @@ export const deleteAdditionalEmail = async (email: string): Promise<void> => {
   await apiClient.delete(`${USER_API_PATH}/me/additional-emails/${encodeURIComponent(email)}`);
 };
 
+// =====================================================================
+// Additional-email verification (v2)
+// =====================================================================
+
+export interface AdditionalEmailVerificationCheck {
+  /** Masked email (e.g. in***@example.com). */
+  email: string;
+  verified: boolean;
+}
+
+export interface AdditionalEmailVerificationConfirm {
+  email: string;
+  verified: boolean;
+  alreadyVerified: boolean;
+}
+
+/**
+ * Additional-email verification (v2) — GET-check a token (no mutation). Public:
+ * the token IS the credential. Throws on invalid/expired (surface errorCode via
+ * the Axios error shape).
+ */
+export const checkAdditionalEmailVerification = async (
+  token: string
+): Promise<AdditionalEmailVerificationCheck> => {
+  const response = await apiClient.get<AdditionalEmailVerificationCheck>(
+    `${USER_API_PATH}/additional-emails/verify`,
+    { params: { token } }
+  );
+  return response.data;
+};
+
+/**
+ * Additional-email verification (v2) — POST-confirm a token (mutates). Public.
+ */
+export const confirmAdditionalEmailVerification = async (
+  token: string
+): Promise<AdditionalEmailVerificationConfirm> => {
+  const response = await apiClient.post<AdditionalEmailVerificationConfirm>(
+    `${USER_API_PATH}/additional-emails/verify`,
+    { token }
+  );
+  return response.data;
+};
+
+/**
+ * Additional-email verification (v2) — resend the verification email for one of
+ * the caller's own (unverified) additional emails. 204 on success.
+ */
+export const resendAdditionalEmailVerification = async (email: string): Promise<void> => {
+  await apiClient.post(
+    `${USER_API_PATH}/me/additional-emails/${encodeURIComponent(email)}/resend-verification`
+  );
+};
+
 // Admin endpoints for uploading profile pictures for other users
 
 /**

--- a/web-frontend/src/services/devEmailService.test.ts
+++ b/web-frontend/src/services/devEmailService.test.ts
@@ -41,16 +41,18 @@ describe('devEmailService', () => {
   beforeEach(() => vi.clearAllMocks());
 
   describe('fetchAll', () => {
-    it('merges emails from EMS and PCS, sorted newest first, tagged with source URL', async () => {
+    it('merges emails from EMS, PCS and CUMS, sorted newest first, tagged with source URL', async () => {
       mockFetch
         .mockResolvedValueOnce({ ok: true, json: async () => [EMS_EMAIL] }) // EMS
-        .mockResolvedValueOnce({ ok: true, json: async () => [PCS_EMAIL] }); // PCS
+        .mockResolvedValueOnce({ ok: true, json: async () => [PCS_EMAIL] }) // PCS
+        .mockResolvedValueOnce({ ok: true, json: async () => [] }); // CUMS (empty)
 
       const result = await devEmailService.fetchAll();
 
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
       expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('8002/dev/emails'));
       expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('8004/dev/emails'));
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('8001/dev/emails'));
       // PCS email is newer → should come first
       expect(result[0].id).toBe('pcs-1');
       expect(result[0]._sourceBaseUrl).toContain('8004');
@@ -100,16 +102,19 @@ describe('devEmailService', () => {
   });
 
   describe('clearAll', () => {
-    it('sends DELETE to both EMS and PCS', async () => {
+    it('sends DELETE to EMS, PCS and CUMS', async () => {
       mockFetch.mockResolvedValue({ ok: true, status: 204 });
 
       await devEmailService.clearAll();
 
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
       expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('8002/dev/emails'), {
         method: 'DELETE',
       });
       expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('8004/dev/emails'), {
+        method: 'DELETE',
+      });
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('8001/dev/emails'), {
         method: 'DELETE',
       });
     });

--- a/web-frontend/src/services/devEmailService.ts
+++ b/web-frontend/src/services/devEmailService.ts
@@ -2,12 +2,14 @@
  * Dev-only email service for the local email inbox.
  * Aggregates captured emails from all services that have a DevEmailController.
  *
- * Currently: Event Management Service (EMS, :8002) + Partner Coordination Service (PCS, :8004).
+ * Currently: Event Management Service (EMS, :8002) + Partner Coordination Service (PCS, :8004)
+ * + Company/User Management Service (CUMS, :8001 — additional-email verification mails).
  * Only used by DevEmailInboxPage (accessible at /dev/emails in local dev).
  */
 
 const EMS_BASE = `http://localhost:${import.meta.env.VITE_EMS_PORT ?? 8002}`;
 const PCS_BASE = `http://localhost:${import.meta.env.VITE_PCS_PORT ?? 8004}`;
+const CUMS_BASE = `http://localhost:${import.meta.env.VITE_CUMS_PORT ?? 8001}`;
 
 export interface CapturedEmail {
   id: string;
@@ -45,12 +47,13 @@ async function fetchFromService(baseUrl: string): Promise<CapturedEmailWithSourc
 
 export const devEmailService = {
   fetchAll: async (): Promise<CapturedEmailWithSource[]> => {
-    const [emsEmails, pcsEmails] = await Promise.all([
+    const [emsEmails, pcsEmails, cumsEmails] = await Promise.all([
       fetchFromService(EMS_BASE),
       fetchFromService(PCS_BASE),
+      fetchFromService(CUMS_BASE),
     ]);
     // Merge and sort newest first
-    return [...emsEmails, ...pcsEmails].sort(
+    return [...emsEmails, ...pcsEmails, ...cumsEmails].sort(
       (a, b) => new Date(b.capturedAt).getTime() - new Date(a.capturedAt).getTime()
     );
   },
@@ -63,6 +66,7 @@ export const devEmailService = {
     await Promise.all([
       fetch(`${EMS_BASE}/dev/emails`, { method: 'DELETE' }),
       fetch(`${PCS_BASE}/dev/emails`, { method: 'DELETE' }).catch(() => undefined),
+      fetch(`${CUMS_BASE}/dev/emails`, { method: 'DELETE' }).catch(() => undefined),
     ]);
   },
 

--- a/web-frontend/src/types/generated/user-api.types.ts
+++ b/web-frontend/src/types/generated/user-api.types.ts
@@ -393,6 +393,64 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/users/me/additional-emails/{email}/resend-verification': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Resend the verification email for an additional email address
+     * @description Additional-email verification v2 — re-dispatch the signed verification
+     *     link to one of the caller's own (still unverified) additional emails.
+     *     Idempotent in effect: a 204 means a fresh email was queued. The token is
+     *     regenerated on each call (stateless HMAC JWT, 48h TTL).
+     */
+    post: operations['resendAdditionalEmailVerification'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/users/additional-emails/verify': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Check an additional-email verification token (no mutation)
+     * @description Additional-email verification v2 — public, token-credentialed pre-flight
+     *     check used by the `/verify-email` landing page. Validates the token's
+     *     signature + expiry and returns the (masked) email and its current
+     *     verification status WITHOUT mutating any state. Mail-scanner prefetches
+     *     of the link land here (GET) and never confirm; the actual confirm is a
+     *     separate POST. No JWT — the token IS the credential.
+     */
+    get: operations['checkAdditionalEmailVerification'];
+    put?: never;
+    /**
+     * Confirm an additional-email verification token (mutates)
+     * @description Additional-email verification v2 — public, token-credentialed confirm.
+     *     POST-only so mail-scanner prefetches (GET) cannot accidentally verify.
+     *     On success sets `verified_at` and returns the masked email. Idempotent:
+     *     a token for an already-verified row returns 200 with
+     *     `alreadyVerified: true`. If the underlying row was deleted (or re-added
+     *     with a new id) since the token was issued, returns 404. No JWT — the
+     *     token IS the credential.
+     */
+    post: operations['confirmAdditionalEmailVerification'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/users/{username}/roles': {
     parameters: {
       query?: never;
@@ -1013,6 +1071,46 @@ export interface components {
       email: string;
       /** @example Hostpoint shared */
       label?: string | null;
+    };
+    /**
+     * @description Additional-email verification v2 — GET-check response. Returns the masked
+     *     email and current verification status without mutating state.
+     */
+    AdditionalEmailVerificationCheckResponse: {
+      /**
+       * @description Masked form of the additional email (e.g. `in***@example.com`). The
+       *     full address is never returned on the public verify path.
+       * @example in***@berner-architekten-treffen.ch
+       */
+      email: string;
+      /**
+       * @description True if the row's verified_at is already set.
+       * @example false
+       */
+      verified: boolean;
+    };
+    ConfirmAdditionalEmailVerificationRequest: {
+      /** @description The signed verification token from the email link. */
+      token: string;
+    };
+    /** @description Additional-email verification v2 — POST-confirm response. */
+    AdditionalEmailVerificationConfirmResponse: {
+      /**
+       * @description Masked form of the additional email.
+       * @example in***@berner-architekten-treffen.ch
+       */
+      email: string;
+      /**
+       * @description Always true after a successful confirm.
+       * @example true
+       */
+      verified: boolean;
+      /**
+       * @description True when the row was already verified before this call (idempotent
+       *     re-confirm); false when this call set verified_at.
+       * @example false
+       */
+      alreadyVerified: boolean;
     };
     UserPreferences: {
       /**
@@ -2156,6 +2254,130 @@ export interface operations {
       };
       401: components['responses']['Unauthorized'];
       /** @description No matching additional email on the caller's profile. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      500: components['responses']['InternalServerError'];
+    };
+  };
+  resendAdditionalEmailVerification: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description URL-encoded email address. Case-insensitive match against the caller's
+         *     additional emails.
+         * @example info@berner-architekten-treffen.ch
+         */
+        email: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description A fresh verification email was dispatched. */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components['responses']['Unauthorized'];
+      /** @description No matching additional email on the caller's profile. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description The email is already verified. Error code: `ALREADY_VERIFIED`. */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      500: components['responses']['InternalServerError'];
+    };
+  };
+  checkAdditionalEmailVerification: {
+    parameters: {
+      query: {
+        /** @description The signed verification token from the email link. */
+        token: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Token is valid; returns masked email + status. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['AdditionalEmailVerificationCheckResponse'];
+        };
+      };
+      /** @description Token is invalid (`TOKEN_INVALID`) or expired (`TOKEN_EXPIRED`). */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      500: components['responses']['InternalServerError'];
+    };
+  };
+  confirmAdditionalEmailVerification: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ConfirmAdditionalEmailVerificationRequest'];
+      };
+    };
+    responses: {
+      /** @description Email verified (or already verified). */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['AdditionalEmailVerificationConfirmResponse'];
+        };
+      };
+      /** @description Token is invalid (`TOKEN_INVALID`) or expired (`TOKEN_EXPIRED`). */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /**
+       * @description The additional-email row referenced by the token no longer exists
+       *     (deleted or re-added with a new id since issuance).
+       */
       404: {
         headers: {
           [name: string]: unknown;


### PR DESCRIPTION
## Summary

Two sequential stories enabling **"Continue with Google" with a private Gmail registered as an additional email** — without creating a duplicate user — plus supporting fixes.

### Story A — Additional-email verification flow (`cf856616`)
- Stateless HMAC JWT verification links (JJWT HS256, 48h TTL, claims bound to the `user_additional_emails` row UUID → delete/re-add invalidates). No new migration — fills the reserved `verified_at` column (10.32 v2).
- New endpoints (contract-first, `users-api.openapi.yml`): public `GET/POST /users/additional-emails/verify` (token is the credential; permitAll in gateway + all CUMS profiles; **POST-only mutates** — mail scanners prefetch GETs) + authenticated resend (204/404/409).
- CUMS becomes an email sender: SES IAM grant, `JWT_SECRET` (reuses `WATCH_JWT_SECRET`, EMS pattern), `APP_BASE_URL`; DE+EN templates, EN fallback; send-on-add is failure-tolerant (201 even if SES fails).
- Frontend: `/verify-email` landing page (mirrors UnsubscribePage; distinct 404 vs 400 states), real Verified/Unverified pill + Resend in settings, i18n ×10 locales.

### Story B — Google SSO via verified additional email (`cfda3945`)
- `pre-signup.ts`: when the primary `user_profiles.email` match is empty, fall back to `user_additional_emails` — **double-gated** on `verified_at IS NOT NULL` AND IdP `email_verified='true'` — and `AdminLinkProviderForUser` to the owning account (sub preserved, same as primary path). Never-throw property preserved; metric `FederatedUserLinkedViaAdditionalEmail`.
- JIT interceptor: duplicate guard (skip creation when JWT email is someone's verified additional email; owner's `cognito_user_id` never touched) + primary lookup now case-insensitive.
- ADR-010 D3 amended in the same commit.

### Supporting commits
- `b85f5378` — local `/dev/emails` inbox now aggregates CUMS (`@Profile("local")` DevEmailController)
- `88978256` — user-menu order (Profile, Settings, Admin) + deep-linkable `/account/{profile|settings}` tabs
- `c114bcdf` — `project-context.md` refresh (post-February rules)

## Security design
Unverified additional emails were an account-takeover vector for SSO linking (self-asserted, no ownership proof) — hence Story A is a hard precondition for Story B, and linking requires BOTH the platform-side verification AND the IdP's email_verified attestation. Deferred follow-ups recorded in `deferred-work.md` (notably: gate the *primary*-email linking path on `email_verified` before Apple/generic OIDC lands, Story 12.10).

## Test plan
- [x] CUMS: BUILD SUCCESSFUL (723 tests; 18 new verification + 4 token unit + JIT guard integration via Testcontainers)
- [x] Lambda handler tests: 18/18 (`pre-signup.test.ts` — imports and runs the handler)
- [x] Infra: 382/382 · Frontend: settings/page/menu/account suites green · type-check + lint clean
- [x] Adversarial review (3 agents per story): 15 patches applied, 4 findings deferred with rationale
- [x] Local-dev E2E: add email → mail in `/dev/emails` → verify link → pill flips Verified (user-verified)
- [ ] Post-deploy smoke: verify an additional Gmail on a real account, then "Continue with Google" with it → lands in the existing account (no duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)