### PR TITLE
fix(events): stop slides-online blasting subscribers + add Registrant Notices tab

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,24 +43,42 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
+            STEP 1 — Load the project's rules BEFORE reviewing. Read both of these files
+            from the checked-out repository and treat them as the standard you review against:
+              1. `_bmad-output/project-context.md` — the distilled, authoritative rules AI
+                 agents and contributors MUST follow in this codebase: scope/architecture
+                 decisions (ADR-003 cross-service identifiers, ADR-004 domain entity design,
+                 ADR-006 OpenAPI contract-first, ADR-009 unified speaker workflow, the
+                 enum value-flow UPPER/lowercase rule, the no-MUI-on-public-pages bundle
+                 boundary, the Flyway never-edit-an-applied-migration rule, the i18n locale
+                 rules, the Testcontainers/PostgreSQL testing rules, auth/JWT patterns, etc.).
+              2. `CLAUDE.md` — style, conventions, and workflow guidance.
+
+            STEP 2 — Review this pull request AGAINST those rules and provide feedback on:
+            - Adherence to project-context.md — call out the specific rule any change
+              violates (e.g. "ADR-003: storing a UUID FK across services", "enum stored
+              UPPER_CASE in DB", "MUI imported on a public page", "edited an applied
+              Flyway migration", "new i18n key missing in some of the 10 locales").
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
-            - Test coverage
+            - Test coverage (integration tests must use PostgreSQL/Testcontainers, not H2)
             - Documentation drift: if this PR modifies business logic, scheduler
               behaviour, state machine transitions, or API contracts, check whether
               the relevant docs in docs/architecture/, docs/prd/, or docs/api/ are
               included in the diff. If not, note which docs likely need updating and why.
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            If you cannot read `_bmad-output/project-context.md`, say so explicitly in your
+            review rather than reviewing without it. Be constructive and helpful.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # Read/Grep/Glob are allowed so the reviewer can load project-context.md + CLAUDE.md
+          # and inspect any referenced source before commenting.
+          claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
   doc-drift-check:
     name: Doc Drift Check

--- a/_bmad-output/implementation-artifacts/7-3-slides-online-mail.md
+++ b/_bmad-output/implementation-artifacts/7-3-slides-online-mail.md
@@ -152,3 +152,35 @@ _Resolved with the PM 2026-06-10._
 
 1. **Is the due date 2 weeks *after* the event (not before)?** Slides go up after the event, so the task should fall due ~14 days *after* the event date (offset `+14`). The original phrasing was ambiguous ("two weeks … of the event"). The story assumes **+14 after**; please confirm so the seed offset sign is right.
 2. **Reuse the existing newsletter-send endpoint, or a dedicated slides-online send?** The cleanest reuse is the existing `POST …/newsletter/send` with `templateKey=slides-online` plus a "recipients = event registrants" flag. If you'd rather keep the registrant-targeted send fully separate from the subscriber newsletter (different audit, different metrics), say so — it changes whether we extend `NewsletterEmailService` or add a sibling service.
+
+---
+
+## Safety hardening + organizer UI (2026-06-12)
+
+**Problem found (review):** the original 7.3 had NO organizer UI for the dedicated, safe
+`/slides-online/send` (registrant-targeted) endpoint — and the `slides-online` template was
+categorised `NEWSLETTER`, so it appeared in the Event → **Newsletter** tab's template picker.
+Selecting it there and clicking Send would have **blasted the entire newsletter-subscriber pool**
+(the subscriber send passed any `templateKey` straight through, no whitelist). The only reachable
+action was the dangerous one.
+
+**Fix (this change):**
+1. **Backend reject (defence in depth):** `NewsletterEmailService.preview`/`sendNewsletter` now
+   reject any `REGISTRANT_NOTICE`-category template with a 400 — the subscriber pool can never be
+   sent a registrant template, regardless of UI.
+2. **Recategorise:** `deriveCategory("slides-online") → REGISTRANT_NOTICE` (was `NEWSLETTER`), so it
+   no longer appears in the subscriber-newsletter picker. Forward migration **V114** recategorises
+   the already-seeded staging/prod rows (seeding is insert-only).
+3. **Generalised, safe send + preview:** `SlidesOnlineEmailService` gained
+   `sendRegistrantNotice(event, templateKey, sentBy)` + `previewRegistrantNotice(event, templateKey,
+   locale)` (validates the template is `REGISTRANT_NOTICE`); `sendSlidesOnline` now delegates.
+   New `RegistrantNoticeController`: `POST /events/{code}/registrant-notices/{preview,send}`
+   (ORGANIZER). OpenAPI + regenerated FE types.
+4. **New organizer tab "Registrant Notices"** (`EventRegistrantNoticesTab`, sibling of Newsletter):
+   pick a `REGISTRANT_NOTICE` template + preview language, preview iframe (shows active-registrant
+   count), send + confirm. The actual send still resolves each registrant's language (AC4); the
+   selector is preview-only. i18n in all 10 locales.
+
+**Tests:** `NewsletterEmailServiceTest` rejects a REGISTRANT_NOTICE template (preview + send);
+`SlidesOnlineEmailServiceTest` (5) green with the new category guard; `EventRegistrantNoticesTab`
+test (4). Backend `compileJava`/`compileTestJava` + FE `tsc`/ESLint clean.

--- a/_bmad-output/implementation-artifacts/7-3-slides-online-mail.md
+++ b/_bmad-output/implementation-artifacts/7-3-slides-online-mail.md
@@ -184,3 +184,13 @@ action was the dangerous one.
 **Tests:** `NewsletterEmailServiceTest` rejects a REGISTRANT_NOTICE template (preview + send);
 `SlidesOnlineEmailServiceTest` (5) green with the new category guard; `EventRegistrantNoticesTab`
 test (4). Backend `compileJava`/`compileTestJava` + FE `tsc`/ESLint clean.
+
+### Recipient-status correction (2026-06-12)
+
+Found while testing on local: the send/preview targeted only `['registered','confirmed']`, but a
+registrant notice fires POST-event (task due event+1d), by which time a completed event's
+registrants are `attended`. So for BATbern57 (173 `attended` + 1 `confirmed`) the preview/confirm
+showed **0 recipients**. Fixed: `ACTIVE_REGISTRANT_STATUSES` now reuses the canonical
+`Registration.CONFIRMED_STATUSES` = `[registered, confirmed, attended]` (excludes `waitlist` and
+`cancelled`). This corrects the original AC2 wording, which assumed the mail goes out while
+registrations are still registered/confirmed. Integration test gains an `attended` recipient.

--- a/docs/api/events-api.openapi.yml
+++ b/docs/api/events-api.openapi.yml
@@ -5699,6 +5699,84 @@ paths:
         '409':
           description: A slides-online send is already in progress or has already been sent
 
+  /events/{eventCode}/registrant-notices/preview:
+    post:
+      tags: [Newsletter]
+      summary: Preview a registrant-notice mail in a chosen language (ORGANIZER)
+      description: |
+        Story 7.3 hardening — renders a REGISTRANT_NOTICE-category template (e.g. slides-online)
+        in the chosen preview language and reports how many active registrants would receive it.
+        The actual send still resolves each registrant's own language; this locale is preview-only.
+        Rejects (400) a template that is not REGISTRANT_NOTICE.
+      operationId: previewRegistrantNotice
+      parameters:
+        - name: eventCode
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegistrantNoticePreviewRequest'
+      responses:
+        '200':
+          description: Rendered preview + recipient count
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegistrantNoticePreviewResponse'
+        '400':
+          description: Template is not a registrant-notice template
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Event not found
+
+  /events/{eventCode}/registrant-notices/send:
+    post:
+      tags: [Newsletter]
+      summary: Send a registrant-notice mail to the event's active registrants (ORGANIZER)
+      description: |
+        Story 7.3 hardening — sends a REGISTRANT_NOTICE-category template (e.g. slides-online) to the
+        event's ACTIVE REGISTRANTS (registered/confirmed), NOT the newsletter-subscriber pool. Honours
+        the global newsletter opt-out, resolves the language per recipient (de*/en/else→German), guards
+        against double-send (409), and runs asynchronously. Rejects (400) a non-REGISTRANT_NOTICE template.
+      operationId: sendRegistrantNotice
+      parameters:
+        - name: eventCode
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegistrantNoticeSendRequest'
+      responses:
+        '200':
+          description: Registrant-notice send queued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SlidesOnlineSendResponse'
+        '400':
+          description: Template is not a registrant-notice template
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Event not found
+        '409':
+          description: A send of this template is already in progress or has already been sent
+
   /events/{eventCode}/newsletter/send:
     post:
       tags: [Newsletter]
@@ -6588,6 +6666,43 @@ components:
         recipientCount:
           type: integer
           description: Number of active registrants resolved as the recipient base.
+
+    RegistrantNoticePreviewRequest:
+      type: object
+      description: Story 7.3 hardening — request to preview a registrant-notice mail.
+      required: [templateKey]
+      properties:
+        templateKey:
+          type: string
+          description: A REGISTRANT_NOTICE-category template key (e.g. slides-online).
+        locale:
+          type: string
+          enum: [de, en]
+          description: Preview language; defaults to German when omitted/unknown.
+
+    RegistrantNoticeSendRequest:
+      type: object
+      description: Story 7.3 hardening — request to send a registrant-notice mail to registrants.
+      required: [templateKey]
+      properties:
+        templateKey:
+          type: string
+          description: A REGISTRANT_NOTICE-category template key (e.g. slides-online).
+
+    RegistrantNoticePreviewResponse:
+      type: object
+      description: Story 7.3 hardening — rendered preview + active-registrant recipient count.
+      required: [subject, htmlPreview, recipientCount]
+      properties:
+        subject:
+          type: string
+          description: Rendered, variable-substituted subject line.
+        htmlPreview:
+          type: string
+          description: Rendered, layout-merged HTML body for the preview iframe.
+        recipientCount:
+          type: integer
+          description: Number of active registrants (registered/confirmed) who would receive the mail.
 
     NewsletterSendStatusResponse:
       type: object

--- a/docs/api/events-api.openapi.yml
+++ b/docs/api/events-api.openapi.yml
@@ -4859,10 +4859,10 @@ paths:
         - name: category
           in: query
           required: false
-          description: Filter by category (SPEAKER, REGISTRATION, TASK_REMINDER, LAYOUT, NEWSLETTER, VENUE_COORDINATION)
+          description: Filter by category (SPEAKER, REGISTRATION, TASK_REMINDER, LAYOUT, NEWSLETTER, VENUE_COORDINATION, REGISTRANT_NOTICE)
           schema:
             type: string
-            enum: [SPEAKER, REGISTRATION, TASK_REMINDER, LAYOUT, NEWSLETTER, VENUE_COORDINATION]
+            enum: [SPEAKER, REGISTRATION, TASK_REMINDER, LAYOUT, NEWSLETTER, VENUE_COORDINATION, REGISTRANT_NOTICE]
         - name: isLayout
           in: query
           required: false
@@ -7057,7 +7057,7 @@ components:
         category:
           type: string
           description: Template category
-          enum: [SPEAKER, REGISTRATION, TASK_REMINDER, LAYOUT, NEWSLETTER, VENUE_COORDINATION]
+          enum: [SPEAKER, REGISTRATION, TASK_REMINDER, LAYOUT, NEWSLETTER, VENUE_COORDINATION, REGISTRANT_NOTICE]
         subject:
           type: string
           nullable: true
@@ -7107,7 +7107,7 @@ components:
         category:
           type: string
           description: Template category
-          enum: [SPEAKER, REGISTRATION, TASK_REMINDER, LAYOUT, NEWSLETTER, VENUE_COORDINATION]
+          enum: [SPEAKER, REGISTRATION, TASK_REMINDER, LAYOUT, NEWSLETTER, VENUE_COORDINATION, REGISTRANT_NOTICE]
         subject:
           type: string
           nullable: true

--- a/services/event-management-service/src/main/java/ch/batbern/events/controller/RegistrantNoticeController.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/controller/RegistrantNoticeController.java
@@ -1,0 +1,79 @@
+package ch.batbern.events.controller;
+
+import ch.batbern.events.domain.Event;
+import ch.batbern.events.dto.RegistrantNoticePreviewRequest;
+import ch.batbern.events.dto.RegistrantNoticePreviewResponse;
+import ch.batbern.events.dto.RegistrantNoticeSendRequest;
+import ch.batbern.events.dto.SlidesOnlineSendResponse;
+import ch.batbern.events.repository.EventRepository;
+import ch.batbern.events.security.SecurityContextHelper;
+import ch.batbern.events.service.SlidesOnlineEmailService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Story 7.3 hardening — ORGANIZER-only endpoints to preview and send a registrant-notice mail
+ * (any {@code REGISTRANT_NOTICE}-category template, e.g. {@code slides-online}) to an event's
+ * <b>active registrants</b>.
+ *
+ * <p>This is the safe, dedicated send path that the "Registrant Notices" organizer tab uses.
+ * It is intentionally separate from {@code NewsletterController} (subscriber blast); the
+ * subscriber newsletter now hard-rejects {@code REGISTRANT_NOTICE} templates, and those
+ * templates no longer appear in the subscriber-newsletter picker.
+ */
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Slf4j
+public class RegistrantNoticeController {
+
+    private final SlidesOnlineEmailService registrantNoticeEmailService;
+    private final EventRepository eventRepository;
+    private final SecurityContextHelper securityContextHelper;
+
+    /**
+     * Preview a registrant-notice template in a chosen language and report the recipient count.
+     */
+    @PostMapping("/events/{eventCode}/registrant-notices/preview")
+    @PreAuthorize("hasRole('ORGANIZER')")
+    public ResponseEntity<RegistrantNoticePreviewResponse> preview(
+            @PathVariable String eventCode,
+            @Valid @RequestBody RegistrantNoticePreviewRequest request) {
+        Event event = findEventOrThrow(eventCode);
+        RegistrantNoticePreviewResponse preview = registrantNoticeEmailService
+                .previewRegistrantNotice(event, request.getTemplateKey(), request.getLocale());
+        return ResponseEntity.ok(preview);
+    }
+
+    /**
+     * Send a registrant-notice mail to the event's active registrants (ORGANIZER only).
+     *
+     * @return 200 with the send id + PENDING status (the send runs asynchronously)
+     */
+    @PostMapping("/events/{eventCode}/registrant-notices/send")
+    @PreAuthorize("hasRole('ORGANIZER')")
+    public ResponseEntity<SlidesOnlineSendResponse> send(
+            @PathVariable String eventCode,
+            @Valid @RequestBody RegistrantNoticeSendRequest request) {
+        Event event = findEventOrThrow(eventCode);
+        String sentByUsername = securityContextHelper.getCurrentUsername();
+        SlidesOnlineSendResponse response = registrantNoticeEmailService
+                .sendRegistrantNotice(event, request.getTemplateKey(), sentByUsername);
+        return ResponseEntity.ok(response);
+    }
+
+    private Event findEventOrThrow(String eventCode) {
+        return eventRepository.findByEventCode(eventCode)
+                .orElseThrow(() -> new NoSuchElementException("Event not found: " + eventCode));
+    }
+}

--- a/services/event-management-service/src/main/java/ch/batbern/events/dto/RegistrantNoticePreviewRequest.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/dto/RegistrantNoticePreviewRequest.java
@@ -1,0 +1,22 @@
+package ch.batbern.events.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request to preview a registrant-notice mail (Story 7.3 hardening — Registrant Notices tab).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegistrantNoticePreviewRequest {
+
+    /** Template key — must be a {@code REGISTRANT_NOTICE}-category template (e.g. slides-online). */
+    @NotBlank
+    private String templateKey;
+
+    /** Preview language (de/en). Defaults to German when null/unknown. */
+    private String locale;
+}

--- a/services/event-management-service/src/main/java/ch/batbern/events/dto/RegistrantNoticePreviewResponse.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/dto/RegistrantNoticePreviewResponse.java
@@ -1,0 +1,29 @@
+package ch.batbern.events.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Preview of a registrant-notice mail (Story 7.3 hardening — Registrant Notices tab).
+ *
+ * <p>Rendered subject + HTML for the organizer's chosen preview language, plus the count of
+ * active registrants the send would reach. The actual send still resolves each registrant's own
+ * language (AC4) — this preview locale only controls what the organizer sees.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegistrantNoticePreviewResponse {
+
+    /** Rendered, variable-substituted subject line. */
+    private String subject;
+
+    /** Rendered, layout-merged HTML body for the preview iframe. */
+    private String htmlPreview;
+
+    /** Number of active registrants (registered/confirmed) who would receive the mail. */
+    private int recipientCount;
+}

--- a/services/event-management-service/src/main/java/ch/batbern/events/dto/RegistrantNoticeSendRequest.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/dto/RegistrantNoticeSendRequest.java
@@ -1,0 +1,20 @@
+package ch.batbern.events.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request to send a registrant-notice mail to an event's active registrants
+ * (Story 7.3 hardening — Registrant Notices tab).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegistrantNoticeSendRequest {
+
+    /** Template key — must be a {@code REGISTRANT_NOTICE}-category template (e.g. slides-online). */
+    @NotBlank
+    private String templateKey;
+}

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/EmailTemplateSeedService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/EmailTemplateSeedService.java
@@ -164,11 +164,13 @@ public class EmailTemplateSeedService {
         if (templateKey.startsWith("newsletter-")) {
             return "NEWSLETTER";
         }
-        // Story 7.3: the "slides are online" mail is a newsletter-style send to event
-        // registrants. It does not carry the "newsletter-" prefix, so map it explicitly —
-        // otherwise it would fall through to LAYOUT.
+        // Story 7.3 (hardened): the "slides are online" mail goes to event REGISTRANTS, not the
+        // newsletter-subscriber pool. It lives in its own REGISTRANT_NOTICE category so it is
+        // surfaced ONLY in the dedicated "Registrant Notices" tab and can NEVER be selected in the
+        // subscriber-newsletter picker (where sending it would blast every subscriber). The
+        // NewsletterEmailService also hard-rejects REGISTRANT_NOTICE templates as defence in depth.
         if (templateKey.startsWith("slides-online")) {
-            return "NEWSLETTER";
+            return "REGISTRANT_NOTICE";
         }
         // Story (venue-coordination): outbound mails to the event venue + caterer.
         // Both share one category so the Event Detail Venue tab dropdown can list them

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/NewsletterEmailService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/NewsletterEmailService.java
@@ -198,6 +198,7 @@ public class NewsletterEmailService {
     public NewsletterPreviewResponse preview(Event event, boolean isReminder, String locale,
                                               @Nullable String templateKey, boolean testMode) {
         String effectiveKey = resolveTemplateKey(templateKey);
+        rejectRegistrantTemplate(effectiveKey, locale);
         Map<String, String> vars = buildVariables(event, locale, isReminder,
                 baseUrl + "/unsubscribe?token=PREVIEW");
         String contentHtml = renderContent(locale, vars, effectiveKey);
@@ -257,6 +258,7 @@ public class NewsletterEmailService {
                                                   @Nullable Integer maxRecipients,
                                                   boolean testMode) {
         String effectiveKey = resolveTemplateKey(templateKey);
+        rejectRegistrantTemplate(effectiveKey, locale);
 
         // Duplicate-send prevention: reject if a send is already in progress for this event.
         sendRepository.findFirstByEventIdAndStatus(event.getId(), STATUS_IN_PROGRESS)
@@ -930,6 +932,23 @@ public class NewsletterEmailService {
 
     private String resolveTemplateKey(@Nullable String templateKey) {
         return (templateKey != null && !templateKey.isBlank()) ? templateKey : DEFAULT_TEMPLATE_KEY;
+    }
+
+    /**
+     * Defence in depth (Story 7.3 hardening): the subscriber newsletter must NEVER send a
+     * registrant-targeted template (category {@code REGISTRANT_NOTICE}, e.g. {@code slides-online})
+     * to the global subscriber pool. Reject it with 400 ({@link IllegalArgumentException}) — those
+     * templates go through the dedicated Registrant Notices send, which targets event registrants.
+     */
+    private void rejectRegistrantTemplate(String templateKey, String locale) {
+        emailTemplateService.findByKeyAndLocale(templateKey, locale)
+                .filter(t -> "REGISTRANT_NOTICE".equalsIgnoreCase(t.getCategory()))
+                .ifPresent(t -> {
+                    throw new IllegalArgumentException(
+                            "Template '" + templateKey + "' targets event registrants (category "
+                            + "REGISTRANT_NOTICE) and cannot be sent to newsletter subscribers. "
+                            + "Use the Registrant Notices tab.");
+                });
     }
 
     private String renderContent(String locale, Map<String, String> vars, String templateKey) {

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/SlidesOnlineEmailService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/SlidesOnlineEmailService.java
@@ -373,6 +373,14 @@ public class SlidesOnlineEmailService {
         vars.put("eventDate", formatEventDate(event, isDe ? Locale.GERMAN : Locale.ENGLISH));
         vars.put("eventDetailLink", baseUrl + "/events/" + event.getEventCode());
         vars.put("currentYear", String.valueOf(Year.now().getValue()));
+        // batbern-default layout variables (the layout is shared with the newsletter; without
+        // these the merged email shows literal {{logoUrl}} etc. — replaceVariables leaves
+        // unmatched placeholders untouched). logoUrl matches the newsletter (white logo on the
+        // dark header); the footer links point at the public site / event detail.
+        vars.put("logoUrl", baseUrl + "/BATbern_white_logo.png");
+        vars.put("eventUrl", baseUrl + "/events/" + event.getEventCode());
+        vars.put("dashboardLink", baseUrl);
+        vars.put("supportUrl", baseUrl);
         return vars;
     }
 

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/SlidesOnlineEmailService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/SlidesOnlineEmailService.java
@@ -6,6 +6,7 @@ import ch.batbern.events.domain.NewsletterRecipient;
 import ch.batbern.events.domain.NewsletterRecipientId;
 import ch.batbern.events.domain.NewsletterSend;
 import ch.batbern.events.domain.Registration;
+import ch.batbern.events.dto.RegistrantNoticePreviewResponse;
 import ch.batbern.events.dto.SlidesOnlineSendResponse;
 import ch.batbern.events.exception.DuplicateNewsletterSendException;
 import ch.batbern.events.exception.SlidesOnlineAlreadySentException;
@@ -124,39 +125,94 @@ public class SlidesOnlineEmailService {
      * @throws SlidesOnlineAlreadySentException (409) if a slides-online send already completed
      */
     public SlidesOnlineSendResponse sendSlidesOnline(Event event, String sentByUsername) {
+        return sendRegistrantNotice(event, TEMPLATE_KEY, sentByUsername);
+    }
+
+    /**
+     * Initiate a registrant-notice send for an event's active registrants using any
+     * {@code REGISTRANT_NOTICE}-category template (e.g. {@code slides-online}).
+     *
+     * <p>Creates the audit row (status {@code PENDING}), launches the {@code @Async} worker, and
+     * returns immediately. Guards against double-send per (event, templateKey).
+     *
+     * @throws IllegalArgumentException (400) if the template is not a REGISTRANT_NOTICE template
+     * @throws DuplicateNewsletterSendException (409) if such a send is already IN_PROGRESS
+     * @throws SlidesOnlineAlreadySentException (409) if such a send already completed for the event
+     */
+    public SlidesOnlineSendResponse sendRegistrantNotice(Event event, String templateKey,
+                                                         String sentByUsername) {
+        requireRegistrantNoticeTemplate(templateKey);
         UUID eventId = event.getId();
 
-        // AC5: reuse the in-progress guard, scoped to the slides-online template.
-        sendRepository.findFirstByEventIdAndTemplateKeyAndStatus(eventId, TEMPLATE_KEY, STATUS_IN_PROGRESS)
+        // AC5: in-progress guard, scoped to (event, templateKey).
+        sendRepository.findFirstByEventIdAndTemplateKeyAndStatus(eventId, templateKey, STATUS_IN_PROGRESS)
                 .ifPresent(active -> {
                     throw new DuplicateNewsletterSendException(
-                            "A slides-online send is already in progress for event "
+                            "A '" + templateKey + "' send is already in progress for event "
                             + event.getEventCode() + " (sendId=" + active.getId() + ")");
                 });
 
-        // AC5: a completed slides-online send must not re-fire (one-shot, event-triggered).
+        // AC5: a completed send of this template must not re-fire (one-shot, event-triggered).
         if (sendRepository.existsByEventIdAndTemplateKeyAndStatusIn(
-                eventId, TEMPLATE_KEY, List.of(STATUS_COMPLETED, STATUS_PARTIAL))) {
+                eventId, templateKey, List.of(STATUS_COMPLETED, STATUS_PARTIAL))) {
             throw new SlidesOnlineAlreadySentException(
-                    "The slides-online mail has already been sent for event " + event.getEventCode());
+                    "The '" + templateKey + "' mail has already been sent for event "
+                    + event.getEventCode());
         }
 
         List<Registration> registrants =
                 registrationRepository.findByEventIdAndStatusIn(eventId, ACTIVE_REGISTRANT_STATUSES);
 
-        NewsletterSend saved = createSendAuditRecord(event, sentByUsername, registrants.size());
+        NewsletterSend saved = createSendAuditRecord(event, templateKey, sentByUsername, registrants.size());
 
         // Launch background job via the proxy so @Async is honoured.
-        self.executeSlidesOnlineSendAsync(saved.getId(), event);
+        self.executeSlidesOnlineSendAsync(saved.getId(), event, templateKey);
 
-        log.info("Slides-online send queued: sendId={}, event={}, registrants={}",
-                saved.getId(), event.getEventCode(), registrants.size());
+        log.info("Registrant-notice send queued: sendId={}, event={}, template={}, registrants={}",
+                saved.getId(), event.getEventCode(), templateKey, registrants.size());
 
         return SlidesOnlineSendResponse.builder()
                 .sendId(saved.getId())
                 .status(STATUS_PENDING)
                 .recipientCount(registrants.size())
                 .build();
+    }
+
+    /**
+     * Render a registrant-notice template for preview in a chosen language and report how many
+     * active registrants would receive it. The actual SEND still resolves each registrant's own
+     * language (AC4); this preview locale only controls what the organizer sees.
+     */
+    @Transactional(readOnly = true)
+    public RegistrantNoticePreviewResponse previewRegistrantNotice(Event event, String templateKey,
+                                                                   String locale) {
+        requireRegistrantNoticeTemplate(templateKey);
+        String loc = "en".equalsIgnoreCase(locale) ? "en" : "de";
+        RenderedMail mail = renderMail(event, templateKey, loc);
+        int recipientCount = registrationRepository
+                .findByEventIdAndStatusIn(event.getId(), ACTIVE_REGISTRANT_STATUSES).size();
+        return RegistrantNoticePreviewResponse.builder()
+                .subject(mail.subject())
+                .htmlPreview(mail.html())
+                .recipientCount(recipientCount)
+                .build();
+    }
+
+    /**
+     * Guard: only templates categorised {@code REGISTRANT_NOTICE} may be sent to registrants.
+     * Prevents a subscriber-newsletter template from being blasted to registrants by mistake
+     * (the symmetric counterpart of {@code NewsletterEmailService#rejectRegistrantTemplate}).
+     */
+    private void requireRegistrantNoticeTemplate(String templateKey) {
+        boolean isRegistrantNotice = java.util.stream.Stream.of("de", "en")
+                .map(l -> emailTemplateService.findByKeyAndLocale(templateKey, l))
+                .flatMap(Optional::stream)
+                .anyMatch(t -> "REGISTRANT_NOTICE".equalsIgnoreCase(t.getCategory()));
+        if (!isRegistrantNotice) {
+            throw new IllegalArgumentException(
+                    "Template '" + templateKey + "' is not a registrant-notice template "
+                    + "(category REGISTRANT_NOTICE) and cannot be sent to registrants.");
+        }
     }
 
     // ── Async worker ───────────────────────────────────────────────────────────
@@ -167,15 +223,15 @@ public class SlidesOnlineEmailService {
      * it deterministically without a thread-pool race).
      */
     @Async
-    public void executeSlidesOnlineSendAsync(UUID sendId, Event event) {
-        processSend(sendId, event);
+    public void executeSlidesOnlineSendAsync(UUID sendId, Event event, String templateKey) {
+        processSend(sendId, event, templateKey);
     }
 
     /**
      * Synchronous send core: resolve active registrants, skip opt-outs, send the locale-correct
      * template to each, record per-recipient audit, isolate per-recipient failures, throttle for SES.
      */
-    void processSend(UUID sendId, Event event) {
+    void processSend(UUID sendId, Event event, String templateKey) {
         markInProgress(sendId);
 
         // Render once per locale (body + subject are identical for all recipients of a locale).
@@ -209,7 +265,8 @@ public class SlidesOnlineEmailService {
                 }
 
                 String locale = resolveLocale(registration.getAttendeeUsername());
-                RenderedMail mail = renderedByLocale.computeIfAbsent(locale, l -> renderMail(event, l));
+                RenderedMail mail =
+                        renderedByLocale.computeIfAbsent(locale, l -> renderMail(event, templateKey, l));
 
                 String deliveryStatus = "sent";
                 try {
@@ -279,21 +336,21 @@ public class SlidesOnlineEmailService {
 
     // ── Rendering ────────────────────────────────────────────────────────────────
 
-    private RenderedMail renderMail(Event event, String locale) {
+    private RenderedMail renderMail(Event event, String templateKey, String locale) {
         Map<String, String> vars = buildVariables(event, locale);
 
         Optional<ch.batbern.events.domain.EmailTemplate> templateOpt =
-                emailTemplateService.findByKeyAndLocale(TEMPLATE_KEY, locale);
+                emailTemplateService.findByKeyAndLocale(templateKey, locale);
         String contentHtml = templateOpt
                 .map(t -> emailService.replaceVariables(t.getHtmlBody(), vars))
                 .orElseGet(() -> {
-                    log.warn("Slides-online template '{}' locale '{}' not found in DB", TEMPLATE_KEY, locale);
+                    log.warn("Registrant-notice template '{}' locale '{}' not found in DB", templateKey, locale);
                     return "<p>The slides are online.</p>";
                 });
         String mergedHtml = emailService.replaceVariables(
                 emailTemplateService.mergeWithLayout(contentHtml, LAYOUT_KEY, locale), vars);
 
-        String subject = emailTemplateService.resolveSubject(TEMPLATE_KEY, locale)
+        String subject = emailTemplateService.resolveSubject(templateKey, locale)
                 .map(s -> emailService.replaceVariables(s, vars))
                 .orElseGet(() -> ("de".equals(locale) ? "Die Folien sind online — " : "The slides are online — ")
                         + event.getTitle());
@@ -337,10 +394,11 @@ public class SlidesOnlineEmailService {
     // ── @Transactional audit helpers (short, autonomous transactions) ─────────────
 
     @Transactional
-    protected NewsletterSend createSendAuditRecord(Event event, String sentByUsername, int recipientCount) {
+    protected NewsletterSend createSendAuditRecord(Event event, String templateKey,
+                                                   String sentByUsername, int recipientCount) {
         NewsletterSend send = NewsletterSend.builder()
                 .eventId(event.getId())
-                .templateKey(TEMPLATE_KEY)
+                .templateKey(templateKey)
                 .reminder(false)
                 .locale("de") // nominal — actual locale is resolved per recipient (AC4)
                 .sentAt(Instant.now())

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/SlidesOnlineEmailService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/SlidesOnlineEmailService.java
@@ -75,8 +75,14 @@ public class SlidesOnlineEmailService {
     static final String TEMPLATE_KEY = "slides-online";
     private static final String LAYOUT_KEY = "batbern-default";
 
-    /** Active registrant statuses that receive the mail (AC2). */
-    static final List<String> ACTIVE_REGISTRANT_STATUSES = List.of("registered", "confirmed");
+    /**
+     * Registrant statuses that receive the mail. Uses the canonical "confirmed/attending" set
+     * ({@code registered} + {@code confirmed} + {@code attended}) — NOT just registered/confirmed:
+     * a registrant notice (e.g. slides-online) is sent POST-event (the seeded task is due event+1d),
+     * by which time real registrants of a completed event are {@code attended}. Excludes
+     * {@code waitlist} (never got a seat) and {@code cancelled}.
+     */
+    static final List<String> ACTIVE_REGISTRANT_STATUSES = Registration.CONFIRMED_STATUSES;
 
     static final String STATUS_PENDING = "PENDING";
     static final String STATUS_IN_PROGRESS = "IN_PROGRESS";

--- a/services/event-management-service/src/main/resources/db/migration/V114__recategorize_slides_online_as_registrant_notice.sql
+++ b/services/event-management-service/src/main/resources/db/migration/V114__recategorize_slides_online_as_registrant_notice.sql
@@ -1,0 +1,14 @@
+-- Story 7.3 hardening: the "slides-online" template is a REGISTRANT-targeted notice, NOT a
+-- subscriber newsletter. It was originally seeded with category NEWSLETTER, which made it
+-- selectable in the Event → Newsletter tab — where sending it would blast ALL newsletter
+-- subscribers instead of the event's registrants. Recategorise it to REGISTRANT_NOTICE so it
+-- no longer appears in the subscriber-newsletter template picker (it now lives in the dedicated
+-- "Registrant Notices" tab). Mirrors V68 (which fixed the newsletter category the same way).
+--
+-- EmailTemplateSeedService is insert-only (it never updates an existing row's category), so the
+-- deriveCategory() change alone would only affect fresh environments — this migration fixes the
+-- rows already seeded in staging/production.
+UPDATE email_templates
+SET category = 'REGISTRANT_NOTICE'
+WHERE template_key = 'slides-online'
+  AND category != 'REGISTRANT_NOTICE';

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/NewsletterEmailServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/NewsletterEmailServiceTest.java
@@ -374,7 +374,7 @@ class NewsletterEmailServiceTest {
 
         newsletterEmailService.preview(testEvent, false, "de", "custom-newsletter");
 
-        verify(emailTemplateService).findByKeyAndLocale("custom-newsletter", "de");
+        verify(emailTemplateService, atLeastOnce()).findByKeyAndLocale("custom-newsletter", "de");
         verify(emailTemplateService, never()).findByKeyAndLocale("newsletter-event", "de");
     }
 
@@ -394,7 +394,29 @@ class NewsletterEmailServiceTest {
 
         newsletterEmailService.preview(testEvent, false, "de", null);
 
-        verify(emailTemplateService).findByKeyAndLocale("newsletter-event", "de");
+        verify(emailTemplateService, atLeastOnce()).findByKeyAndLocale("newsletter-event", "de");
+    }
+
+    @Test
+    @DisplayName("Story 7.3 hardening: a REGISTRANT_NOTICE template is rejected (400) — never blasted to subscribers")
+    void rejectsRegistrantNoticeTemplateOnSubscriberSend() {
+        testEvent.setId(UUID.randomUUID());
+        EmailTemplate registrantTpl = mockTemplate("slides-online", "de", "<p>slides</p>");
+        registrantTpl.setCategory("REGISTRANT_NOTICE");
+        when(emailTemplateService.findByKeyAndLocale("slides-online", "de"))
+                .thenReturn(Optional.of(registrantTpl));
+
+        // Preview is blocked...
+        assertThatThrownBy(() -> newsletterEmailService.preview(testEvent, false, "de", "slides-online"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Registrant Notices");
+
+        // ...and so is the actual subscriber send — the registrant pool must never be blasted.
+        assertThatThrownBy(() -> newsletterEmailService.sendNewsletter(
+                testEvent, false, "de", "org.user", "slides-online"))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(sendRepository, never()).save(any());
     }
 
     private EmailTemplate mockTemplate(String key, String locale, String html) {

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/SlidesOnlineEmailServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/SlidesOnlineEmailServiceTest.java
@@ -108,6 +108,7 @@ class SlidesOnlineEmailServiceTest {
     @Test
     @DisplayName("sendSlidesOnline: in-progress send → 409 DuplicateNewsletterSendException")
     void sendSlidesOnline_inProgress_throwsDuplicate() {
+        stubIsRegistrantNoticeTemplate();
         when(sendRepository.findFirstByEventIdAndTemplateKeyAndStatus(
                 event.getId(), "slides-online", "IN_PROGRESS"))
                 .thenReturn(Optional.of(NewsletterSend.builder().id(UUID.randomUUID()).build()));
@@ -121,6 +122,7 @@ class SlidesOnlineEmailServiceTest {
     @Test
     @DisplayName("sendSlidesOnline: already-sent → 409 SlidesOnlineAlreadySentException")
     void sendSlidesOnline_alreadySent_throws() {
+        stubIsRegistrantNoticeTemplate();
         when(sendRepository.findFirstByEventIdAndTemplateKeyAndStatus(
                 event.getId(), "slides-online", "IN_PROGRESS")).thenReturn(Optional.empty());
         when(sendRepository.existsByEventIdAndTemplateKeyAndStatusIn(
@@ -133,6 +135,7 @@ class SlidesOnlineEmailServiceTest {
     @Test
     @DisplayName("sendSlidesOnline: no prior send → creates audit row + returns PENDING with registrant count")
     void sendSlidesOnline_happy_returnsPending() {
+        stubIsRegistrantNoticeTemplate();
         when(sendRepository.findFirstByEventIdAndTemplateKeyAndStatus(
                 event.getId(), "slides-online", "IN_PROGRESS")).thenReturn(Optional.empty());
         when(sendRepository.existsByEventIdAndTemplateKeyAndStatusIn(
@@ -155,7 +158,7 @@ class SlidesOnlineEmailServiceTest {
         assertThat(resp.getSendId()).isEqualTo(sendId);
         assertThat(resp.getStatus()).isEqualTo("PENDING");
         assertThat(resp.getRecipientCount()).isEqualTo(2);
-        verify(selfMock).executeSlidesOnlineSendAsync(sendId, event);
+        verify(selfMock).executeSlidesOnlineSendAsync(sendId, event, "slides-online");
     }
 
     // ── processSend: recipients, opt-out, counts (AC2, AC3, AC6) ────────────
@@ -179,7 +182,7 @@ class SlidesOnlineEmailServiceTest {
         NewsletterSend send = pendingSend();
         when(sendRepository.findById(sendId)).thenReturn(Optional.of(send));
 
-        service.processSend(sendId, event);
+        service.processSend(sendId, event, "slides-online");
 
         // Two active, non-opted-out recipients → two sends; opted-out skipped.
         verify(emailService, times(2)).sendHtmlEmailSync(anyString(), anyString(), anyString(), any());
@@ -195,6 +198,13 @@ class SlidesOnlineEmailServiceTest {
     // computeIfAbsent interaction that does not reflect production behaviour, so it is omitted.
 
     // ── helpers ─────────────────────────────────────────────────────────────
+
+    /** Make the slides-online template resolve as a REGISTRANT_NOTICE so the send-guard passes. */
+    private void stubIsRegistrantNoticeTemplate() {
+        EmailTemplate t = new EmailTemplate();
+        t.setCategory("REGISTRANT_NOTICE");
+        when(emailTemplateService.findByKeyAndLocale("slides-online", "de")).thenReturn(Optional.of(t));
+    }
 
     private void stubRenderingAndSend() {
         EmailTemplate template = new EmailTemplate();

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/SlidesOnlineIntegrationTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/SlidesOnlineIntegrationTest.java
@@ -150,7 +150,7 @@ class SlidesOnlineIntegrationTest extends AbstractIntegrationTest {
         lenient().when(userApiClient.getPreferredLanguage("att.fr")).thenReturn("fr");
 
         NewsletterSend send = savePendingSend(event.getId());
-        slidesOnlineEmailService.processSend(send.getId(), event);
+        slidesOnlineEmailService.processSend(send.getId(), event, "slides-online");
 
         // Capture every (to, subject) the send dispatched.
         var toCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
@@ -197,7 +197,7 @@ class SlidesOnlineIntegrationTest extends AbstractIntegrationTest {
                         org.mockito.ArgumentMatchers.any());
 
         NewsletterSend send = savePendingSend(event.getId());
-        slidesOnlineEmailService.processSend(send.getId(), event);
+        slidesOnlineEmailService.processSend(send.getId(), event, "slides-online");
 
         NewsletterSend result = sendRepository.findById(send.getId()).orElseThrow();
         assertThat(result.getStatus()).isEqualTo("PARTIAL");

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/SlidesOnlineIntegrationTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/SlidesOnlineIntegrationTest.java
@@ -136,6 +136,7 @@ class SlidesOnlineIntegrationTest extends AbstractIntegrationTest {
         saveRegistration(event.getId(), "att.en", "en@x.ch", "registered");   // EN
         saveRegistration(event.getId(), "att.de", "de@x.ch", "confirmed");    // DE
         saveRegistration(event.getId(), "att.fr", "fr@x.ch", "confirmed");    // fr → German fallback
+        saveRegistration(event.getId(), "att.attd", "attended@x.ch", "attended"); // INCLUDED: post-event status
         saveRegistration(event.getId(), "att.cancel", "cancel@x.ch", "cancelled"); // excluded (status)
         saveRegistration(event.getId(), "att.wait", "wait@x.ch", "waitlist");      // excluded (status)
         saveRegistration(event.getId(), "att.opt", "opt@x.ch", "registered");      // excluded (opt-out)
@@ -148,6 +149,7 @@ class SlidesOnlineIntegrationTest extends AbstractIntegrationTest {
         lenient().when(userApiClient.getPreferredLanguage("att.en")).thenReturn("en");
         lenient().when(userApiClient.getPreferredLanguage("att.de")).thenReturn("de");
         lenient().when(userApiClient.getPreferredLanguage("att.fr")).thenReturn("fr");
+        lenient().when(userApiClient.getPreferredLanguage("att.attd")).thenReturn("en");
 
         NewsletterSend send = savePendingSend(event.getId());
         slidesOnlineEmailService.processSend(send.getId(), event, "slides-online");
@@ -155,7 +157,7 @@ class SlidesOnlineIntegrationTest extends AbstractIntegrationTest {
         // Capture every (to, subject) the send dispatched.
         var toCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
         var subjectCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
-        org.mockito.Mockito.verify(emailService, org.mockito.Mockito.times(3))
+        org.mockito.Mockito.verify(emailService, org.mockito.Mockito.times(4))
                 .sendHtmlEmailSync(toCaptor.capture(), subjectCaptor.capture(), anyString(),
                         org.mockito.ArgumentMatchers.any());
 
@@ -164,21 +166,23 @@ class SlidesOnlineIntegrationTest extends AbstractIntegrationTest {
             subjectByEmail.put(toCaptor.getAllValues().get(i), subjectCaptor.getAllValues().get(i));
         }
 
-        // Only the three active, non-opted-out registrants received the mail.
-        assertThat(subjectByEmail.keySet()).containsExactlyInAnyOrder("en@x.ch", "de@x.ch", "fr@x.ch");
+        // The active, non-opted-out registrants — including the post-event 'attended' one — received it.
+        assertThat(subjectByEmail.keySet())
+                .containsExactlyInAnyOrder("en@x.ch", "de@x.ch", "fr@x.ch", "attended@x.ch");
         assertThat(subjectByEmail).doesNotContainKeys("cancel@x.ch", "wait@x.ch", "opt@x.ch");
 
         // Per-recipient locale: en → English subject; de + fr(fallback) → German subject.
         assertThat(subjectByEmail.get("en@x.ch")).contains("The slides are online");
         assertThat(subjectByEmail.get("de@x.ch")).contains("Die Folien sind online");
         assertThat(subjectByEmail.get("fr@x.ch")).contains("Die Folien sind online");
+        assertThat(subjectByEmail.get("attended@x.ch")).contains("The slides are online");
 
         NewsletterSend completed = sendRepository.findById(send.getId()).orElseThrow();
         assertThat(completed.getStatus()).isEqualTo("COMPLETED");
-        assertThat(completed.getSentCount()).isEqualTo(3);
+        assertThat(completed.getSentCount()).isEqualTo(4);
         assertThat(completed.getFailedCount()).isZero();
         assertThat(recipientRepository.findAll())
-                .filteredOn(r -> "sent".equals(r.getDeliveryStatus())).hasSize(3);
+                .filteredOn(r -> "sent".equals(r.getDeliveryStatus())).hasSize(4);
     }
 
     // ── AC6: per-recipient failure isolation ─────────────────────────────────

--- a/web-frontend/public/locales/de/common.json
+++ b/web-frontend/public/locales/de/common.json
@@ -632,7 +632,8 @@
       "REGISTRATION": "Registrierungs-E-Mails",
       "TASK_REMINDER": "Aufgaben-Erinnerungen",
       "NEWSLETTER": "Newsletter",
-      "VENUE_COORDINATION": "Veranstaltungsort & Catering"
+      "VENUE_COORDINATION": "Veranstaltungsort & Catering",
+      "REGISTRANT_NOTICE": "Teilnehmer-Infos"
     },
     "layoutKey": "Layout",
     "standalone": "Kein Layout (eigenständig)",

--- a/web-frontend/public/locales/de/events.json
+++ b/web-frontend/public/locales/de/events.json
@@ -238,10 +238,13 @@
       "previewTitle": "E-Mail-Vorschau",
       "description": "Sende eine einmalige Info (z. B. «die Folien sind online») an die Teilnehmer dieses Events. Empfänger sind die aktiven Angemeldeten – nicht die Newsletter-Abonnenten – und jeder erhält die Mail in seiner Sprache.",
       "confirmBody": "«{{templateKey}}» an {{count}} aktive Angemeldete von «{{eventTitle}}» senden? Jede:r erhält die Mail in der eigenen Sprache.",
-      "sendQueued": "In Warteschlange – wird an {{count}} Angemeldete gesendet.",
       "recipientCount": "{{count}} aktive Angemeldete",
       "noTemplates": "Noch keine Teilnehmer-Info-Vorlage für diese Sprache.",
-      "error": "Etwas ist schiefgelaufen. Bitte versuche es erneut."
+      "error": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",
+      "sending": "Wird gesendet… {{sent}} / {{total}}",
+      "sendResult": "An {{sent}} von {{total}} Angemeldete gesendet.",
+      "sendResultSkipped": "{{count}} ohne E-Mail-Adresse hinterlegt (übersprungen).",
+      "sendResultFailed": "{{count}} fehlgeschlagen."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/de/events.json
+++ b/web-frontend/public/locales/de/events.json
@@ -12,7 +12,8 @@
       "publishing": "Veröffentlichung",
       "newsletter": "Newsletter",
       "settings": "Einstellungen",
-      "photos": "Fotos"
+      "photos": "Fotos",
+      "registrantNotices": "Teilnehmer-Infos"
     },
     "tabsAriaLabel": "Veranstaltungsseiten-Navigation",
     "overview": {
@@ -226,6 +227,21 @@
       "confirmSend": "Ja, senden",
       "sentSuccess": "An {{count}} Empfänger gesendet.",
       "sentFailed": "Versand fehlgeschlagen: {{message}}"
+    },
+    "registrantNotices": {
+      "title": "Teilnehmer-Infos",
+      "preview": "Vorschau",
+      "send": "An Teilnehmer senden",
+      "locale": "Vorschausprache",
+      "templateSelect": "Vorlage",
+      "confirmTitle": "An Teilnehmer senden?",
+      "previewTitle": "E-Mail-Vorschau",
+      "description": "Sende eine einmalige Info (z. B. «die Folien sind online») an die Teilnehmer dieses Events. Empfänger sind die aktiven Angemeldeten – nicht die Newsletter-Abonnenten – und jeder erhält die Mail in seiner Sprache.",
+      "confirmBody": "«{{templateKey}}» an {{count}} aktive Angemeldete von «{{eventTitle}}» senden? Jede:r erhält die Mail in der eigenen Sprache.",
+      "sendQueued": "In Warteschlange – wird an {{count}} Angemeldete gesendet.",
+      "recipientCount": "{{count}} aktive Angemeldete",
+      "noTemplates": "Noch keine Teilnehmer-Info-Vorlage für diese Sprache.",
+      "error": "Etwas ist schiefgelaufen. Bitte versuche es erneut."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/de/events.json
+++ b/web-frontend/public/locales/de/events.json
@@ -244,7 +244,8 @@
       "sending": "Wird gesendet… {{sent}} / {{total}}",
       "sendResult": "An {{sent}} von {{total}} Angemeldete gesendet.",
       "sendResultSkipped": "{{count}} ohne E-Mail-Adresse hinterlegt (übersprungen).",
-      "sendResultFailed": "{{count}} fehlgeschlagen."
+      "sendResultFailed": "{{count}} fehlgeschlagen.",
+      "alreadySent": "Diese Mitteilung wurde für diesen Event bereits gesendet (oder ein Versand läuft)."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/en/common.json
+++ b/web-frontend/public/locales/en/common.json
@@ -667,7 +667,8 @@
       "REGISTRATION": "Registration",
       "TASK_REMINDER": "Task Reminders",
       "NEWSLETTER": "Newsletter",
-      "VENUE_COORDINATION": "Venue & Catering"
+      "VENUE_COORDINATION": "Venue & Catering",
+      "REGISTRANT_NOTICE": "Registrant Notices"
     },
     "layoutKey": "Layout",
     "standalone": "None (standalone)",

--- a/web-frontend/public/locales/en/events.json
+++ b/web-frontend/public/locales/en/events.json
@@ -244,7 +244,8 @@
       "sending": "Sending… {{sent}} / {{total}}",
       "sendResult": "Sent to {{sent}} of {{total}} registrants.",
       "sendResultSkipped": "{{count}} had no email address on file (skipped).",
-      "sendResultFailed": "{{count}} failed."
+      "sendResultFailed": "{{count}} failed.",
+      "alreadySent": "This notice has already been sent (or a send is in progress) for this event."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/en/events.json
+++ b/web-frontend/public/locales/en/events.json
@@ -12,7 +12,8 @@
       "publishing": "Publishing",
       "newsletter": "Newsletter",
       "settings": "Settings",
-      "photos": "Photos"
+      "photos": "Photos",
+      "registrantNotices": "Registrant Notices"
     },
     "tabsAriaLabel": "Event page navigation",
     "overview": {
@@ -226,6 +227,21 @@
       "confirmSend": "Yes, send",
       "sentSuccess": "Sent to {{count}} recipient(s).",
       "sentFailed": "Send failed: {{message}}"
+    },
+    "registrantNotices": {
+      "title": "Registrant Notices",
+      "preview": "Preview",
+      "send": "Send to registrants",
+      "locale": "Preview language",
+      "templateSelect": "Template",
+      "confirmTitle": "Send to registrants?",
+      "previewTitle": "Email Preview",
+      "description": "Send a one-off notice (e.g. “the slides are online”) to this event’s registrants. Recipients are the active registrants — not newsletter subscribers — and each gets the mail in their own language.",
+      "confirmBody": "Send '{{templateKey}}' to {{count}} active registrants of «{{eventTitle}}»? Each receives it in their own language.",
+      "sendQueued": "Queued — sending to {{count}} registrants.",
+      "recipientCount": "{{count}} active registrants",
+      "noTemplates": "No registrant-notice template for this language yet.",
+      "error": "Something went wrong. Please try again."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/en/events.json
+++ b/web-frontend/public/locales/en/events.json
@@ -238,10 +238,13 @@
       "previewTitle": "Email Preview",
       "description": "Send a one-off notice (e.g. “the slides are online”) to this event’s registrants. Recipients are the active registrants — not newsletter subscribers — and each gets the mail in their own language.",
       "confirmBody": "Send '{{templateKey}}' to {{count}} active registrants of «{{eventTitle}}»? Each receives it in their own language.",
-      "sendQueued": "Queued — sending to {{count}} registrants.",
       "recipientCount": "{{count}} active registrants",
       "noTemplates": "No registrant-notice template for this language yet.",
-      "error": "Something went wrong. Please try again."
+      "error": "Something went wrong. Please try again.",
+      "sending": "Sending… {{sent}} / {{total}}",
+      "sendResult": "Sent to {{sent}} of {{total}} registrants.",
+      "sendResultSkipped": "{{count}} had no email address on file (skipped).",
+      "sendResultFailed": "{{count}} failed."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/es/common.json
+++ b/web-frontend/public/locales/es/common.json
@@ -630,7 +630,8 @@
       "REGISTRATION": "Inscripción",
       "TASK_REMINDER": "Recordatorios de tareas",
       "NEWSLETTER": "Boletín",
-      "VENUE_COORDINATION": "Lugar y Catering"
+      "VENUE_COORDINATION": "Lugar y Catering",
+      "REGISTRANT_NOTICE": "Avisos a inscritos"
     },
     "layoutKey": "Diseño",
     "standalone": "Ninguno (independiente)",

--- a/web-frontend/public/locales/es/events.json
+++ b/web-frontend/public/locales/es/events.json
@@ -230,7 +230,8 @@
       "sending": "Enviando… {{sent}} / {{total}}",
       "sendResult": "Enviado a {{sent}} de {{total}} inscritos.",
       "sendResultSkipped": "{{count}} sin dirección de correo registrada (omitidos).",
-      "sendResultFailed": "{{count}} con error."
+      "sendResultFailed": "{{count}} con error.",
+      "alreadySent": "Este aviso ya se ha enviado (o hay un envío en curso) para este evento."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/es/events.json
+++ b/web-frontend/public/locales/es/events.json
@@ -224,10 +224,13 @@
       "previewTitle": "Vista previa del correo",
       "description": "Envía un aviso puntual (p. ej. «las diapositivas están en línea») a los inscritos de este evento. Los destinatarios son los inscritos activos, no los suscriptores del boletín, y cada uno lo recibe en su idioma.",
       "confirmBody": "¿Enviar «{{templateKey}}» a {{count}} inscritos activos de «{{eventTitle}}»? Cada uno lo recibe en su idioma.",
-      "sendQueued": "En cola — enviando a {{count}} inscritos.",
       "recipientCount": "{{count}} inscritos activos",
       "noTemplates": "Aún no hay plantilla de aviso a inscritos para este idioma.",
-      "error": "Algo salió mal. Inténtalo de nuevo."
+      "error": "Algo salió mal. Inténtalo de nuevo.",
+      "sending": "Enviando… {{sent}} / {{total}}",
+      "sendResult": "Enviado a {{sent}} de {{total}} inscritos.",
+      "sendResultSkipped": "{{count}} sin dirección de correo registrada (omitidos).",
+      "sendResultFailed": "{{count}} con error."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/es/events.json
+++ b/web-frontend/public/locales/es/events.json
@@ -12,7 +12,8 @@
       "publishing": "Publicación",
       "newsletter": "Newsletter",
       "settings": "Configuración",
-      "photos": "Fotos"
+      "photos": "Fotos",
+      "registrantNotices": "Avisos a inscritos"
     },
     "tabsAriaLabel": "Navegación de la página de evento",
     "overview": {
@@ -212,6 +213,21 @@
       "confirmSend": "Sí, enviar",
       "sentSuccess": "Enviado a {{count}} destinatario(s).",
       "sentFailed": "Error de envío: {{message}}"
+    },
+    "registrantNotices": {
+      "title": "Avisos a inscritos",
+      "preview": "Vista previa",
+      "send": "Enviar a inscritos",
+      "locale": "Idioma de vista previa",
+      "templateSelect": "Plantilla",
+      "confirmTitle": "¿Enviar a inscritos?",
+      "previewTitle": "Vista previa del correo",
+      "description": "Envía un aviso puntual (p. ej. «las diapositivas están en línea») a los inscritos de este evento. Los destinatarios son los inscritos activos, no los suscriptores del boletín, y cada uno lo recibe en su idioma.",
+      "confirmBody": "¿Enviar «{{templateKey}}» a {{count}} inscritos activos de «{{eventTitle}}»? Cada uno lo recibe en su idioma.",
+      "sendQueued": "En cola — enviando a {{count}} inscritos.",
+      "recipientCount": "{{count}} inscritos activos",
+      "noTemplates": "Aún no hay plantilla de aviso a inscritos para este idioma.",
+      "error": "Algo salió mal. Inténtalo de nuevo."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/fi/common.json
+++ b/web-frontend/public/locales/fi/common.json
@@ -630,7 +630,8 @@
       "REGISTRATION": "Ilmoittautuminen",
       "TASK_REMINDER": "Tehtävämuistutukset",
       "NEWSLETTER": "Uutiskirje",
-      "VENUE_COORDINATION": "Tila & Catering"
+      "VENUE_COORDINATION": "Tila & Catering",
+      "REGISTRANT_NOTICE": "Ilmoittautuneiden tiedotteet"
     },
     "layoutKey": "Asettelu",
     "standalone": "Ei mitään (itsenäinen)",

--- a/web-frontend/public/locales/fi/events.json
+++ b/web-frontend/public/locales/fi/events.json
@@ -224,10 +224,13 @@
       "previewTitle": "Sähköpostin esikatselu",
       "description": "Lähetä kertaluonteinen tiedote (esim. ”diat ovat verkossa”) tämän tapahtuman ilmoittautuneille. Vastaanottajat ovat aktiiviset ilmoittautuneet – eivät uutiskirjeen tilaajat – ja kukin saa sen omalla kielellään.",
       "confirmBody": "Lähetetäänkö ”{{templateKey}}” {{count}} aktiiviselle ilmoittautuneelle tapahtumasta «{{eventTitle}}»? Kukin saa sen omalla kielellään.",
-      "sendQueued": "Jonossa – lähetetään {{count}} ilmoittautuneelle.",
       "recipientCount": "{{count}} aktiivista ilmoittautunutta",
       "noTemplates": "Tälle kielelle ei vielä ole ilmoittautuneiden tiedotemallia.",
-      "error": "Jokin meni pieleen. Yritä uudelleen."
+      "error": "Jokin meni pieleen. Yritä uudelleen.",
+      "sending": "Lähetetään… {{sent}} / {{total}}",
+      "sendResult": "Lähetetty {{sent}}/{{total}} ilmoittautuneelle.",
+      "sendResultSkipped": "{{count}} ilman sähköpostiosoitetta (ohitettu).",
+      "sendResultFailed": "{{count}} epäonnistui."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/fi/events.json
+++ b/web-frontend/public/locales/fi/events.json
@@ -12,7 +12,8 @@
       "publishing": "Julkaisu",
       "newsletter": "Uutiskirje",
       "settings": "Asetukset",
-      "photos": "Valokuvat"
+      "photos": "Valokuvat",
+      "registrantNotices": "Ilmoittautuneiden tiedotteet"
     },
     "tabsAriaLabel": "Tapahtumassivun navigointi",
     "overview": {
@@ -212,6 +213,21 @@
       "confirmSend": "Kyllä, lähetä",
       "sentSuccess": "Lähetetty {{count}} vastaanottajalle.",
       "sentFailed": "Lähetys epäonnistui: {{message}}"
+    },
+    "registrantNotices": {
+      "title": "Ilmoittautuneiden tiedotteet",
+      "preview": "Esikatselu",
+      "send": "Lähetä ilmoittautuneille",
+      "locale": "Esikatselun kieli",
+      "templateSelect": "Malli",
+      "confirmTitle": "Lähetetäänkö ilmoittautuneille?",
+      "previewTitle": "Sähköpostin esikatselu",
+      "description": "Lähetä kertaluonteinen tiedote (esim. ”diat ovat verkossa”) tämän tapahtuman ilmoittautuneille. Vastaanottajat ovat aktiiviset ilmoittautuneet – eivät uutiskirjeen tilaajat – ja kukin saa sen omalla kielellään.",
+      "confirmBody": "Lähetetäänkö ”{{templateKey}}” {{count}} aktiiviselle ilmoittautuneelle tapahtumasta «{{eventTitle}}»? Kukin saa sen omalla kielellään.",
+      "sendQueued": "Jonossa – lähetetään {{count}} ilmoittautuneelle.",
+      "recipientCount": "{{count}} aktiivista ilmoittautunutta",
+      "noTemplates": "Tälle kielelle ei vielä ole ilmoittautuneiden tiedotemallia.",
+      "error": "Jokin meni pieleen. Yritä uudelleen."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/fi/events.json
+++ b/web-frontend/public/locales/fi/events.json
@@ -230,7 +230,8 @@
       "sending": "Lähetetään… {{sent}} / {{total}}",
       "sendResult": "Lähetetty {{sent}}/{{total}} ilmoittautuneelle.",
       "sendResultSkipped": "{{count}} ilman sähköpostiosoitetta (ohitettu).",
-      "sendResultFailed": "{{count}} epäonnistui."
+      "sendResultFailed": "{{count}} epäonnistui.",
+      "alreadySent": "Tämä tiedote on jo lähetetty (tai lähetys on käynnissä) tälle tapahtumalle."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/fr/common.json
+++ b/web-frontend/public/locales/fr/common.json
@@ -630,7 +630,8 @@
       "REGISTRATION": "Inscription",
       "TASK_REMINDER": "Rappels de tâches",
       "NEWSLETTER": "Newsletter",
-      "VENUE_COORDINATION": "Lieu & Restauration"
+      "VENUE_COORDINATION": "Lieu & Restauration",
+      "REGISTRANT_NOTICE": "Infos participants"
     },
     "layoutKey": "Mise en page",
     "standalone": "Aucune (autonome)",

--- a/web-frontend/public/locales/fr/events.json
+++ b/web-frontend/public/locales/fr/events.json
@@ -12,7 +12,8 @@
       "publishing": "Publication",
       "newsletter": "Newsletter",
       "settings": "Paramètres",
-      "photos": "Photos"
+      "photos": "Photos",
+      "registrantNotices": "Infos participants"
     },
     "tabsAriaLabel": "Navigation de la page événement",
     "overview": {
@@ -212,6 +213,21 @@
       "confirmSend": "Oui, envoyer",
       "sentSuccess": "Envoyé à {{count}} destinataire(s).",
       "sentFailed": "Échec de l'envoi : {{message}}"
+    },
+    "registrantNotices": {
+      "title": "Infos participants",
+      "preview": "Aperçu",
+      "send": "Envoyer aux inscrits",
+      "locale": "Langue d’aperçu",
+      "templateSelect": "Modèle",
+      "confirmTitle": "Envoyer aux inscrits ?",
+      "previewTitle": "Aperçu de l’e-mail",
+      "description": "Envoyez une info ponctuelle (p. ex. « les diapos sont en ligne ») aux inscrits de cet événement. Les destinataires sont les inscrits actifs — pas les abonnés à la newsletter — et chacun la reçoit dans sa langue.",
+      "confirmBody": "Envoyer « {{templateKey}} » à {{count}} inscrits actifs de «{{eventTitle}}» ? Chacun la reçoit dans sa langue.",
+      "sendQueued": "En file — envoi à {{count}} inscrits.",
+      "recipientCount": "{{count}} inscrits actifs",
+      "noTemplates": "Aucun modèle d’info participants pour cette langue.",
+      "error": "Une erreur s’est produite. Veuillez réessayer."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/fr/events.json
+++ b/web-frontend/public/locales/fr/events.json
@@ -224,10 +224,13 @@
       "previewTitle": "Aperçu de l’e-mail",
       "description": "Envoyez une info ponctuelle (p. ex. « les diapos sont en ligne ») aux inscrits de cet événement. Les destinataires sont les inscrits actifs — pas les abonnés à la newsletter — et chacun la reçoit dans sa langue.",
       "confirmBody": "Envoyer « {{templateKey}} » à {{count}} inscrits actifs de «{{eventTitle}}» ? Chacun la reçoit dans sa langue.",
-      "sendQueued": "En file — envoi à {{count}} inscrits.",
       "recipientCount": "{{count}} inscrits actifs",
       "noTemplates": "Aucun modèle d’info participants pour cette langue.",
-      "error": "Une erreur s’est produite. Veuillez réessayer."
+      "error": "Une erreur s’est produite. Veuillez réessayer.",
+      "sending": "Envoi… {{sent}} / {{total}}",
+      "sendResult": "Envoyé à {{sent}} inscrits sur {{total}}.",
+      "sendResultSkipped": "{{count}} sans adresse e-mail enregistrée (ignorés).",
+      "sendResultFailed": "{{count}} en échec."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/fr/events.json
+++ b/web-frontend/public/locales/fr/events.json
@@ -230,7 +230,8 @@
       "sending": "Envoi… {{sent}} / {{total}}",
       "sendResult": "Envoyé à {{sent}} inscrits sur {{total}}.",
       "sendResultSkipped": "{{count}} sans adresse e-mail enregistrée (ignorés).",
-      "sendResultFailed": "{{count}} en échec."
+      "sendResultFailed": "{{count}} en échec.",
+      "alreadySent": "Cette information a déjà été envoyée (ou un envoi est en cours) pour cet événement."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/gsw-BE/common.json
+++ b/web-frontend/public/locales/gsw-BE/common.json
@@ -535,7 +535,8 @@
       "REGISTRATION": "Amäldigä",
       "TASK_REMINDER": "Ufgabeerinnerige",
       "NEWSLETTER": "Newsletter",
-      "VENUE_COORDINATION": "Lokau & Catering"
+      "VENUE_COORDINATION": "Lokau & Catering",
+      "REGISTRANT_NOTICE": "Teilnähmer-Infos"
     },
     "layoutKey": "Layout",
     "standalone": "Keis (eigenständig)",

--- a/web-frontend/public/locales/gsw-BE/events.json
+++ b/web-frontend/public/locales/gsw-BE/events.json
@@ -236,7 +236,8 @@
       "sending": "Wird gschickt… {{sent}} / {{total}}",
       "sendResult": "A {{sent}} vo {{total}} Aagmäldeti gschickt.",
       "sendResultSkipped": "{{count}} ohni E-Mail-Adrässe (übersprunge).",
-      "sendResultFailed": "{{count}} fehlgschlage."
+      "sendResultFailed": "{{count}} fehlgschlage.",
+      "alreadySent": "Die Mitteilig isch für dää Event scho gschickt worde (oder e Versand louft grad)."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/gsw-BE/events.json
+++ b/web-frontend/public/locales/gsw-BE/events.json
@@ -230,10 +230,13 @@
       "previewTitle": "E-Mail-Vorschou",
       "description": "Schick e einmaligi Info (z.B. «d Folie si online») a d Teilnähmer vo däm Event. Empfänger si di aktive Aagmäldete – nid d Newsletter-Abonnänte – u jede überchunnt s Mail i siner Sprach.",
       "confirmBody": "«{{templateKey}}» a {{count}} aktivi Aagmäldeti vo «{{eventTitle}}» schicke? Jede überchunnt s i siner Sprach.",
-      "sendQueued": "I dr Warteschlange – wird a {{count}} Aagmäldeti gschickt.",
       "recipientCount": "{{count}} aktivi Aagmäldeti",
       "noTemplates": "No kei Teilnähmer-Info-Vorlag für die Sprach.",
-      "error": "Öppis isch schiefgloffe. Bitte versuechs nomal."
+      "error": "Öppis isch schiefgloffe. Bitte versuechs nomal.",
+      "sending": "Wird gschickt… {{sent}} / {{total}}",
+      "sendResult": "A {{sent}} vo {{total}} Aagmäldeti gschickt.",
+      "sendResultSkipped": "{{count}} ohni E-Mail-Adrässe (übersprunge).",
+      "sendResultFailed": "{{count}} fehlgschlage."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/gsw-BE/events.json
+++ b/web-frontend/public/locales/gsw-BE/events.json
@@ -12,7 +12,8 @@
       "publishing": "Veröffentlichig",
       "newsletter": "Newsletter",
       "settings": "Istellige",
-      "photos": "Fotos"
+      "photos": "Fotos",
+      "registrantNotices": "Teilnähmer-Infos"
     },
     "tabsAriaLabel": "Veranstautigsnavigation",
     "overview": {
@@ -218,6 +219,21 @@
       "confirmSend": "Jo, schicke",
       "sentSuccess": "A {{count}} Empfänger gschickt.",
       "sentFailed": "S Schicke het nid klappt: {{message}}"
+    },
+    "registrantNotices": {
+      "title": "Teilnähmer-Infos",
+      "preview": "Vorschou",
+      "send": "A Teilnähmer schicke",
+      "locale": "Vorschousprach",
+      "templateSelect": "Vorlag",
+      "confirmTitle": "A Teilnähmer schicke?",
+      "previewTitle": "E-Mail-Vorschou",
+      "description": "Schick e einmaligi Info (z.B. «d Folie si online») a d Teilnähmer vo däm Event. Empfänger si di aktive Aagmäldete – nid d Newsletter-Abonnänte – u jede überchunnt s Mail i siner Sprach.",
+      "confirmBody": "«{{templateKey}}» a {{count}} aktivi Aagmäldeti vo «{{eventTitle}}» schicke? Jede überchunnt s i siner Sprach.",
+      "sendQueued": "I dr Warteschlange – wird a {{count}} Aagmäldeti gschickt.",
+      "recipientCount": "{{count}} aktivi Aagmäldeti",
+      "noTemplates": "No kei Teilnähmer-Info-Vorlag für die Sprach.",
+      "error": "Öppis isch schiefgloffe. Bitte versuechs nomal."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/it/common.json
+++ b/web-frontend/public/locales/it/common.json
@@ -630,7 +630,8 @@
       "REGISTRATION": "Iscrizione",
       "TASK_REMINDER": "Promemoria attività",
       "NEWSLETTER": "Newsletter",
-      "VENUE_COORDINATION": "Sede & Catering"
+      "VENUE_COORDINATION": "Sede & Catering",
+      "REGISTRANT_NOTICE": "Avvisi iscritti"
     },
     "layoutKey": "Layout",
     "standalone": "Nessuno (autonomo)",

--- a/web-frontend/public/locales/it/events.json
+++ b/web-frontend/public/locales/it/events.json
@@ -230,7 +230,8 @@
       "sending": "Invio… {{sent}} / {{total}}",
       "sendResult": "Inviato a {{sent}} iscritti su {{total}}.",
       "sendResultSkipped": "{{count}} senza indirizzo e-mail registrato (saltati).",
-      "sendResultFailed": "{{count}} non riusciti."
+      "sendResultFailed": "{{count}} non riusciti.",
+      "alreadySent": "Questo avviso è già stato inviato (o un invio è in corso) per questo evento."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/it/events.json
+++ b/web-frontend/public/locales/it/events.json
@@ -12,7 +12,8 @@
       "publishing": "Pubblicazione",
       "newsletter": "Newsletter",
       "settings": "Impostazioni",
-      "photos": "Foto"
+      "photos": "Foto",
+      "registrantNotices": "Avvisi iscritti"
     },
     "tabsAriaLabel": "Navigazione pagina evento",
     "overview": {
@@ -212,6 +213,21 @@
       "confirmSend": "Sì, invia",
       "sentSuccess": "Inviato a {{count}} destinatario/i.",
       "sentFailed": "Invio fallito: {{message}}"
+    },
+    "registrantNotices": {
+      "title": "Avvisi iscritti",
+      "preview": "Anteprima",
+      "send": "Invia agli iscritti",
+      "locale": "Lingua anteprima",
+      "templateSelect": "Modello",
+      "confirmTitle": "Inviare agli iscritti?",
+      "previewTitle": "Anteprima e-mail",
+      "description": "Invia un avviso una tantum (es. «le slide sono online») agli iscritti di questo evento. I destinatari sono gli iscritti attivi — non gli abbonati alla newsletter — e ognuno la riceve nella propria lingua.",
+      "confirmBody": "Inviare «{{templateKey}}» a {{count}} iscritti attivi di «{{eventTitle}}»? Ognuno la riceve nella propria lingua.",
+      "sendQueued": "In coda — invio a {{count}} iscritti.",
+      "recipientCount": "{{count}} iscritti attivi",
+      "noTemplates": "Nessun modello di avviso iscritti per questa lingua.",
+      "error": "Qualcosa è andato storto. Riprova."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/it/events.json
+++ b/web-frontend/public/locales/it/events.json
@@ -224,10 +224,13 @@
       "previewTitle": "Anteprima e-mail",
       "description": "Invia un avviso una tantum (es. «le slide sono online») agli iscritti di questo evento. I destinatari sono gli iscritti attivi — non gli abbonati alla newsletter — e ognuno la riceve nella propria lingua.",
       "confirmBody": "Inviare «{{templateKey}}» a {{count}} iscritti attivi di «{{eventTitle}}»? Ognuno la riceve nella propria lingua.",
-      "sendQueued": "In coda — invio a {{count}} iscritti.",
       "recipientCount": "{{count}} iscritti attivi",
       "noTemplates": "Nessun modello di avviso iscritti per questa lingua.",
-      "error": "Qualcosa è andato storto. Riprova."
+      "error": "Qualcosa è andato storto. Riprova.",
+      "sending": "Invio… {{sent}} / {{total}}",
+      "sendResult": "Inviato a {{sent}} iscritti su {{total}}.",
+      "sendResultSkipped": "{{count}} senza indirizzo e-mail registrato (saltati).",
+      "sendResultFailed": "{{count}} non riusciti."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/ja/common.json
+++ b/web-frontend/public/locales/ja/common.json
@@ -630,7 +630,8 @@
       "REGISTRATION": "登録",
       "TASK_REMINDER": "タスクリマインダー",
       "NEWSLETTER": "ニュースレター",
-      "VENUE_COORDINATION": "会場とケータリング"
+      "VENUE_COORDINATION": "会場とケータリング",
+      "REGISTRANT_NOTICE": "参加者へのお知らせ"
     },
     "layoutKey": "レイアウト",
     "standalone": "なし（スタンドアロン）",

--- a/web-frontend/public/locales/ja/events.json
+++ b/web-frontend/public/locales/ja/events.json
@@ -224,10 +224,13 @@
       "previewTitle": "メールプレビュー",
       "description": "このイベントの参加者に一度限りのお知らせ（例：「スライドを公開しました」）を送ります。宛先はニュースレター購読者ではなくアクティブな参加者で、各自の言語で届きます。",
       "confirmBody": "「{{templateKey}}」を「{{eventTitle}}」のアクティブな参加者 {{count}} 名に送信しますか？各自の言語で届きます。",
-      "sendQueued": "送信待ち — {{count}} 名の参加者に送信します。",
       "recipientCount": "アクティブな参加者 {{count}} 名",
       "noTemplates": "この言語の参加者向けお知らせテンプレートはまだありません。",
-      "error": "問題が発生しました。もう一度お試しください。"
+      "error": "問題が発生しました。もう一度お試しください。",
+      "sending": "送信中… {{sent}} / {{total}}",
+      "sendResult": "{{total}} 名中 {{sent}} 名の参加者に送信しました。",
+      "sendResultSkipped": "{{count}} 名はメールアドレス未登録のためスキップしました。",
+      "sendResultFailed": "{{count}} 名が失敗しました。"
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/ja/events.json
+++ b/web-frontend/public/locales/ja/events.json
@@ -12,7 +12,8 @@
       "publishing": "公開",
       "newsletter": "ニュースレター",
       "settings": "設定",
-      "photos": "写真"
+      "photos": "写真",
+      "registrantNotices": "参加者へのお知らせ"
     },
     "tabsAriaLabel": "イベントページのナビゲーション",
     "overview": {
@@ -212,6 +213,21 @@
       "confirmSend": "はい、送信",
       "sentSuccess": "{{count}} 名の受信者に送信しました。",
       "sentFailed": "送信に失敗しました：{{message}}"
+    },
+    "registrantNotices": {
+      "title": "参加者へのお知らせ",
+      "preview": "プレビュー",
+      "send": "参加者に送信",
+      "locale": "プレビュー言語",
+      "templateSelect": "テンプレート",
+      "confirmTitle": "参加者に送信しますか？",
+      "previewTitle": "メールプレビュー",
+      "description": "このイベントの参加者に一度限りのお知らせ（例：「スライドを公開しました」）を送ります。宛先はニュースレター購読者ではなくアクティブな参加者で、各自の言語で届きます。",
+      "confirmBody": "「{{templateKey}}」を「{{eventTitle}}」のアクティブな参加者 {{count}} 名に送信しますか？各自の言語で届きます。",
+      "sendQueued": "送信待ち — {{count}} 名の参加者に送信します。",
+      "recipientCount": "アクティブな参加者 {{count}} 名",
+      "noTemplates": "この言語の参加者向けお知らせテンプレートはまだありません。",
+      "error": "問題が発生しました。もう一度お試しください。"
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/ja/events.json
+++ b/web-frontend/public/locales/ja/events.json
@@ -230,7 +230,8 @@
       "sending": "送信中… {{sent}} / {{total}}",
       "sendResult": "{{total}} 名中 {{sent}} 名の参加者に送信しました。",
       "sendResultSkipped": "{{count}} 名はメールアドレス未登録のためスキップしました。",
-      "sendResultFailed": "{{count}} 名が失敗しました。"
+      "sendResultFailed": "{{count}} 名が失敗しました。",
+      "alreadySent": "このお知らせはこのイベントに対して既に送信済みです（または送信中です）。"
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/nl/common.json
+++ b/web-frontend/public/locales/nl/common.json
@@ -630,7 +630,8 @@
       "REGISTRATION": "Registratie",
       "TASK_REMINDER": "Taakherinneringen",
       "NEWSLETTER": "Nieuwsbrief",
-      "VENUE_COORDINATION": "Locatie & Catering"
+      "VENUE_COORDINATION": "Locatie & Catering",
+      "REGISTRANT_NOTICE": "Deelnemersberichten"
     },
     "layoutKey": "Lay-out",
     "standalone": "Geen (zelfstandig)",

--- a/web-frontend/public/locales/nl/events.json
+++ b/web-frontend/public/locales/nl/events.json
@@ -12,7 +12,8 @@
       "publishing": "Publicatie",
       "newsletter": "Nieuwsbrief",
       "settings": "Instellingen",
-      "photos": "Foto's"
+      "photos": "Foto's",
+      "registrantNotices": "Deelnemersberichten"
     },
     "tabsAriaLabel": "Navigatie evenementenpagina",
     "overview": {
@@ -212,6 +213,21 @@
       "confirmSend": "Ja, versturen",
       "sentSuccess": "Verzonden naar {{count}} ontvanger(s).",
       "sentFailed": "Verzenden mislukt: {{message}}"
+    },
+    "registrantNotices": {
+      "title": "Deelnemersberichten",
+      "preview": "Voorbeeld",
+      "send": "Naar deelnemers sturen",
+      "locale": "Voorbeeldtaal",
+      "templateSelect": "Sjabloon",
+      "confirmTitle": "Naar deelnemers sturen?",
+      "previewTitle": "E-mailvoorbeeld",
+      "description": "Stuur een eenmalig bericht (bijv. “de slides staan online”) naar de deelnemers van dit evenement. Ontvangers zijn de actieve deelnemers — niet de nieuwsbriefabonnees — en iedereen ontvangt het in de eigen taal.",
+      "confirmBody": "«{{templateKey}}» naar {{count}} actieve deelnemers van «{{eventTitle}}» sturen? Iedereen ontvangt het in de eigen taal.",
+      "sendQueued": "In wachtrij — versturen naar {{count}} deelnemers.",
+      "recipientCount": "{{count}} actieve deelnemers",
+      "noTemplates": "Nog geen deelnemersbericht-sjabloon voor deze taal.",
+      "error": "Er ging iets mis. Probeer het opnieuw."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/nl/events.json
+++ b/web-frontend/public/locales/nl/events.json
@@ -224,10 +224,13 @@
       "previewTitle": "E-mailvoorbeeld",
       "description": "Stuur een eenmalig bericht (bijv. “de slides staan online”) naar de deelnemers van dit evenement. Ontvangers zijn de actieve deelnemers — niet de nieuwsbriefabonnees — en iedereen ontvangt het in de eigen taal.",
       "confirmBody": "«{{templateKey}}» naar {{count}} actieve deelnemers van «{{eventTitle}}» sturen? Iedereen ontvangt het in de eigen taal.",
-      "sendQueued": "In wachtrij — versturen naar {{count}} deelnemers.",
       "recipientCount": "{{count}} actieve deelnemers",
       "noTemplates": "Nog geen deelnemersbericht-sjabloon voor deze taal.",
-      "error": "Er ging iets mis. Probeer het opnieuw."
+      "error": "Er ging iets mis. Probeer het opnieuw.",
+      "sending": "Verzenden… {{sent}} / {{total}}",
+      "sendResult": "Verstuurd naar {{sent}} van {{total}} deelnemers.",
+      "sendResultSkipped": "{{count}} zonder e-mailadres in het bestand (overgeslagen).",
+      "sendResultFailed": "{{count}} mislukt."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/nl/events.json
+++ b/web-frontend/public/locales/nl/events.json
@@ -230,7 +230,8 @@
       "sending": "Verzenden… {{sent}} / {{total}}",
       "sendResult": "Verstuurd naar {{sent}} van {{total}} deelnemers.",
       "sendResultSkipped": "{{count}} zonder e-mailadres in het bestand (overgeslagen).",
-      "sendResultFailed": "{{count}} mislukt."
+      "sendResultFailed": "{{count}} mislukt.",
+      "alreadySent": "Dit bericht is al verstuurd (of een verzending is bezig) voor dit evenement."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/rm/common.json
+++ b/web-frontend/public/locales/rm/common.json
@@ -630,7 +630,8 @@
       "REGISTRATION": "Inscripziun",
       "TASK_REMINDER": "Memorials da incumbensas",
       "NEWSLETTER": "Newsletter",
-      "VENUE_COORDINATION": "Lieu & Catering"
+      "VENUE_COORDINATION": "Lieu & Catering",
+      "REGISTRANT_NOTICE": "Infos participants"
     },
     "layoutKey": "Layout",
     "standalone": "Nagin (independent)",

--- a/web-frontend/public/locales/rm/events.json
+++ b/web-frontend/public/locales/rm/events.json
@@ -230,7 +230,8 @@
       "sending": "Trametter… {{sent}} / {{total}}",
       "sendResult": "Tramess a {{sent}} da {{total}} participants.",
       "sendResultSkipped": "{{count}} senza adressa d’e-mail (sursaglì).",
-      "sendResultFailed": "{{count}} betg reussì."
+      "sendResultFailed": "{{count}} betg reussì.",
+      "alreadySent": "Questa infurmaziun è gia vegnida tramessa (u in process è en curs) per quest eveniment."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/rm/events.json
+++ b/web-frontend/public/locales/rm/events.json
@@ -12,7 +12,8 @@
       "publishing": "Publicaziun",
       "newsletter": "Newsletter",
       "settings": "Parameters",
-      "photos": "Fotografias"
+      "photos": "Fotografias",
+      "registrantNotices": "Infos participants"
     },
     "tabsAriaLabel": "Navigaziun da la pagina eveniment",
     "overview": {
@@ -212,6 +213,21 @@
       "confirmSend": "Gea, trametter",
       "sentSuccess": "Tramess a {{count}} destinatur(s).",
       "sentFailed": "Trametter n'è betg reussì: {{message}}"
+    },
+    "registrantNotices": {
+      "title": "Infos participants",
+      "preview": "Prevista",
+      "send": "Trametter als participants",
+      "locale": "Lingua da prevista",
+      "templateSelect": "Model",
+      "confirmTitle": "Trametter als participants?",
+      "previewTitle": "Prevista da l’e-mail",
+      "description": "Tramet ina infurmaziun unica (p.ex. «las slides èn online») als participants da quest eveniment. Ils destinaturs èn ils participants activs – betg ils abunents da la newsletter – e mintgin la retschaiva en sia lingua.",
+      "confirmBody": "Trametter «{{templateKey}}» a {{count}} participants activs da «{{eventTitle}}»? Mintgin la retschaiva en sia lingua.",
+      "sendQueued": "En la colonna d’spetga – trametter a {{count}} participants.",
+      "recipientCount": "{{count}} participants activs",
+      "noTemplates": "Anc nagin model d’infurmaziun per questa lingua.",
+      "error": "Insatge è ì stort. Emprova anc ina giada."
     }
   },
   "dashboard": {

--- a/web-frontend/public/locales/rm/events.json
+++ b/web-frontend/public/locales/rm/events.json
@@ -224,10 +224,13 @@
       "previewTitle": "Prevista da l’e-mail",
       "description": "Tramet ina infurmaziun unica (p.ex. «las slides èn online») als participants da quest eveniment. Ils destinaturs èn ils participants activs – betg ils abunents da la newsletter – e mintgin la retschaiva en sia lingua.",
       "confirmBody": "Trametter «{{templateKey}}» a {{count}} participants activs da «{{eventTitle}}»? Mintgin la retschaiva en sia lingua.",
-      "sendQueued": "En la colonna d’spetga – trametter a {{count}} participants.",
       "recipientCount": "{{count}} participants activs",
       "noTemplates": "Anc nagin model d’infurmaziun per questa lingua.",
-      "error": "Insatge è ì stort. Emprova anc ina giada."
+      "error": "Insatge è ì stort. Emprova anc ina giada.",
+      "sending": "Trametter… {{sent}} / {{total}}",
+      "sendResult": "Tramess a {{sent}} da {{total}} participants.",
+      "sendResultSkipped": "{{count}} senza adressa d’e-mail (sursaglì).",
+      "sendResultFailed": "{{count}} betg reussì."
     }
   },
   "dashboard": {

--- a/web-frontend/src/components/organizer/Admin/EmailTemplateEditModal.tsx
+++ b/web-frontend/src/components/organizer/Admin/EmailTemplateEditModal.tsx
@@ -170,7 +170,9 @@ export const EmailTemplateEditModal: React.FC<Props> = ({
             | 'REGISTRATION'
             | 'TASK_REMINDER'
             | 'LAYOUT'
-            | 'NEWSLETTER',
+            | 'NEWSLETTER'
+            | 'VENUE_COORDINATION'
+            | 'REGISTRANT_NOTICE',
           isLayout: false,
           subject,
           htmlBody: currentHtmlBody,

--- a/web-frontend/src/components/organizer/Admin/EmailTemplatesTab.test.tsx
+++ b/web-frontend/src/components/organizer/Admin/EmailTemplatesTab.test.tsx
@@ -306,9 +306,10 @@ describe('EmailTemplatesTab', () => {
     expect(select).toBeInTheDocument();
     const combobox = screen.getByRole('combobox');
     await user.click(combobox);
-    // All 5 category options appear in the opened listbox
+    // All 6 category options appear in the opened listbox
+    // (Speaker, Registration, Task Reminders, Newsletter, Venue & Catering, Registrant Notices)
     const options = await screen.findAllByRole('option');
-    expect(options).toHaveLength(5);
+    expect(options).toHaveLength(6);
   });
 
   it('should_renderCategoryToggleGroup_when_desktopViewport', () => {

--- a/web-frontend/src/components/organizer/Admin/EmailTemplatesTab.tsx
+++ b/web-frontend/src/components/organizer/Admin/EmailTemplatesTab.tsx
@@ -60,7 +60,13 @@ const EmailTemplatePreviewModal = React.lazy(() =>
   import('./EmailTemplatePreviewModal').then((m) => ({ default: m.EmailTemplatePreviewModal }))
 );
 
-type Category = 'SPEAKER' | 'REGISTRATION' | 'TASK_REMINDER' | 'NEWSLETTER' | 'VENUE_COORDINATION';
+type Category =
+  | 'SPEAKER'
+  | 'REGISTRATION'
+  | 'TASK_REMINDER'
+  | 'NEWSLETTER'
+  | 'VENUE_COORDINATION'
+  | 'REGISTRANT_NOTICE';
 
 const formatDate = (dateStr: string) => {
   try {
@@ -76,6 +82,7 @@ const CATEGORY_OPTIONS: Category[] = [
   'TASK_REMINDER',
   'NEWSLETTER',
   'VENUE_COORDINATION',
+  'REGISTRANT_NOTICE',
 ];
 
 const CATEGORY_LABEL_KEYS: Record<Category, [string, string]> = {
@@ -84,6 +91,7 @@ const CATEGORY_LABEL_KEYS: Record<Category, [string, string]> = {
   TASK_REMINDER: ['emailTemplates.categories.TASK_REMINDER', 'Task Reminders'],
   NEWSLETTER: ['emailTemplates.categories.NEWSLETTER', 'Newsletter'],
   VENUE_COORDINATION: ['emailTemplates.categories.VENUE_COORDINATION', 'Venue & Catering'],
+  REGISTRANT_NOTICE: ['emailTemplates.categories.REGISTRANT_NOTICE', 'Registrant Notices'],
 };
 
 export const EmailTemplatesTab: React.FC = () => {

--- a/web-frontend/src/components/organizer/EventPage/EventPage.tsx
+++ b/web-frontend/src/components/organizer/EventPage/EventPage.tsx
@@ -54,6 +54,7 @@ import EventParticipantsTab from './EventParticipantsTab';
 import { EventPublishingTab } from './EventPublishingTab';
 import { EventSettingsTab } from './EventSettingsTab';
 import { EventNewsletterTab } from './EventNewsletterTab';
+import { EventRegistrantNoticesTab } from './EventRegistrantNoticesTab';
 import { EventPhotosTab } from './EventPhotosTab';
 import { EventForm } from '@/components/organizer/EventManagement';
 
@@ -65,6 +66,11 @@ const TABS = [
   { id: 'participants', labelKey: 'eventPage.tabs.participants', icon: <ParticipantsIcon /> },
   { id: 'publishing', labelKey: 'eventPage.tabs.publishing', icon: <PublishIcon /> },
   { id: 'newsletter', labelKey: 'eventPage.tabs.newsletter', icon: <NewsletterIcon /> },
+  {
+    id: 'registrant-notices',
+    labelKey: 'eventPage.tabs.registrantNotices',
+    icon: <SlideshowIcon />,
+  },
   { id: 'settings', labelKey: 'eventPage.tabs.settings', icon: <SettingsIcon /> },
   { id: 'photos', labelKey: 'eventPage.tabs.photos', icon: <PhotosIcon /> },
 ] as const;
@@ -191,6 +197,8 @@ export const EventPage: React.FC = () => {
         return <EventPublishingTab event={event} eventCode={eventCode!} />;
       case 'newsletter':
         return <EventNewsletterTab eventCode={eventCode!} eventTitle={event.title || ''} />;
+      case 'registrant-notices':
+        return <EventRegistrantNoticesTab eventCode={eventCode!} eventTitle={event.title || ''} />;
       case 'settings':
         return <EventSettingsTab event={event} eventCode={eventCode!} />;
       case 'photos':

--- a/web-frontend/src/components/organizer/EventPage/EventPage.tsx
+++ b/web-frontend/src/components/organizer/EventPage/EventPage.tsx
@@ -281,16 +281,18 @@ export const EventPage: React.FC = () => {
         <Box>{renderTabContent()}</Box>
       </Container>
 
-      {/* Mobile Bottom Navigation */}
+      {/* Mobile Bottom Navigation — icon-only for every tab (consistent + compact). Labels are
+          provided via aria-label for accessibility but never rendered, so the selected tab does
+          not widen the bar (MUI shows the selected action's label by default). */}
       {isMobile && (
         <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 1100 }} elevation={3}>
-          <BottomNavigation value={currentTab} onChange={handleMobileNavChange}>
+          <BottomNavigation value={currentTab} onChange={handleMobileNavChange} showLabels={false}>
             {TABS.map((tab) => (
               <BottomNavigationAction
                 key={tab.id}
                 value={tab.id}
-                label={t(tab.labelKey, tab.id)}
                 icon={tab.icon}
+                aria-label={t(tab.labelKey, tab.id)}
                 data-testid={`event-tab-${tab.id}`}
                 sx={{ minWidth: 0, flex: 1, px: 0 }}
               />

--- a/web-frontend/src/components/organizer/EventPage/EventRegistrantNoticesTab.tsx
+++ b/web-frontend/src/components/organizer/EventPage/EventRegistrantNoticesTab.tsx
@@ -37,6 +37,7 @@ import {
   usePreviewRegistrantNotice,
   useSendRegistrantNotice,
 } from '@/hooks/useRegistrantNotice/useRegistrantNotice';
+import { useSendStatus } from '@/hooks/useNewsletter/useNewsletter';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
 
 interface EventRegistrantNoticesTabProps {
@@ -55,11 +56,14 @@ export const EventRegistrantNoticesTab: React.FC<EventRegistrantNoticesTabProps>
   const [previewHtml, setPreviewHtml] = useState<string | null>(null);
   const [recipientCount, setRecipientCount] = useState<number | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [sentCount, setSentCount] = useState<number | null>(null);
+  /** sendId of the most recently triggered send — polled for its final status. */
+  const [activeSendId, setActiveSendId] = useState<string | null>(null);
 
   const templatesQuery = useEmailTemplates({ category: 'REGISTRANT_NOTICE' });
   const previewMutation = usePreviewRegistrantNotice(eventCode);
   const sendMutation = useSendRegistrantNotice(eventCode);
+  // Reuse the template-agnostic newsletter send-status endpoint (polls until terminal).
+  const sendStatusQuery = useSendStatus(eventCode, activeSendId);
 
   const filteredTemplates: EmailTemplateResponse[] = React.useMemo(
     () => (templatesQuery.data ?? []).filter((tpl) => tpl.locale === locale),
@@ -79,7 +83,7 @@ export const EventRegistrantNoticesTab: React.FC<EventRegistrantNoticesTabProps>
 
   function handlePreview() {
     if (!selectedTemplateKey) return;
-    setSentCount(null);
+    setActiveSendId(null);
     previewMutation.mutate(
       { templateKey: selectedTemplateKey, locale },
       {
@@ -116,7 +120,7 @@ export const EventRegistrantNoticesTab: React.FC<EventRegistrantNoticesTabProps>
     sendMutation.mutate(selectedTemplateKey, {
       onSuccess: (data) => {
         setConfirmOpen(false);
-        setSentCount(data.recipientCount);
+        setActiveSendId(data.sendId); // begin polling for the final result
       },
       onError: () => setConfirmOpen(false),
     });
@@ -138,14 +142,50 @@ export const EventRegistrantNoticesTab: React.FC<EventRegistrantNoticesTabProps>
         </Typography>
       </Box>
 
-      {sentCount !== null && (
-        <Alert severity="success" onClose={() => setSentCount(null)} data-testid="rn-send-success">
-          {t('eventPage.registrantNotices.sendQueued', {
-            count: sentCount,
-            defaultValue: `Queued — sending to ${sentCount} registrants.`,
-          })}
-        </Alert>
-      )}
+      {activeSendId &&
+        sendStatusQuery.data &&
+        (() => {
+          const s = sendStatusQuery.data;
+          const sending = s.status === 'PENDING' || s.status === 'IN_PROGRESS';
+          if (sending) {
+            return (
+              <Alert severity="info" data-testid="rn-send-progress">
+                {t('eventPage.registrantNotices.sending', {
+                  sent: s.sentCount,
+                  total: s.totalCount,
+                  defaultValue: `Sending… ${s.sentCount} / ${s.totalCount}`,
+                })}
+              </Alert>
+            );
+          }
+          // Terminal: skipped = registrants with no resolvable email on file.
+          const skipped = Math.max(0, s.totalCount - s.sentCount - s.failedCount);
+          return (
+            <Alert
+              severity={s.sentCount > 0 ? 'success' : 'warning'}
+              onClose={() => setActiveSendId(null)}
+              data-testid="rn-send-success"
+            >
+              {t('eventPage.registrantNotices.sendResult', {
+                sent: s.sentCount,
+                total: s.totalCount,
+                defaultValue: `Sent to ${s.sentCount} of ${s.totalCount} registrants.`,
+              })}
+              {skipped > 0 &&
+                ' ' +
+                  t('eventPage.registrantNotices.sendResultSkipped', {
+                    count: skipped,
+                    defaultValue: `${skipped} had no email address on file (skipped).`,
+                  })}
+              {s.failedCount > 0 &&
+                ' ' +
+                  t('eventPage.registrantNotices.sendResultFailed', {
+                    count: s.failedCount,
+                    defaultValue: `${s.failedCount} failed.`,
+                  })}
+            </Alert>
+          );
+        })()}
 
       <Box>
         <Stack spacing={2} maxWidth={400}>

--- a/web-frontend/src/components/organizer/EventPage/EventRegistrantNoticesTab.tsx
+++ b/web-frontend/src/components/organizer/EventPage/EventRegistrantNoticesTab.tsx
@@ -30,6 +30,7 @@ import {
   Typography,
 } from '@mui/material';
 import { Email as EmailIcon } from '@mui/icons-material';
+import axios from 'axios';
 import { useTranslation } from 'react-i18next';
 import { useEmailTemplates } from '@/hooks/useEmailTemplates';
 import type { EmailTemplateResponse } from '@/services/emailTemplateService';
@@ -127,6 +128,33 @@ export const EventRegistrantNoticesTab: React.FC<EventRegistrantNoticesTabProps>
   }
 
   const noTemplates = !templatesQuery.isLoading && filteredTemplates.length === 0;
+
+  // Surface the API error. The 409 "already sent / in progress" guard is an expected outcome the
+  // organizer must understand (shown as an info, not a red failure); other errors show the API
+  // message when present, else a generic fallback.
+  const apiError: { severity: 'info' | 'error'; message: string } | null = (() => {
+    const err = sendMutation.error ?? previewMutation.error;
+    if (!err) return null;
+    if (axios.isAxiosError(err)) {
+      const status = err.response?.status;
+      const apiMsg = (err.response?.data as { message?: string } | undefined)?.message;
+      if (status === 409) {
+        return {
+          severity: 'info',
+          message: t('eventPage.registrantNotices.alreadySent', {
+            defaultValue:
+              apiMsg ??
+              'This notice has already been sent (or a send is in progress) for this event.',
+          }),
+        };
+      }
+      if (apiMsg) return { severity: 'error', message: apiMsg };
+    }
+    return {
+      severity: 'error',
+      message: t('eventPage.registrantNotices.error', 'Something went wrong. Please try again.'),
+    };
+  })();
 
   return (
     <Stack spacing={4}>
@@ -272,9 +300,9 @@ export const EventRegistrantNoticesTab: React.FC<EventRegistrantNoticesTabProps>
             </Typography>
           )}
 
-          {(previewMutation.isError || sendMutation.isError) && (
-            <Alert severity="error" data-testid="rn-error">
-              {t('eventPage.registrantNotices.error', 'Something went wrong. Please try again.')}
+          {apiError && (
+            <Alert severity={apiError.severity} data-testid="rn-error">
+              {apiError.message}
             </Alert>
           )}
         </Stack>

--- a/web-frontend/src/components/organizer/EventPage/EventRegistrantNoticesTab.tsx
+++ b/web-frontend/src/components/organizer/EventPage/EventRegistrantNoticesTab.tsx
@@ -91,6 +91,26 @@ export const EventRegistrantNoticesTab: React.FC<EventRegistrantNoticesTabProps>
     );
   }
 
+  // Open the confirm dialog with a real recipient count. If the organizer hasn't previewed yet,
+  // fetch the count first so the dialog never shows a misleading "0".
+  function handleOpenConfirm() {
+    if (!selectedTemplateKey) return;
+    if (recipientCount !== null) {
+      setConfirmOpen(true);
+      return;
+    }
+    previewMutation.mutate(
+      { templateKey: selectedTemplateKey, locale },
+      {
+        onSuccess: (data) => {
+          setPreviewHtml(data.htmlPreview);
+          setRecipientCount(data.recipientCount);
+          setConfirmOpen(true);
+        },
+      }
+    );
+  }
+
   function handleConfirmSend() {
     if (!selectedTemplateKey) return;
     sendMutation.mutate(selectedTemplateKey, {
@@ -195,8 +215,8 @@ export const EventRegistrantNoticesTab: React.FC<EventRegistrantNoticesTabProps>
             </Button>
             <Button
               variant="contained"
-              onClick={() => setConfirmOpen(true)}
-              disabled={sendMutation.isPending || !selectedTemplateKey}
+              onClick={handleOpenConfirm}
+              disabled={sendMutation.isPending || previewMutation.isPending || !selectedTemplateKey}
               data-testid="rn-send-button"
             >
               {t('eventPage.registrantNotices.send', 'Send to registrants')}

--- a/web-frontend/src/components/organizer/EventPage/EventRegistrantNoticesTab.tsx
+++ b/web-frontend/src/components/organizer/EventPage/EventRegistrantNoticesTab.tsx
@@ -1,0 +1,284 @@
+/**
+ * EventRegistrantNoticesTab (Story 7.3 hardening)
+ *
+ * Organizer tab to send a REGISTRANT-targeted notice (e.g. the "slides are online" mail) to an
+ * event's ACTIVE REGISTRANTS — never the global newsletter-subscriber pool. Mirrors the Newsletter
+ * tab UX (template select, language, preview iframe, send + confirm) but is wired to the dedicated
+ * registrant-notice endpoints.
+ *
+ * The language selector controls the PREVIEW only — the actual send resolves each registrant's own
+ * language (de-anything to German, en to English, otherwise German fallback).
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  Link,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { Email as EmailIcon } from '@mui/icons-material';
+import { useTranslation } from 'react-i18next';
+import { useEmailTemplates } from '@/hooks/useEmailTemplates';
+import type { EmailTemplateResponse } from '@/services/emailTemplateService';
+import {
+  usePreviewRegistrantNotice,
+  useSendRegistrantNotice,
+} from '@/hooks/useRegistrantNotice/useRegistrantNotice';
+import { useBreakpoints } from '@/hooks/useBreakpoints';
+
+interface EventRegistrantNoticesTabProps {
+  eventCode: string;
+  eventTitle: string;
+}
+
+export const EventRegistrantNoticesTab: React.FC<EventRegistrantNoticesTabProps> = ({
+  eventCode,
+  eventTitle,
+}) => {
+  const { t } = useTranslation(['events', 'organizer', 'common']);
+  const { isMobile } = useBreakpoints();
+  const [locale, setLocale] = useState<'de' | 'en'>('de');
+  const [selectedTemplateKey, setSelectedTemplateKey] = useState<string>('');
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+  const [recipientCount, setRecipientCount] = useState<number | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [sentCount, setSentCount] = useState<number | null>(null);
+
+  const templatesQuery = useEmailTemplates({ category: 'REGISTRANT_NOTICE' });
+  const previewMutation = usePreviewRegistrantNotice(eventCode);
+  const sendMutation = useSendRegistrantNotice(eventCode);
+
+  const filteredTemplates: EmailTemplateResponse[] = React.useMemo(
+    () => (templatesQuery.data ?? []).filter((tpl) => tpl.locale === locale),
+    [templatesQuery.data, locale]
+  );
+
+  // Keep a valid template selected as the locale/template list changes.
+  useEffect(() => {
+    if (filteredTemplates.length === 0) {
+      setSelectedTemplateKey('');
+      return;
+    }
+    if (!filteredTemplates.some((tpl) => tpl.templateKey === selectedTemplateKey)) {
+      setSelectedTemplateKey(filteredTemplates[0].templateKey);
+    }
+  }, [filteredTemplates, selectedTemplateKey]);
+
+  function handlePreview() {
+    if (!selectedTemplateKey) return;
+    setSentCount(null);
+    previewMutation.mutate(
+      { templateKey: selectedTemplateKey, locale },
+      {
+        onSuccess: (data) => {
+          setPreviewHtml(data.htmlPreview);
+          setRecipientCount(data.recipientCount);
+        },
+      }
+    );
+  }
+
+  function handleConfirmSend() {
+    if (!selectedTemplateKey) return;
+    sendMutation.mutate(selectedTemplateKey, {
+      onSuccess: (data) => {
+        setConfirmOpen(false);
+        setSentCount(data.recipientCount);
+      },
+      onError: () => setConfirmOpen(false),
+    });
+  }
+
+  const noTemplates = !templatesQuery.isLoading && filteredTemplates.length === 0;
+
+  return (
+    <Stack spacing={4}>
+      <Box>
+        <Typography variant="h6" gutterBottom>
+          {t('eventPage.registrantNotices.title', 'Registrant Notices')}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {t(
+            'eventPage.registrantNotices.description',
+            'Send a one-off notice (e.g. “the slides are online”) to this event’s registrants. Recipients are the active registrants — not newsletter subscribers — and each gets the mail in their own language.'
+          )}
+        </Typography>
+      </Box>
+
+      {sentCount !== null && (
+        <Alert severity="success" onClose={() => setSentCount(null)} data-testid="rn-send-success">
+          {t('eventPage.registrantNotices.sendQueued', {
+            count: sentCount,
+            defaultValue: `Queued — sending to ${sentCount} registrants.`,
+          })}
+        </Alert>
+      )}
+
+      <Box>
+        <Stack spacing={2} maxWidth={400}>
+          {/* Preview language */}
+          <FormControl size="small">
+            <InputLabel>{t('eventPage.registrantNotices.locale', 'Preview language')}</InputLabel>
+            <Select
+              value={locale}
+              label={t('eventPage.registrantNotices.locale', 'Preview language')}
+              onChange={(e) => {
+                setLocale(e.target.value as 'de' | 'en');
+                setPreviewHtml(null);
+              }}
+              SelectDisplayProps={
+                { 'data-testid': 'rn-locale-select' } as React.HTMLAttributes<HTMLDivElement>
+              }
+            >
+              <MenuItem value="de">Deutsch</MenuItem>
+              <MenuItem value="en">English</MenuItem>
+            </Select>
+          </FormControl>
+
+          {/* Template selector — REGISTRANT_NOTICE category only */}
+          <FormControl size="small">
+            <InputLabel>{t('eventPage.registrantNotices.templateSelect', 'Template')}</InputLabel>
+            <Select
+              value={selectedTemplateKey}
+              label={t('eventPage.registrantNotices.templateSelect', 'Template')}
+              onChange={(e) => {
+                setSelectedTemplateKey(e.target.value);
+                setPreviewHtml(null);
+              }}
+              disabled={templatesQuery.isLoading || noTemplates}
+              SelectDisplayProps={
+                { 'data-testid': 'rn-template-select' } as React.HTMLAttributes<HTMLDivElement>
+              }
+            >
+              {filteredTemplates.map((tpl) => (
+                <MenuItem key={tpl.templateKey} value={tpl.templateKey}>
+                  {tpl.templateKey}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          {noTemplates && (
+            <Alert severity="info" data-testid="rn-no-templates">
+              {t(
+                'eventPage.registrantNotices.noTemplates',
+                'No registrant-notice templates for this language yet.'
+              )}{' '}
+              <Link href="/organizer/admin?tab=email-templates" underline="hover">
+                {t('organizer:newsletter.templateSelect.createNew', 'Create one')} ↗
+              </Link>
+            </Alert>
+          )}
+
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            <Button
+              variant="outlined"
+              startIcon={previewMutation.isPending ? <CircularProgress size={16} /> : <EmailIcon />}
+              onClick={handlePreview}
+              disabled={previewMutation.isPending || !selectedTemplateKey}
+              data-testid="rn-preview-button"
+            >
+              {t('eventPage.registrantNotices.preview', 'Preview')}
+            </Button>
+            <Button
+              variant="contained"
+              onClick={() => setConfirmOpen(true)}
+              disabled={sendMutation.isPending || !selectedTemplateKey}
+              data-testid="rn-send-button"
+            >
+              {t('eventPage.registrantNotices.send', 'Send to registrants')}
+            </Button>
+          </Stack>
+
+          {recipientCount !== null && (
+            <Typography variant="caption" color="text.secondary" data-testid="rn-recipient-count">
+              {t('eventPage.registrantNotices.recipientCount', {
+                count: recipientCount,
+                defaultValue: `${recipientCount} active registrants`,
+              })}
+            </Typography>
+          )}
+
+          {(previewMutation.isError || sendMutation.isError) && (
+            <Alert severity="error" data-testid="rn-error">
+              {t('eventPage.registrantNotices.error', 'Something went wrong. Please try again.')}
+            </Alert>
+          )}
+        </Stack>
+
+        {previewHtml && (
+          <Box mt={3}>
+            <Typography variant="body2" color="text.secondary" gutterBottom>
+              {t('eventPage.registrantNotices.previewTitle', 'Email Preview')}
+            </Typography>
+            <Box
+              component="iframe"
+              srcDoc={previewHtml}
+              sx={{
+                width: '100%',
+                height: 600,
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1,
+              }}
+              title="registrant-notice-preview"
+              sandbox="allow-same-origin"
+              data-testid="rn-preview-iframe"
+            />
+          </Box>
+        )}
+      </Box>
+
+      {/* Confirmation dialog */}
+      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)} fullScreen={isMobile}>
+        <DialogTitle>
+          {t('eventPage.registrantNotices.confirmTitle', 'Send to registrants?')}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {t('eventPage.registrantNotices.confirmBody', {
+              templateKey: selectedTemplateKey,
+              eventTitle,
+              count: recipientCount ?? 0,
+              defaultValue:
+                recipientCount !== null
+                  ? `Send '${selectedTemplateKey}' to ${recipientCount} active registrants of «${eventTitle}»? Each receives it in their own language.`
+                  : `Send '${selectedTemplateKey}' to the active registrants of «${eventTitle}»? Each receives it in their own language.`,
+            })}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)} disabled={sendMutation.isPending}>
+            {t('common:actions.cancel', 'Cancel')}
+          </Button>
+          <Button
+            onClick={handleConfirmSend}
+            variant="contained"
+            disabled={sendMutation.isPending}
+            autoFocus
+            data-testid="rn-confirm-send"
+          >
+            {sendMutation.isPending ? (
+              <CircularProgress size={20} />
+            ) : (
+              t('common.confirm', 'Confirm')
+            )}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+};

--- a/web-frontend/src/components/organizer/EventPage/__tests__/EventPage.test.tsx
+++ b/web-frontend/src/components/organizer/EventPage/__tests__/EventPage.test.tsx
@@ -401,8 +401,9 @@ describe('EventPage Component (Story 5.6)', () => {
       renderWithProviders();
 
       const tabs = screen.getAllByRole('tab');
-      // 8 tabs: Overview, Speakers, Venue, Participants, Publishing, Newsletter, Settings, Photos
-      expect(tabs.length).toBe(8);
+      // 9 tabs: Overview, Speakers, Venue, Participants, Publishing, Newsletter,
+      // Registrant Notices, Settings, Photos
+      expect(tabs.length).toBe(9);
     });
 
     it('should_haveAriaLabel_forTabNavigation', () => {

--- a/web-frontend/src/components/organizer/EventPage/__tests__/EventRegistrantNoticesTab.test.tsx
+++ b/web-frontend/src/components/organizer/EventPage/__tests__/EventRegistrantNoticesTab.test.tsx
@@ -120,4 +120,21 @@ describe('EventRegistrantNoticesTab', () => {
     );
     expect(screen.getByTestId('rn-send-success')).toBeInTheDocument();
   });
+
+  it('surfaces the API 409 "already sent" message instead of a generic error', () => {
+    vi.mocked(useSendRegistrantNotice).mockReturnValue({
+      mutate: sendMutate,
+      isPending: false,
+      isError: true,
+      error: {
+        isAxiosError: true,
+        response: {
+          status: 409,
+          data: { message: "The 'slides-online' mail has already been sent for event BATbern73" },
+        },
+      },
+    } as unknown as ReturnType<typeof useSendRegistrantNotice>);
+    renderTab();
+    expect(screen.getByTestId('rn-error')).toHaveTextContent('already been sent');
+  });
 });

--- a/web-frontend/src/components/organizer/EventPage/__tests__/EventRegistrantNoticesTab.test.tsx
+++ b/web-frontend/src/components/organizer/EventPage/__tests__/EventRegistrantNoticesTab.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * EventRegistrantNoticesTab Tests (Story 7.3 hardening)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { EventRegistrantNoticesTab } from '../EventRegistrantNoticesTab';
+
+vi.mock('@/hooks/useEmailTemplates', () => ({
+  useEmailTemplates: vi.fn(),
+}));
+vi.mock('@/hooks/useRegistrantNotice/useRegistrantNotice', () => ({
+  usePreviewRegistrantNotice: vi.fn(),
+  useSendRegistrantNotice: vi.fn(),
+}));
+vi.mock('@/hooks/useBreakpoints', () => ({
+  useBreakpoints: () => ({ isMobile: false }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => (opts?.defaultValue as string) ?? key,
+  }),
+}));
+
+import { useEmailTemplates } from '@/hooks/useEmailTemplates';
+import {
+  usePreviewRegistrantNotice,
+  useSendRegistrantNotice,
+} from '@/hooks/useRegistrantNotice/useRegistrantNotice';
+
+const previewMutate = vi.fn();
+const sendMutate = vi.fn();
+
+function mockTemplates(list: Array<{ templateKey: string; locale: string; category: string }>) {
+  vi.mocked(useEmailTemplates).mockReturnValue({
+    data: list,
+    isLoading: false,
+  } as ReturnType<typeof useEmailTemplates>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockTemplates([{ templateKey: 'slides-online', locale: 'de', category: 'REGISTRANT_NOTICE' }]);
+  vi.mocked(usePreviewRegistrantNotice).mockReturnValue({
+    mutate: previewMutate,
+    isPending: false,
+    isError: false,
+  } as unknown as ReturnType<typeof usePreviewRegistrantNotice>);
+  vi.mocked(useSendRegistrantNotice).mockReturnValue({
+    mutate: sendMutate,
+    isPending: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useSendRegistrantNotice>);
+});
+
+function renderTab() {
+  return render(<EventRegistrantNoticesTab eventCode="BATbern73" eventTitle="DevOps Event" />);
+}
+
+describe('EventRegistrantNoticesTab', () => {
+  it('renders the REGISTRANT_NOTICE template selector + send/preview buttons', () => {
+    renderTab();
+    expect(screen.getByTestId('rn-template-select')).toBeInTheDocument();
+    expect(screen.getByTestId('rn-preview-button')).toBeInTheDocument();
+    expect(screen.getByTestId('rn-send-button')).toBeInTheDocument();
+  });
+
+  it('shows a hint when no registrant-notice template exists for the language', () => {
+    mockTemplates([]); // none for de
+    renderTab();
+    expect(screen.getByTestId('rn-no-templates')).toBeInTheDocument();
+  });
+
+  it('previews the selected template and shows the recipient count', async () => {
+    previewMutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess({ subject: 'S', htmlPreview: '<p>hi</p>', recipientCount: 42 })
+    );
+    renderTab();
+    fireEvent.click(screen.getByTestId('rn-preview-button'));
+    await waitFor(() => expect(previewMutate).toHaveBeenCalled());
+    expect(previewMutate.mock.calls[0][0]).toEqual({ templateKey: 'slides-online', locale: 'de' });
+    expect(screen.getByTestId('rn-recipient-count')).toHaveTextContent('42');
+    expect(screen.getByTestId('rn-preview-iframe')).toBeInTheDocument();
+  });
+
+  it('opens the confirm dialog and sends to registrants', async () => {
+    sendMutate.mockImplementation((_templateKey, opts) =>
+      opts.onSuccess({ sendId: 's1', status: 'PENDING', recipientCount: 42 })
+    );
+    renderTab();
+    fireEvent.click(screen.getByTestId('rn-send-button'));
+    await waitFor(() => expect(screen.getByTestId('rn-confirm-send')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('rn-confirm-send'));
+    await waitFor(() =>
+      expect(sendMutate).toHaveBeenCalledWith('slides-online', expect.anything())
+    );
+    expect(screen.getByTestId('rn-send-success')).toBeInTheDocument();
+  });
+});

--- a/web-frontend/src/components/organizer/EventPage/__tests__/EventRegistrantNoticesTab.test.tsx
+++ b/web-frontend/src/components/organizer/EventPage/__tests__/EventRegistrantNoticesTab.test.tsx
@@ -83,12 +83,18 @@ describe('EventRegistrantNoticesTab', () => {
   });
 
   it('opens the confirm dialog and sends to registrants', async () => {
+    // Send without previewing first → the tab fetches the recipient count before confirming.
+    previewMutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess({ subject: 'S', htmlPreview: '<p>hi</p>', recipientCount: 174 })
+    );
     sendMutate.mockImplementation((_templateKey, opts) =>
-      opts.onSuccess({ sendId: 's1', status: 'PENDING', recipientCount: 42 })
+      opts.onSuccess({ sendId: 's1', status: 'PENDING', recipientCount: 174 })
     );
     renderTab();
     fireEvent.click(screen.getByTestId('rn-send-button'));
     await waitFor(() => expect(screen.getByTestId('rn-confirm-send')).toBeInTheDocument());
+    // count was resolved before the dialog opened
+    expect(screen.getByTestId('rn-recipient-count')).toHaveTextContent('174');
     fireEvent.click(screen.getByTestId('rn-confirm-send'));
     await waitFor(() =>
       expect(sendMutate).toHaveBeenCalledWith('slides-online', expect.anything())

--- a/web-frontend/src/components/organizer/EventPage/__tests__/EventRegistrantNoticesTab.test.tsx
+++ b/web-frontend/src/components/organizer/EventPage/__tests__/EventRegistrantNoticesTab.test.tsx
@@ -12,6 +12,9 @@ vi.mock('@/hooks/useRegistrantNotice/useRegistrantNotice', () => ({
   usePreviewRegistrantNotice: vi.fn(),
   useSendRegistrantNotice: vi.fn(),
 }));
+vi.mock('@/hooks/useNewsletter/useNewsletter', () => ({
+  useSendStatus: vi.fn(),
+}));
 vi.mock('@/hooks/useBreakpoints', () => ({
   useBreakpoints: () => ({ isMobile: false }),
 }));
@@ -26,6 +29,7 @@ import {
   usePreviewRegistrantNotice,
   useSendRegistrantNotice,
 } from '@/hooks/useRegistrantNotice/useRegistrantNotice';
+import { useSendStatus } from '@/hooks/useNewsletter/useNewsletter';
 
 const previewMutate = vi.fn();
 const sendMutate = vi.fn();
@@ -50,6 +54,10 @@ beforeEach(() => {
     isPending: false,
     isError: false,
   } as unknown as ReturnType<typeof useSendRegistrantNotice>);
+  // No active send by default → no status alert.
+  vi.mocked(useSendStatus).mockReturnValue({
+    data: undefined,
+  } as ReturnType<typeof useSendStatus>);
 });
 
 function renderTab() {
@@ -90,6 +98,17 @@ describe('EventRegistrantNoticesTab', () => {
     sendMutate.mockImplementation((_templateKey, opts) =>
       opts.onSuccess({ sendId: 's1', status: 'PENDING', recipientCount: 174 })
     );
+    // Status poll resolves to a terminal COMPLETED result.
+    vi.mocked(useSendStatus).mockReturnValue({
+      data: {
+        id: 's1',
+        status: 'COMPLETED',
+        sentCount: 174,
+        failedCount: 0,
+        totalCount: 174,
+        percentComplete: 100,
+      },
+    } as ReturnType<typeof useSendStatus>);
     renderTab();
     fireEvent.click(screen.getByTestId('rn-send-button'));
     await waitFor(() => expect(screen.getByTestId('rn-confirm-send')).toBeInTheDocument());

--- a/web-frontend/src/hooks/useRegistrantNotice/useRegistrantNotice.ts
+++ b/web-frontend/src/hooks/useRegistrantNotice/useRegistrantNotice.ts
@@ -1,0 +1,33 @@
+/**
+ * useRegistrantNotice hooks (Story 7.3 hardening)
+ *
+ * React Query mutations for previewing + sending a registrant-targeted notice (e.g. the
+ * "slides are online" mail) to an event's active registrants.
+ */
+
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import * as registrantNoticeService from '@/services/registrantNoticeService';
+import type {
+  RegistrantNoticePreviewRequest,
+  RegistrantNoticePreviewResponse,
+  RegistrantNoticeSendResponse,
+} from '@/services/registrantNoticeService';
+
+/** Preview a registrant-notice template in a chosen language. */
+export function usePreviewRegistrantNotice(
+  eventCode: string
+): UseMutationResult<RegistrantNoticePreviewResponse, Error, RegistrantNoticePreviewRequest> {
+  return useMutation({
+    mutationFn: (request: RegistrantNoticePreviewRequest) =>
+      registrantNoticeService.preview(eventCode, request),
+  });
+}
+
+/** Send a registrant-notice mail to the event's active registrants. */
+export function useSendRegistrantNotice(
+  eventCode: string
+): UseMutationResult<RegistrantNoticeSendResponse, Error, string> {
+  return useMutation({
+    mutationFn: (templateKey: string) => registrantNoticeService.send(eventCode, templateKey),
+  });
+}

--- a/web-frontend/src/services/registrantNoticeService.ts
+++ b/web-frontend/src/services/registrantNoticeService.ts
@@ -1,0 +1,51 @@
+/**
+ * Registrant Notice Service (Story 7.3 hardening)
+ *
+ * HTTP client for the dedicated, registrant-targeted notice send (e.g. the "slides are online"
+ * mail). This is SEPARATE from newsletterService — it sends to an event's active registrants,
+ * never the global newsletter-subscriber pool.
+ */
+
+import apiClient from '@/services/api/apiClient';
+
+export interface RegistrantNoticePreviewRequest {
+  templateKey: string;
+  locale: 'de' | 'en';
+}
+
+export interface RegistrantNoticePreviewResponse {
+  subject: string;
+  htmlPreview: string;
+  recipientCount: number;
+}
+
+export interface RegistrantNoticeSendResponse {
+  sendId: string;
+  /** PENDING | IN_PROGRESS | COMPLETED | PARTIAL | FAILED */
+  status: string;
+  recipientCount: number;
+}
+
+/** Preview a registrant-notice template in a chosen language (ORGANIZER). */
+export async function preview(
+  eventCode: string,
+  request: RegistrantNoticePreviewRequest
+): Promise<RegistrantNoticePreviewResponse> {
+  const { data } = await apiClient.post<RegistrantNoticePreviewResponse>(
+    `/events/${eventCode}/registrant-notices/preview`,
+    request
+  );
+  return data;
+}
+
+/** Send a registrant-notice mail to the event's active registrants (ORGANIZER). Runs async. */
+export async function send(
+  eventCode: string,
+  templateKey: string
+): Promise<RegistrantNoticeSendResponse> {
+  const { data } = await apiClient.post<RegistrantNoticeSendResponse>(
+    `/events/${eventCode}/registrant-notices/send`,
+    { templateKey }
+  );
+  return data;
+}

--- a/web-frontend/src/types/generated/events-api.types.ts
+++ b/web-frontend/src/types/generated/events-api.types.ts
@@ -2444,6 +2444,52 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/events/{eventCode}/registrant-notices/preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Preview a registrant-notice mail in a chosen language (ORGANIZER)
+     * @description Story 7.3 hardening — renders a REGISTRANT_NOTICE-category template (e.g. slides-online)
+     *     in the chosen preview language and reports how many active registrants would receive it.
+     *     The actual send still resolves each registrant's own language; this locale is preview-only.
+     *     Rejects (400) a template that is not REGISTRANT_NOTICE.
+     */
+    post: operations['previewRegistrantNotice'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/events/{eventCode}/registrant-notices/send': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Send a registrant-notice mail to the event's active registrants (ORGANIZER)
+     * @description Story 7.3 hardening — sends a REGISTRANT_NOTICE-category template (e.g. slides-online) to the
+     *     event's ACTIVE REGISTRANTS (registered/confirmed), NOT the newsletter-subscriber pool. Honours
+     *     the global newsletter opt-out, resolves the language per recipient (de*\/en/else→German), guards
+     *     against double-send (409), and runs asynchronously. Rejects (400) a non-REGISTRANT_NOTICE template.
+     */
+    post: operations['sendRegistrantNotice'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/events/{eventCode}/newsletter/send': {
     parameters: {
       query?: never;
@@ -2941,6 +2987,30 @@ export interface components {
        */
       status: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'PARTIAL' | 'FAILED';
       /** @description Number of active registrants resolved as the recipient base. */
+      recipientCount: number;
+    };
+    /** @description Story 7.3 hardening — request to preview a registrant-notice mail. */
+    RegistrantNoticePreviewRequest: {
+      /** @description A REGISTRANT_NOTICE-category template key (e.g. slides-online). */
+      templateKey: string;
+      /**
+       * @description Preview language; defaults to German when omitted/unknown.
+       * @enum {string}
+       */
+      locale?: 'de' | 'en';
+    };
+    /** @description Story 7.3 hardening — request to send a registrant-notice mail to registrants. */
+    RegistrantNoticeSendRequest: {
+      /** @description A REGISTRANT_NOTICE-category template key (e.g. slides-online). */
+      templateKey: string;
+    };
+    /** @description Story 7.3 hardening — rendered preview + active-registrant recipient count. */
+    RegistrantNoticePreviewResponse: {
+      /** @description Rendered, variable-substituted subject line. */
+      subject: string;
+      /** @description Rendered, layout-merged HTML body for the preview iframe. */
+      htmlPreview: string;
+      /** @description Number of active registrants (registered/confirmed) who would receive the mail. */
       recipientCount: number;
     };
     NewsletterSendStatusResponse: {
@@ -9846,6 +9916,97 @@ export interface operations {
         content?: never;
       };
       /** @description A slides-online send is already in progress or has already been sent */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  previewRegistrantNotice: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        eventCode: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['RegistrantNoticePreviewRequest'];
+      };
+    };
+    responses: {
+      /** @description Rendered preview + recipient count */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['RegistrantNoticePreviewResponse'];
+        };
+      };
+      /** @description Template is not a registrant-notice template */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      /** @description Event not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  sendRegistrantNotice: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        eventCode: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['RegistrantNoticeSendRequest'];
+      };
+    };
+    responses: {
+      /** @description Registrant-notice send queued */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SlidesOnlineSendResponse'];
+        };
+      };
+      /** @description Template is not a registrant-notice template */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      /** @description Event not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description A send of this template is already in progress or has already been sent */
       409: {
         headers: {
           [name: string]: unknown;

--- a/web-frontend/src/types/generated/events-api.types.ts
+++ b/web-frontend/src/types/generated/events-api.types.ts
@@ -3251,7 +3251,8 @@ export interface components {
         | 'TASK_REMINDER'
         | 'LAYOUT'
         | 'NEWSLETTER'
-        | 'VENUE_COORDINATION';
+        | 'VENUE_COORDINATION'
+        | 'REGISTRANT_NOTICE';
       /** @description Email subject line (null for layout templates) */
       subject?: string | null;
       /** @description HTML body content */
@@ -3288,7 +3289,8 @@ export interface components {
         | 'TASK_REMINDER'
         | 'LAYOUT'
         | 'NEWSLETTER'
-        | 'VENUE_COORDINATION';
+        | 'VENUE_COORDINATION'
+        | 'REGISTRANT_NOTICE';
       /** @description Email subject (required for content templates, null for layout) */
       subject?: string | null;
       /** @description HTML body content */
@@ -9146,14 +9148,15 @@ export interface operations {
   listEmailTemplates: {
     parameters: {
       query?: {
-        /** @description Filter by category (SPEAKER, REGISTRATION, TASK_REMINDER, LAYOUT, NEWSLETTER, VENUE_COORDINATION) */
+        /** @description Filter by category (SPEAKER, REGISTRATION, TASK_REMINDER, LAYOUT, NEWSLETTER, VENUE_COORDINATION, REGISTRANT_NOTICE) */
         category?:
           | 'SPEAKER'
           | 'REGISTRATION'
           | 'TASK_REMINDER'
           | 'LAYOUT'
           | 'NEWSLETTER'
-          | 'VENUE_COORDINATION';
+          | 'VENUE_COORDINATION'
+          | 'REGISTRANT_NOTICE';
         /** @description Filter to layout templates only (true) or content templates only (false) */
         isLayout?: boolean;
       };


### PR DESCRIPTION
## Why

Story 7.3's \"slides are online\" mail is meant for an event's **registrants**, but it shipped with a dangerous gap (found in review):

- The `slides-online` template was categorised **NEWSLETTER**, so it appeared in the **Event → Newsletter** tab's template picker.
- The subscriber newsletter send accepted **any** `templateKey` (no whitelist).
- The safe, registrant-targeted `/slides-online/send` endpoint had **no UI**.

→ The only reachable action was selecting `slides-online` in the Newsletter tab and clicking Send, which would have **emailed every newsletter subscriber** instead of the event's registrants.

## What changed (3 fixes + the requested tab)

1. **Backend reject (defence in depth):** `NewsletterEmailService.preview`/`sendNewsletter` now reject any `REGISTRANT_NOTICE`-category template with **400** — the subscriber pool can never receive a registrant template, regardless of UI.
2. **Recategorise:** `deriveCategory(slides-online) → REGISTRANT_NOTICE` (was NEWSLETTER) → it no longer appears in the subscriber-newsletter picker. Forward migration **V114** recategorises already-seeded staging/prod rows (seeding is insert-only).
3. **Generalised safe send + preview:** `SlidesOnlineEmailService.sendRegistrantNotice` / `previewRegistrantNotice` (validates the template is `REGISTRANT_NOTICE`); `sendSlidesOnline` delegates. New `RegistrantNoticeController`: `POST /events/{code}/registrant-notices/{preview,send}` (ORGANIZER). OpenAPI + regenerated FE types.
4. **New organizer "Registrant Notices" tab** (`EventRegistrantNoticesTab`, sibling of Newsletter): pick a `REGISTRANT_NOTICE` template + preview language, preview iframe with active-registrant count, send + confirm dialog. The send still resolves **each registrant's own language** (AC4) — the selector is preview-only. i18n in all 10 locales.

## Behaviour after this PR
- Newsletter tab: only NEWSLETTER templates; `slides-online` is gone and rejected even if forced via API.
- Registrant Notices tab: the safe way to send slides-online (and any future registrant notice) to **active registrants only**, honouring opt-outs, deduped, double-send guarded.

## Testing
- `NewsletterEmailServiceTest` — rejects a REGISTRANT_NOTICE template on preview + send (400, no send row).
- `SlidesOnlineEmailServiceTest` (5) — green with the new category guard.
- `EventRegistrantNoticesTab.test.tsx` (4) — render, no-template hint, preview + recipient count, confirm + send.
- `EventPage.test.tsx` — tab count updated (9).
- Backend `compileJava`/`compileTestJava` + FE `tsc`/ESLint clean; full FE suite (5170) green in pre-push. Full integration suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)