### PR TITLE
fix(events): show per-session Q&A on the agenda timeline cards

### DIFF
--- a/web-frontend/src/components/public/Event/EventProgram.tsx
+++ b/web-frontend/src/components/public/Event/EventProgram.tsx
@@ -20,6 +20,7 @@ import {
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SpeakerDisplay } from './SpeakerDisplay';
+import { SessionQnaThread } from './SessionQnaThread';
 import { eventApiClient } from '@/services/eventApiClient';
 
 const STRUCTURAL_TYPES = new Set(['moderation', 'break', 'lunch']);
@@ -41,9 +42,20 @@ interface EventProgramProps {
   sessions: SessionUI[];
   isArchived?: boolean; // Story 5.9 - Show materials only for archived events
   eventCode: string; // Story 5.9 - Required for material download API
+  /**
+   * Mount the per-session Q&A thread on each timeline card (Story 7.5). Same gate as SessionCards
+   * — the timeline (EventProgram) is what renders in the AGENDA phase, so without this the Q&A
+   * would be invisible once the agenda is published. SessionQnaThread self-gates on the 404.
+   */
+  showQna?: boolean;
 }
 
-export const EventProgram = ({ sessions, isArchived = false, eventCode }: EventProgramProps) => {
+export const EventProgram = ({
+  sessions,
+  isArchived = false,
+  eventCode,
+  showQna = false,
+}: EventProgramProps) => {
   const { t } = useTranslation('events');
   const [downloadingMaterials, setDownloadingMaterials] = useState<Set<string>>(new Set());
 
@@ -311,6 +323,18 @@ export const EventProgram = ({ sessions, isArchived = false, eventCode }: EventP
                                 )
                               )}
                             </div>
+                          </div>
+                        )}
+
+                        {/* Story 7.5: per-session Q&A on the timeline card (the timeline is what
+                            renders in the AGENDA phase). Collapsed by default; renders nothing when
+                            no Q&A window exists for the session (404 self-gate). */}
+                        {showQna && eventCode && (
+                          <div className="mt-4">
+                            <SessionQnaThread
+                              eventCode={eventCode}
+                              sessionSlug={session.sessionSlug}
+                            />
                           </div>
                         )}
                       </div>

--- a/web-frontend/src/pages/public/HomePage.tsx
+++ b/web-frontend/src/pages/public/HomePage.tsx
@@ -324,6 +324,7 @@ const HomePage = () => {
             sessions={event.sessions!}
             isArchived={isCompletedOrArchived}
             eventCode={event.eventCode}
+            showQna={qnaVisible}
           />
         )}
 

--- a/web-frontend/src/pages/public/homePagePhase.test.ts
+++ b/web-frontend/src/pages/public/homePagePhase.test.ts
@@ -134,8 +134,8 @@ describe('showSessionQna', () => {
   it('does NOT mount PRE_EVENT in the TOPIC sub-phase (no session cards)', () =>
     expect(showSessionQna({ kind: 'PRE_EVENT', sub: 'TOPIC' }, enabled)).toBe(false));
 
-  it('does NOT mount PRE_EVENT in the AGENDA sub-phase (timetable, no session cards)', () =>
-    expect(showSessionQna({ kind: 'PRE_EVENT', sub: 'AGENDA' }, enabled)).toBe(false));
+  it('mounts PRE_EVENT in the AGENDA sub-phase (Q&A on the EventProgram timeline cards)', () =>
+    expect(showSessionQna({ kind: 'PRE_EVENT', sub: 'AGENDA' }, enabled)).toBe(true));
 
   it('does NOT mount in COMING_SOON', () =>
     expect(showSessionQna({ kind: 'COMING_SOON' }, enabled)).toBe(false));

--- a/web-frontend/src/pages/public/homePagePhase.ts
+++ b/web-frontend/src/pages/public/homePagePhase.ts
@@ -107,8 +107,9 @@ export interface SectionVisibility {
  * self-gate on window existence (it renders nothing on a 404). We only skip when Q&A is
  * explicitly disabled for the event (`qnaEnabled === false`).
  *
- * Note: session cards only render in PRE_EVENT/SPEAKERS, POST_EVENT and ARCHIVE; the AGENDA
- * sub-phase shows the timetable (EventProgram) instead, which has no Q&A surface yet.
+ * Note: SPEAKERS / POST_EVENT / ARCHIVE render SessionCards while the AGENDA sub-phase renders
+ * the EventProgram timeline instead — both mount SessionQnaThread, so this returns true for all
+ * of them (the timeline cards carry the Q&A thread too).
  */
 export function showSessionQna(
   phase: HomePagePhase,
@@ -122,7 +123,9 @@ export function showSessionQna(
     case 'ARCHIVE':
       return true;
     case 'PRE_EVENT':
-      return phase.sub === 'SPEAKERS';
+      // SPEAKERS renders SessionCards, AGENDA renders the EventProgram timeline — both mount
+      // the Q&A thread, so pre-event Q&A stays visible across both published phases.
+      return phase.sub === 'SPEAKERS' || phase.sub === 'AGENDA';
     default:
       return false;
   }


### PR DESCRIPTION
## Problem (found on prod, event 59)
Q&A was opened on the current event BATbern59, but no Q&A appeared below the timeline/speaker cards.

Root cause: the per-session Q&A thread only mounts on `SessionCards`, which renders in the SPEAKERS / POST_EVENT / ARCHIVE phases. Once an event **publishes its agenda** (AGENDA phase), the homepage swaps `SessionCards` for the `EventProgram` **timeline** — which had no Q&A surface — and `showSessionQna` returned `false` for AGENDA. So an open Q&A on an agenda-published event was invisible. (This is the AGENDA-phase gap noted when the pre-event Q&A was first wired.)

## Fix
- `showSessionQna(phase, event)` now returns `true` for `PRE_EVENT/AGENDA` as well.
- `EventProgram` gained a `showQna` prop and mounts `SessionQnaThread` on each **non-structural** timeline card (HomePage passes `qnaVisible`, same gate as SessionCards). The thread is **collapsed by default** and self-gates on the 404 when no window exists.

## Verified
- BATbern59 (AGENDA phase) sessions have **OPEN** Q&A windows on prod → they'll render once deployed.
- FE `tsc`/ESLint clean; `homePagePhase` tests (85) green, including the flipped AGENDA assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)