### PR TITLE
feat(company): MUI company combobox — display name + logos + create, in admin surfaces

### DIFF
--- a/web-frontend/public/locales/de/common.json
+++ b/web-frontend/public/locales/de/common.json
@@ -747,7 +747,8 @@
   "companySearch": {
     "noOptions": "Keine Unternehmen gefunden",
     "searchAriaLabel": "Unternehmen suchen",
-    "clearSearchAriaLabel": "Suche löschen"
+    "clearSearchAriaLabel": "Suche löschen",
+    "createOption": "Neue Firma „{{value}}\" erstellen"
   },
   "countdown": {
     "nextEvent": "Nächste Veranstaltung",

--- a/web-frontend/public/locales/en/common.json
+++ b/web-frontend/public/locales/en/common.json
@@ -675,7 +675,8 @@
   "companySearch": {
     "noOptions": "No companies found",
     "searchAriaLabel": "Search companies",
-    "clearSearchAriaLabel": "Clear search"
+    "clearSearchAriaLabel": "Clear search",
+    "createOption": "Create new company \"{{value}}\""
   },
   "countdown": {
     "nextEvent": "Next Event",

--- a/web-frontend/public/locales/es/common.json
+++ b/web-frontend/public/locales/es/common.json
@@ -743,7 +743,8 @@
   "companySearch": {
     "noOptions": "No se encontraron empresas",
     "searchAriaLabel": "Buscar empresas",
-    "clearSearchAriaLabel": "Borrar búsqueda"
+    "clearSearchAriaLabel": "Borrar búsqueda",
+    "createOption": "Crear nueva empresa \"{{value}}\""
   },
   "countdown": {
     "nextEvent": "Próximo evento",

--- a/web-frontend/public/locales/fi/common.json
+++ b/web-frontend/public/locales/fi/common.json
@@ -743,7 +743,8 @@
   "companySearch": {
     "noOptions": "Yrityksiä ei löydy",
     "searchAriaLabel": "Etsi yrityksiä",
-    "clearSearchAriaLabel": "Tyhjennä haku"
+    "clearSearchAriaLabel": "Tyhjennä haku",
+    "createOption": "Luo uusi yritys \"{{value}}\""
   },
   "countdown": {
     "nextEvent": "Seuraava tapahtuma",

--- a/web-frontend/public/locales/fr/common.json
+++ b/web-frontend/public/locales/fr/common.json
@@ -743,7 +743,8 @@
   "companySearch": {
     "noOptions": "Aucune entreprise trouvée",
     "searchAriaLabel": "Rechercher des entreprises",
-    "clearSearchAriaLabel": "Effacer la recherche"
+    "clearSearchAriaLabel": "Effacer la recherche",
+    "createOption": "Créer une nouvelle entreprise « {{value}} »"
   },
   "countdown": {
     "nextEvent": "Prochain événement",

--- a/web-frontend/public/locales/gsw-BE/common.json
+++ b/web-frontend/public/locales/gsw-BE/common.json
@@ -643,5 +643,8 @@
     "newsletterDescription": "Über chünftigi BATbern-Aaläss informiert blybe.",
     "newsletterLabel": "Dr BATbern-Newsletter abonniere",
     "companySaveError": "S Unternäme het nid chönne gspeicheret wärde. Bitte versuechs nomal."
+  },
+  "companySearch": {
+    "createOption": "Nöii Firma „{{value}}\" erstelle"
   }
 }

--- a/web-frontend/public/locales/it/common.json
+++ b/web-frontend/public/locales/it/common.json
@@ -743,7 +743,8 @@
   "companySearch": {
     "noOptions": "Nessuna azienda trovata",
     "searchAriaLabel": "Cerca aziende",
-    "clearSearchAriaLabel": "Cancella ricerca"
+    "clearSearchAriaLabel": "Cancella ricerca",
+    "createOption": "Crea nuova azienda \"{{value}}\""
   },
   "countdown": {
     "nextEvent": "Prossimo evento",

--- a/web-frontend/public/locales/ja/common.json
+++ b/web-frontend/public/locales/ja/common.json
@@ -743,7 +743,8 @@
   "companySearch": {
     "noOptions": "企業が見つかりません",
     "searchAriaLabel": "企業を検索",
-    "clearSearchAriaLabel": "検索をクリア"
+    "clearSearchAriaLabel": "検索をクリア",
+    "createOption": "新しい会社「{{value}}」を作成"
   },
   "countdown": {
     "nextEvent": "次のイベント",

--- a/web-frontend/public/locales/nl/common.json
+++ b/web-frontend/public/locales/nl/common.json
@@ -743,7 +743,8 @@
   "companySearch": {
     "noOptions": "Geen bedrijven gevonden",
     "searchAriaLabel": "Bedrijven zoeken",
-    "clearSearchAriaLabel": "Zoekopdracht wissen"
+    "clearSearchAriaLabel": "Zoekopdracht wissen",
+    "createOption": "Nieuw bedrijf \"{{value}}\" aanmaken"
   },
   "countdown": {
     "nextEvent": "Volgend evenement",

--- a/web-frontend/public/locales/rm/common.json
+++ b/web-frontend/public/locales/rm/common.json
@@ -743,7 +743,8 @@
   "companySearch": {
     "noOptions": "Naginas cumpagnias chattadas",
     "searchAriaLabel": "Tschertgar cumpagnias",
-    "clearSearchAriaLabel": "Stizzar la tschertga"
+    "clearSearchAriaLabel": "Stizzar la tschertga",
+    "createOption": "Crear nova interpresa \"{{value}}\""
   },
   "countdown": {
     "nextEvent": "Proxim eveniment",

--- a/web-frontend/src/components/organizer/PartnerManagement/CompanyAutocomplete.test.tsx
+++ b/web-frontend/src/components/organizer/PartnerManagement/CompanyAutocomplete.test.tsx
@@ -80,7 +80,11 @@ describe('CompanyAutocomplete Component - Story 2.8.3 AC3', () => {
     await user.type(input, 'acme');
 
     await waitFor(() => {
-      expect(searchSpy).toHaveBeenCalledWith('acme', expect.any(Number));
+      expect(searchSpy).toHaveBeenCalledWith(
+        'acme',
+        expect.any(Number),
+        expect.objectContaining({ expand: ['logo'] })
+      );
     });
   });
 
@@ -233,8 +237,44 @@ describe('CompanyAutocomplete Component - Story 2.8.3 AC3', () => {
     });
   });
 
-  // Additional AC3 tests: Empty state
+  // Additional AC3 tests: Empty state (create disabled → falls back to "no companies found")
   it('should_showEmptyState_when_noCompaniesFound', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(companyApi, 'searchCompanies').mockResolvedValue([]);
+
+    await act(async () => {
+      render(
+        <TestWrapper>
+          <CompanyAutocomplete value={null} onChange={mockOnChange} allowCreate={false} />
+        </TestWrapper>
+      );
+    });
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'nonexistent');
+
+    await waitFor(() => {
+      expect(screen.getByText(/no companies found/i)).toBeInTheDocument();
+    });
+  });
+
+  // Selection-locked combobox: the input shows the DISPLAY NAME, never the slug.
+  it('should_showDisplayName_when_companySelected', async () => {
+    await act(async () => {
+      render(
+        <TestWrapper>
+          <CompanyAutocomplete value={mockCompanies[0] as never} onChange={mockOnChange} />
+        </TestWrapper>
+      );
+    });
+
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    expect(input.value).toBe('Acme Corporation'); // displayName, not 'acme-corp'
+  });
+
+  // Create flow: when no existing company matches, an explicit "Create" row appears
+  // and selecting it materialises the company via get-or-create.
+  it('should_offerCreateOption_when_noExactMatch', async () => {
     const user = userEvent.setup();
     vi.spyOn(companyApi, 'searchCompanies').mockResolvedValue([]);
 
@@ -247,10 +287,45 @@ describe('CompanyAutocomplete Component - Story 2.8.3 AC3', () => {
     });
 
     const input = screen.getByRole('combobox');
-    await user.type(input, 'nonexistent');
+    await user.type(input, 'Brand New Co');
 
     await waitFor(() => {
-      expect(screen.getByText(/no companies found/i)).toBeInTheDocument();
+      expect(screen.getByTestId('company-create-option')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Create new company "Brand New Co"/i)).toBeInTheDocument();
+  });
+
+  it('should_materialiseCompany_when_createOptionSelected', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(companyApi, 'searchCompanies').mockResolvedValue([]);
+    const created = {
+      name: 'brandnewco',
+      displayName: 'Brand New Co',
+      isVerified: false,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    const getOrCreateSpy = vi
+      .spyOn(companyApi, 'getOrCreateCompany')
+      .mockResolvedValue(created as never);
+
+    await act(async () => {
+      render(
+        <TestWrapper>
+          <CompanyAutocomplete value={null} onChange={mockOnChange} />
+        </TestWrapper>
+      );
+    });
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'Brand New Co');
+
+    const createOption = await screen.findByTestId('company-create-option');
+    await user.click(createOption);
+
+    await waitFor(() => {
+      expect(getOrCreateSpy).toHaveBeenCalledWith('Brand New Co');
+      expect(mockOnChange).toHaveBeenCalledWith(created);
     });
   });
 });

--- a/web-frontend/src/components/organizer/PartnerManagement/CompanyAutocomplete.tsx
+++ b/web-frontend/src/components/organizer/PartnerManagement/CompanyAutocomplete.tsx
@@ -1,21 +1,31 @@
 /**
- * CompanyAutocomplete Component (Story 2.8.3 - GREEN Phase)
+ * CompanyAutocomplete Component (MUI) — selection-locked combobox with logos + create
  *
- * Autocomplete component for searching and selecting companies
- * Features:
- * - Debounced search (300ms)
- * - Min 2 characters to trigger search
- * - Display company name, logo, and industry
- * - Loading states
- * - Error handling
- * - Empty states
+ * Mirrors the public (tailwind) RegistrationWizard combobox approach (PR #774) for the
+ * organizer/admin MUI surfaces. Shared by three consumers: UserProfileTab ("My Profile"),
+ * UserCreateEditModal (admin "Edit User"), and PartnerCreateEditModal.
+ *
+ * Behaviour:
+ *  - The input shows the human DISPLAY NAME, never the ADR-003 slug — so a selected
+ *    company never echoes "swissitsolutionsag" back at the user.
+ *  - Search results render the company logo + display name + industry (?include=logo).
+ *  - The selected value shows its logo as a start-adornment avatar (resolved via
+ *    GET /companies/{slug}), falling back to the display-name initial.
+ *  - When no existing company matches the query, an explicit "Create new company" row
+ *    lets the user deliberately create one. Picking it MATERIALISES the company via
+ *    POST /companies:get-or-create and reports the resulting canonical-slug Company,
+ *    so every parent's existing `company.name` save logic keeps working unchanged.
+ *
+ * Contract unchanged: fully controlled, `value: Company | null`, `onChange(Company | null)`.
  */
 
 import React, { useState, useCallback } from 'react';
 import { Autocomplete, TextField, CircularProgress, Box, Avatar, Typography } from '@mui/material';
+import { Add as AddIcon } from '@mui/icons-material';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { searchCompanies } from '@/services/api/companyApi';
+import { searchCompanies, getOrCreateCompany } from '@/services/api/companyApi';
+import { useCompany } from '@/hooks/useCompany/useCompany';
 import type { components } from '@/types/generated/company-api.types';
 
 type Company = components['schemas']['CompanyResponse'];
@@ -27,7 +37,13 @@ interface CompanyAutocompleteProps {
   disabled?: boolean;
   label?: string;
   inputRef?: React.Ref<HTMLInputElement>;
+  /** Show the explicit "Create new company" row when no existing company matches (default true). */
+  allowCreate?: boolean;
 }
+
+// A brand-new, not-yet-materialised company is represented by an empty slug (`name === ''`)
+// + the typed display name. Selecting it triggers get-or-create to resolve the real slug.
+const isCreateOption = (c: Company | null): boolean => !!c && c.name === '' && !!c.displayName;
 
 // Debounce hook
 function useDebounce<T>(value: T, delay: number): T {
@@ -53,57 +69,112 @@ export const CompanyAutocomplete: React.FC<CompanyAutocompleteProps> = ({
   disabled = false,
   label,
   inputRef,
+  allowCreate = true,
 }) => {
   const { t } = useTranslation('common');
   const [inputValue, setInputValue] = useState('');
+  const [creating, setCreating] = useState(false);
   const debouncedInputValue = useDebounce(inputValue, 300);
 
-  // Sync inputValue when value prop changes (e.g., when editing existing user)
-  React.useEffect(() => {
-    if (value) {
-      setInputValue(value.name); // Show technical identifier in input
-    } else {
-      setInputValue('');
-    }
-  }, [value]);
+  // The label shown for a company is its display name; the slug is never surfaced.
+  const labelOf = useCallback((c: Company) => c.displayName || c.name, []);
 
-  // Only search if:
-  // 1. Input is at least 2 characters
-  // 2. Input doesn't match already selected value (avoid unnecessary search after selection)
-  const isValueSelected = value && debouncedInputValue === value.name;
+  // Sync inputValue when value prop changes (e.g., when editing existing user).
+  React.useEffect(() => {
+    setInputValue(value ? labelOf(value) : '');
+  }, [value, labelOf]);
+
+  // Resolve the selected company's logo for the start-adornment avatar. Only fires for a
+  // real slug (existing company) — a brand-new (name === '') value has no logo to fetch.
+  const selectedSlug = value && !isCreateOption(value) ? value.name : '';
+  const { data: selectedCompany } = useCompany(selectedSlug, { expand: ['logo'] });
+  const selectedLogoUrl = selectedCompany?.logo?.url;
+
+  // Only search if input ≥2 chars and doesn't already match the selected value's label
+  // (avoid a redundant search right after selection).
+  const isValueSelected = !!value && debouncedInputValue === labelOf(value);
   const shouldSearch = debouncedInputValue.length >= 2 && !isValueSelected;
 
-  // Query for company search
   const {
     data: companies = [],
     isLoading,
-    isError,
+    isError: isSearchError,
   } = useQuery({
     queryKey: ['companies', 'search', debouncedInputValue],
-    queryFn: () => searchCompanies(debouncedInputValue, 20),
+    queryFn: () => searchCompanies(debouncedInputValue, 20, { expand: ['logo'] }),
     enabled: shouldSearch,
   });
+
+  // An exact (case-insensitive) display-name/slug match means the company already exists —
+  // suppress the "Create" row so the user picks it instead of producing a duplicate.
+  const trimmedInput = inputValue.trim();
+  const hasExactMatch = companies.some(
+    (c) =>
+      (c.displayName || c.name).toLowerCase() === trimmedInput.toLowerCase() ||
+      c.name.toLowerCase() === trimmedInput.toLowerCase()
+  );
+  // Don't offer "create" while loading or when the search itself errored — surface the
+  // loading/error state instead of letting the create row mask it.
+  const showCreate =
+    allowCreate &&
+    trimmedInput.length >= 2 &&
+    !isLoading &&
+    !isSearchError &&
+    !hasExactMatch &&
+    !isValueSelected;
+
+  const createOption: Company = {
+    name: '',
+    displayName: trimmedInput,
+    isVerified: false,
+    createdAt: '',
+    updatedAt: '',
+  };
+  const options = showCreate ? [...companies, createOption] : companies;
 
   const handleInputChange = useCallback((_event: React.SyntheticEvent, newInputValue: string) => {
     setInputValue(newInputValue);
   }, []);
 
+  const handleChange = useCallback(
+    async (newValue: Company | null) => {
+      if (isCreateOption(newValue)) {
+        // Materialise the brand-new company to its canonical slug, then report the real
+        // Company so the parent stores a proper reference (ADR-003), not a free-typed string.
+        setCreating(true);
+        try {
+          const created = await getOrCreateCompany(newValue!.displayName!);
+          onChange(created);
+        } catch {
+          onChange(null);
+        } finally {
+          setCreating(false);
+        }
+        return;
+      }
+      onChange(newValue);
+    },
+    [onChange]
+  );
+
+  const busy = isLoading || creating;
+
   return (
     <Autocomplete
       value={value}
       onChange={(_event, newValue) => {
-        onChange(newValue);
+        void handleChange(newValue);
       }}
       inputValue={inputValue}
       onInputChange={handleInputChange}
-      options={companies}
-      getOptionLabel={(option) => option.name} // Show technical identifier in input field
-      isOptionEqualToValue={(option, value) => option.name === value.name}
+      options={options}
+      getOptionLabel={(option) => labelOf(option)} // Show display name in the input field
+      isOptionEqualToValue={(option, val) => option.name === val.name}
       disabled={disabled}
-      loading={isLoading}
+      loading={busy}
       filterOptions={(x) => x} // Disable client-side filtering (we do server-side filtering)
       noOptionsText={
-        isError
+        isSearchError
           ? t('Error loading companies')
           : inputValue.length < 2
             ? t('Type at least 2 characters')
@@ -114,17 +185,25 @@ export const CompanyAutocomplete: React.FC<CompanyAutocompleteProps> = ({
           {...params}
           label={label || t('Company')}
           error={!!error}
-          helperText={
-            error ||
-            (value?.displayName && value.displayName !== value.name ? value.displayName : undefined)
-          }
+          helperText={error || undefined}
           inputRef={inputRef}
           data-testid="company-autocomplete"
           InputProps={{
             ...params.InputProps,
+            startAdornment: value ? (
+              <Avatar
+                src={selectedLogoUrl}
+                alt={labelOf(value)}
+                sx={{ width: 24, height: 24, ml: 0.5, mr: 0.5, fontSize: '0.75rem' }}
+              >
+                {labelOf(value).charAt(0).toUpperCase()}
+              </Avatar>
+            ) : (
+              params.InputProps.startAdornment
+            ),
             endAdornment: (
               <React.Fragment>
-                {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                {busy ? <CircularProgress color="inherit" size={20} /> : null}
                 {params.InputProps.endAdornment}
               </React.Fragment>
             ),
@@ -133,6 +212,27 @@ export const CompanyAutocomplete: React.FC<CompanyAutocompleteProps> = ({
       )}
       renderOption={(props, option) => {
         const { key, ...otherProps } = props;
+
+        // Explicit "Create new company" affordance.
+        if (isCreateOption(option)) {
+          return (
+            <Box
+              component="li"
+              key="__create__"
+              {...otherProps}
+              data-testid="company-create-option"
+              sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+            >
+              <Avatar sx={{ width: 32, height: 32, bgcolor: 'grey.200' }}>
+                <AddIcon fontSize="small" sx={{ color: 'grey.700' }} />
+              </Avatar>
+              <Typography variant="body1">
+                {t('companySearch.createOption', { value: option.displayName })}
+              </Typography>
+            </Box>
+          );
+        }
+
         return (
           <Box
             component="li"

--- a/web-frontend/src/components/organizer/PartnerManagement/PartnerCreateEditModal.test.tsx
+++ b/web-frontend/src/components/organizer/PartnerManagement/PartnerCreateEditModal.test.tsx
@@ -7,6 +7,7 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { PartnerCreateEditModal } from './PartnerCreateEditModal';
 import { usePartnerModalStore } from '@/stores/partnerModalStore';
 import * as partnerMutations from '@/hooks/usePartnerMutations/usePartnerMutations';
+import { companyApiClient } from '@/services/api/companyApi';
 import { PartnerResponse } from '@/types/generated/partner-types';
 
 // Mock the hooks
@@ -92,6 +93,17 @@ describe('PartnerCreateEditModal', () => {
       isError: false,
       error: null,
     } as any);
+
+    // Edit-mode readonly company display + autocomplete logo adornment use CompanyLogo,
+    // which fetches the company (with logo) via getCompany. Mock it deterministically.
+    vi.spyOn(companyApiClient, 'getCompany').mockResolvedValue({
+      name: 'TestCo',
+      displayName: 'TestCo',
+      isVerified: false,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      logo: { url: 'https://example.com/logo.png' },
+    } as never);
   });
 
   describe('AC1: Create Partner Modal', () => {
@@ -169,21 +181,21 @@ describe('PartnerCreateEditModal', () => {
       expect(screen.getByRole('heading', { name: /Edit Partnership/i })).toBeInTheDocument();
     });
 
-    it('should_prefillForm_when_editModalOpened', () => {
+    it('should_prefillForm_when_editModalOpened', async () => {
       render(<PartnerCreateEditModal />, { wrapper: createWrapper() });
 
-      // Company should be displayed (read-only)
-      expect(screen.getByText('TestCo')).toBeInTheDocument();
+      // Company should be displayed (read-only, via CompanyLogo after fetch)
+      expect(await screen.findByText('TestCo')).toBeInTheDocument();
 
       // Tier should be pre-selected
       expect(screen.getByDisplayValue('GOLD')).toBeInTheDocument();
     });
 
-    it('should_displayCompanyReadOnly_when_editModalOpened', () => {
+    it('should_displayCompanyReadOnly_when_editModalOpened', async () => {
       render(<PartnerCreateEditModal />, { wrapper: createWrapper() });
 
-      // Company field should be read-only (displayed as text, not input)
-      const companyDisplay = screen.getByText('TestCo');
+      // Company field should be read-only (displayed via CompanyLogo, not an input)
+      const companyDisplay = await screen.findByText('TestCo');
       expect(companyDisplay).toBeInTheDocument();
 
       // Should not have autocomplete input

--- a/web-frontend/src/components/organizer/PartnerManagement/PartnerCreateEditModal.tsx
+++ b/web-frontend/src/components/organizer/PartnerManagement/PartnerCreateEditModal.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/hooks/usePartnerMutations/usePartnerMutations';
 import { CreatePartnerSchema, UpdatePartnerSchema } from '@/schemas/partnerSchema';
 import { CompanyAutocomplete } from './CompanyAutocomplete';
+import CompanyLogo from '@/components/shared/Company/CompanyLogo';
 import { PartnershipTierSelect } from './PartnershipTierSelect';
 import { PartnershipDatePicker } from './PartnershipDatePicker';
 import { TierBenefitsPreview } from './TierBenefitsPreview';
@@ -197,7 +198,13 @@ export const PartnerCreateEditModal: React.FC = () => {
                 <Typography variant="subtitle2" color="text.secondary" gutterBottom>
                   {t('modal.fields.company')}
                 </Typography>
-                <Typography variant="body1">{partnerToEdit?.companyName}</Typography>
+                {partnerToEdit?.companyName && (
+                  <CompanyLogo
+                    companyName={partnerToEdit.companyName}
+                    variant="avatar"
+                    avatarSize={32}
+                  />
+                )}
               </Box>
             )}
 

--- a/web-frontend/src/components/organizer/UserManagement/UserDetailModal.test.tsx
+++ b/web-frontend/src/components/organizer/UserManagement/UserDetailModal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import UserDetailModal from './UserDetailModal';
 import '../../../i18n/config';
+import { companyApiClient } from '@/services/api/companyApi';
 import type { User } from '../../../types/user.types';
 
 describe('UserDetailModal Component', () => {
@@ -40,6 +41,16 @@ describe('UserDetailModal Component', () => {
       },
     });
     mockOnClose.mockClear();
+    // The readonly company display now uses CompanyLogo, which fetches the company
+    // (with its logo + display name) via getCompany. Mock it deterministically.
+    vi.spyOn(companyApiClient, 'getCompany').mockResolvedValue({
+      name: 'TechCorp AG',
+      displayName: 'TechCorp AG',
+      isVerified: false,
+      createdAt: '2024-01-01T10:00:00Z',
+      updatedAt: '2024-01-01T10:00:00Z',
+      logo: { url: 'https://example.com/logo.jpg' },
+    } as never);
   });
 
   const renderComponent = (user: User | null, open: boolean) => {
@@ -87,11 +98,11 @@ describe('UserDetailModal Component', () => {
     expect(screen.getByText(/Speaker/i)).toBeInTheDocument();
   });
 
-  it('should_displayCompanyName_when_companyProvided', () => {
+  it('should_displayCompanyName_when_companyProvided', async () => {
     renderComponent(mockUser, true);
 
-    // Company name should be displayed
-    expect(screen.getByText(/TechCorp AG/i)).toBeInTheDocument();
+    // Company display name should be displayed (rendered by CompanyLogo after fetch)
+    expect(await screen.findByText(/TechCorp AG/i)).toBeInTheDocument();
   });
 
   it('should_displayProfilePicture_when_urlProvided', () => {

--- a/web-frontend/src/components/organizer/UserManagement/UserDetailModal.tsx
+++ b/web-frontend/src/components/organizer/UserManagement/UserDetailModal.tsx
@@ -16,6 +16,7 @@ import {
 import { Close as CloseIcon } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
+import CompanyLogo from '@/components/shared/Company/CompanyLogo';
 import type { User } from '../../../types/user.types';
 
 interface UserDetailModalProps {
@@ -115,7 +116,11 @@ const UserDetailModal: React.FC<UserDetailModalProps> = ({ user, open, onClose, 
               <Typography variant="subtitle2" color="text.secondary" gutterBottom>
                 {t('table.headers.company')}
               </Typography>
-              <Typography variant="body1">{user.company.name}</Typography>
+              {user.company.name ? (
+                <CompanyLogo companyName={user.company.name} variant="avatar" avatarSize={32} />
+              ) : (
+                <Typography variant="body1">{user.company.displayName}</Typography>
+              )}
               {user.company.website && (
                 <Typography variant="body2" color="text.secondary">
                   {user.company.website}

--- a/web-frontend/src/components/user/UserProfileTab/UserProfileTab.tsx
+++ b/web-frontend/src/components/user/UserProfileTab/UserProfileTab.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { Box, Button, Divider, Paper, TextField, Typography } from '@mui/material';
 import ProfileHeader from '../ProfileHeader/ProfileHeader';
 import { CompanyAutocomplete } from '@/components/organizer/PartnerManagement/CompanyAutocomplete';
+import CompanyLogo from '@/components/shared/Company/CompanyLogo';
 import WatchPairingSection from '@/features/profile/WatchPairingSection';
 import type { User, UserActivity } from '@/types/userAccount.types';
 import type { components } from '@/types/generated/company-api.types';
@@ -56,7 +57,7 @@ const UserProfileTab: React.FC<UserProfileTabProps> = ({ user, activity }) => {
       company: user.company
         ? {
             name: user.company.name,
-            displayName: user.company.name,
+            displayName: user.company.displayName || user.company.name,
             isVerified: false,
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString(),
@@ -109,7 +110,7 @@ const UserProfileTab: React.FC<UserProfileTabProps> = ({ user, activity }) => {
       company: user.company
         ? {
             name: user.company.name,
-            displayName: user.company.name,
+            displayName: user.company.displayName || user.company.name,
             isVerified: false,
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString(),
@@ -215,9 +216,12 @@ const UserProfileTab: React.FC<UserProfileTabProps> = ({ user, activity }) => {
               <strong>{t('profile.labelEmail')}</strong> {user.email}
             </Typography>
             {user.company && (
-              <Typography variant="body1" sx={{ mt: 1 }}>
-                <strong>{t('profile.labelCompany')}</strong> {user.company.name}
-              </Typography>
+              <Box sx={{ mt: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography variant="body1" component="span">
+                  <strong>{t('profile.labelCompany')}</strong>
+                </Typography>
+                <CompanyLogo companyName={user.company.name} variant="avatar" avatarSize={28} />
+              </Box>
             )}
             {user.bio && (
               <Typography variant="body1" sx={{ mt: 1 }}>


### PR DESCRIPTION
Ports the public (tailwind) selection-locked company combobox approach (PR #774) to the **MUI organizer/admin surfaces**.

### Key point
The shared MUI `CompanyAutocomplete` lives in `PartnerManagement/` but is consumed by **three** places — reworking it once lands the new approach in all of them:
- `UserProfileTab` (**My Profile** edit)
- `UserCreateEditModal` (admin **Edit User** modal)
- `PartnerCreateEditModal` (**partner** create/edit)

### CompanyAutocomplete (shared, MUI)
- Input shows the human **display name**, never the ADR-003 slug (kills the slug-echo).
- Dropdown requests `?include=logo`; the selected value renders its logo as a **start-adornment avatar** (resolved via `GET /companies/{slug}`), falling back to the display-name initial.
- Explicit **"Create new company"** row when no existing company matches. Picking it **materialises** the company via `POST /companies:get-or-create` and reports the resulting canonical-slug `Company` — so every parent's existing `company.name` save logic keeps working unchanged (no per-parent divergence).
- New `allowCreate` prop (default `true`). Create is suppressed while loading / on search error so those states surface instead of being masked.

### Readonly views → logo + display name (via shared `CompanyLogo`)
- `UserProfileTab` readonly section
- `UserDetailModal`
- `PartnerCreateEditModal` edit-mode company line (the partner *detail header* already rendered a logo)

### Deliberate divergence from the public flow
The public registration/profile **defers** company creation to save (high-volume anonymous, abandonment-prone). The admin surfaces **materialise on-select** — authenticated organizers, low abandonment risk, and `get-or-create` is idempotent. This keeps all three heterogeneous parents unchanged.

### i18n
`companySearch.createOption` added to all 10 locales.

### Verification
- `tsc --noEmit` clean
- ESLint clean
- **411 tests pass** across the touched dirs (`PartnerManagement`, `UserManagement`, `user`). Added display-name + create-flow coverage to `CompanyAutocomplete`; updated `UserDetailModal` and `PartnerCreateEditModal` tests for `CompanyLogo`'s async fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)