### PR TITLE
chore(backlog): renumber SB4 migration to Epic 14 + 19.6 event freeze gate

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -222,14 +222,18 @@ development_status:
   12-12-google-profile-picture-import: review                         # Dev-story 2026-06-04 (Opus 4.8): all 8 ACs implemented TDD. OPEN-VERIFY RESOLVED: ID token reaches CUMS (apiClient.ts:38 sends idToken; JIT already reads ID-token-only claims in prod) -> Jwt.getClaimAsString("picture") works directly. CDK: picture mapped + client read/writeAttributes (F1b applied; PR#735 Schema-trap regression test). CUMS: V18 migration (12-11 holds V17 in parallel) + FederatedAvatarImportService + sibling interceptor AFTER JIT + plain injected Executor (no @Async proxy; non-blocking unit-proven). Mark-attempt-BEFORE-dispatch = one-attempt-ever incl. all failure paths; worker re-checks null before write (never clobber); SSRF guard https+googleusercontent.com-host-only, =s96-c->=s512-c. 2 CDK + 7 IT + 11 unit tests green; full CUMS suite green except 12-11's own WIP V17 tests; infra 392 green; checkstyle clean. Docs: plan §9 + 06b Pattern 1c. PENDING: post-deploy manual smoke (fresh Google sign-in -> /profile picture + S3 object). Prereq: none (independent of 12-11)
   epic-12-retrospective: optional
 
-  # Epic 13: Spring Boot 4 Migration — PLANNED 2026-06-07 (docs/plans/spring-boot-4-migration.md)
+  # Epic 13: RESERVED — partner management enhancements (invoice management etc., April 2026
+  # brainstorm; lives on the demo branch / Nissim's planning, not yet in this repo).
+
+  # Epic 14: Spring Boot 4 Migration — PLANNED 2026-06-07 (docs/plans/spring-boot-4-migration.md)
   # Driver: SB 3.5 OSS support ends 2026-06-30; we are on 3.5.7. Staged per-module PRs,
-  # Jackson-2-compat flag until 13-4, Bruno/Playwright blocking gates as the payload-diff safety net.
-  epic-13: backlog
-  13-1-zero-deprecation-baseline-compat-matrix: backlog
-  13-2-shared-kernel-pilot-service-sb4: backlog          # attendee-experience pilot; >=2 days mixed-fleet gate
-  13-3-remaining-domain-services-sb4: backlog            # 4 PRs: CUMS, EMS, speaker-coordination, partner-coordination
-  13-4-api-gateway-closeout-jackson3-flag-flip: backlog  # gateway + flip Jackson-2-compat OFF + docs/versions update
+  # Jackson-2-compat flag until 14-4, Bruno/Playwright blocking gates as the payload-diff safety net.
+  # FREEZE: no migration work deploys before the BATbern event on 2026-06-19 (prod stability first).
+  epic-14: backlog
+  14-1-zero-deprecation-baseline-compat-matrix: backlog  # start after 2026-06-19
+  14-2-shared-kernel-pilot-service-sb4: backlog          # attendee-experience pilot; >=2 days mixed-fleet gate
+  14-3-remaining-domain-services-sb4: backlog            # 4 PRs: CUMS, EMS, speaker-coordination, partner-coordination
+  14-4-api-gateway-closeout-jackson3-flag-flip: backlog  # gateway + flip Jackson-2-compat OFF + docs/versions update
 
   # Deferred-work backlog clusters (groomed 2026-06-07 — see deferred-work.md) — candidate stories,
   # not yet scheduled. Cluster A is a REQUIRED precondition for 12-10 (Apple/generic OIDC).

--- a/docs/plans/spring-boot-4-migration.md
+++ b/docs/plans/spring-boot-4-migration.md
@@ -1,6 +1,6 @@
-# Spring Boot 4 Migration Plan (Epic 13)
+# Spring Boot 4 Migration Plan (Epic 14)
 
-**Created:** 2026-06-07 · **Status:** planned · **Driver:** Spring Boot 3.5 OSS support ends **2026-06-30** ([spring.io support policy](https://spring.io/support-policy/)) — after that, no CVE patches on Maven Central for our current line (3.5.7).
+**Created:** 2026-06-07 · **Status:** planned · **Start gate: NOT before 2026-06-19** (BATbern #57 event day — nothing that could endanger prod deploys before the event has passed) · **Driver:** Spring Boot 3.5 OSS support ends **2026-06-30** ([spring.io support policy](https://spring.io/support-policy/)) — after that, no CVE patches on Maven Central for our current line (3.5.7).
 
 ## Scope & Goal
 
@@ -20,31 +20,31 @@ Migrate the whole Java estate — `shared-kernel`, `api-gateway`, 5 domain servi
 |---|---|---|
 | **Jackson 3** (`com.fasterxml.jackson` → `tools.jackson`, immutable `JsonMapper`, LanguageTag locale serialization, changed defaults) | Every API payload; the project's enum-flow rule (UPPER_CASE JSON) must survive byte-identical; shared-kernel `ErrorResponse`/`PaginationMetadata` | Start with SB4's Jackson-2-compatible-defaults flag ON; Bruno suite = payload diff detector; flip flag OFF as a separate, final story task |
 | **Spring Security 7** — CSRF enabled for API endpoints by default; lambda-only DSL | api-gateway + all 6 service `SecurityConfig`s (incl. the dual-permitAll pattern, token-credentialed public endpoints) | Explicit `csrf.disable()` audit per config (stateless JWT APIs); our configs are already lambda-DSL |
-| **Deprecated API removal** (~88% of 2.x/3.x deprecations gone) | Unknown until measured — that is Story 13-1's job | Zero-deprecation baseline BEFORE switching the version |
+| **Deprecated API removal** (~88% of 2.x/3.x deprecations gone) | Unknown until measured — that is Story 14-1's job | Zero-deprecation baseline BEFORE switching the version |
 | **Modularized starters** | `build.gradle` per module; possible missing auto-config modules at boot | Pilot story discovers the real list once |
 | **Servlet 6.1 / Tomcat 11** | Embedded Tomcat (we don't use Undertow — no exposure there) | Boot-smoke in integration tests; Testcontainers parity |
 | **Hibernate 7 / JPA 3.2** | All entities, `AttributeConverter`s (enum lowercase mapping!), `@ElementCollection` LAZY rules | Testcontainers integration suites (mandatory PostgreSQL parity pays off here) |
-| **Third-party matrix** | springdoc/OpenAPI Generator 7.2 (generated `*Api` interfaces!), Flyway, Testcontainers, JJWT, AWS SDK v2, resilience4j | Story 13-1 builds the compatibility matrix; OpenAPI Generator output must compile against Spring 7 annotations |
+| **Third-party matrix** | springdoc/OpenAPI Generator 7.2 (generated `*Api` interfaces!), Flyway, Testcontainers, JJWT, AWS SDK v2, resilience4j | Story 14-1 builds the compatibility matrix; OpenAPI Generator output must compile against Spring 7 annotations |
 
 ## Stories
 
-### 13-1 — Zero-deprecation baseline + compatibility matrix (on 3.5.7)
+### 14-1 — Zero-deprecation baseline + compatibility matrix (on 3.5.7)
 - Turn on `-Xlint:deprecation`/`-Werror`-equivalent visibility; fix **every** Java deprecation warning across all modules (SB4 removes those APIs).
 - Build the third-party compatibility matrix (springdoc, OpenAPI Generator, Flyway, Testcontainers/JUnit, JJWT, AWS SDK, resilience4j, Lombok, Checkstyle/Spotless toolchain) — pin the SB4-compatible target versions.
 - Run OpenRewrite `UpgradeSpringBoot_3_5` (no-op confirm) and dry-run `UpgradeSpringBoot_4_0` to size the mechanical diff.
 - **Deliverable:** green build with zero deprecation warnings; matrix table appended to this plan. Low risk, deployable.
 
-### 13-2 — shared-kernel + pilot service (attendee-experience) to SB4
+### 14-2 — shared-kernel + pilot service (attendee-experience) to SB4
 - Apply OpenRewrite `UpgradeSpringBoot_4_0` to `shared-kernel` + `services/attendee-experience-service` (smallest service); manual fixes on top.
 - Jackson-2-compatible defaults flag ON. Shared-kernel types (`ErrorResponse`, EmailService, JwtRolesConverter — Pattern 3b must survive!) are the highest-leverage validation.
 - `:shared-kernel:publishToMavenLocal` → pilot service full Testcontainers suite → deploy → Bruno + Playwright gates.
 - **Gate:** staging (=prod) runs the pilot service on SB4 for ≥2 days with the other services on 3.5.7 (mixed fleet is fine — services share no Spring wire format, only HTTP+JSON).
 
-### 13-3 — Remaining domain services (4 PRs: company-user-management, event-management, speaker-coordination, partner-coordination)
+### 14-3 — Remaining domain services (4 PRs: company-user-management, event-management, speaker-coordination, partner-coordination)
 - Same recipe per service, one PR each, sequenced by blast radius (CUMS first — auth-critical, best-tested; EMS last — biggest).
 - Each PR: full service suite + Bruno collections for that service + deploy + gate. Watch the Cognito trigger paths (CUMS) and email rendering (EMS) closely.
 
-### 13-4 — api-gateway + estate-wide closeout
+### 14-4 — api-gateway + estate-wide closeout
 - Gateway last (it fronts everything; by now the pattern is proven). Spring Security 7 CSRF/DSL audit happens here for the final time.
 - Flip the Jackson-2-compatible defaults flag OFF estate-wide (separate commit, full Bruno run = the payload-diff gate).
 - Remove the compat module, update `docs/architecture/tech-stack.md` + `versions.json` + `_bmad-output/project-context.md` (Spring Boot 4.x line), close the epic.
@@ -52,8 +52,8 @@ Migrate the whole Java estate — `shared-kernel`, `api-gateway`, 5 domain servi
 ## Risks & escape hatches
 
 - **Rollback:** each story is one service = ECS auto-rollback on failed gate; image-level revert is one `update-ecs-task.sh` away.
-- **Mixed-fleet window:** intentional (13-2/13-3); services interact only via HTTP+JSON, so framework versions may diverge safely. Jackson-3 payload drift across the fleet is the one cross-service risk — held down by the compat flag until 13-4.
-- **3.5 EOL gap:** if 13-x slips past 2026-06-30, exposure is bounded — 3.5.7 is the final patch; monitor CVEs manually until 13-4 closes.
+- **Mixed-fleet window:** intentional (14-2/14-3); services interact only via HTTP+JSON, so framework versions may diverge safely. Jackson-3 payload drift across the fleet is the one cross-service risk — held down by the compat flag until 14-4.
+- **3.5 EOL gap:** if 14-x slips past 2026-06-30, exposure is bounded — 3.5.7 is the final patch; monitor CVEs manually until 14-4 closes.
 
 ## References
 


### PR DESCRIPTION
Follow-up to #768, which auto-merged before this fix landed on its branch.

- **Epic 13 → Epic 14** for the Spring Boot 4 migration (13 is reserved — partner-management enhancements from the April brainstorm, per Nissim)
- **Start gate added**: no Epic-14 work deploys before the BATbern event on **2026-06-19** (prod stability before the event takes priority over the SB 3.5 EOL date; risk window documented in the plan)

Files: `docs/plans/spring-boot-4-migration.md`, `sprint-status.yaml` (epic-13 reservation comment + epic-14 entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)