### PR TITLE
fix(events): Q&A posts show poster name + company logo; stagger CI crons

### DIFF
--- a/.github/workflows/dependabot-batch-merge.yml
+++ b/.github/workflows/dependabot-batch-merge.yml
@@ -6,7 +6,7 @@ name: Dependabot Batch Merge
 on:
   # Scheduled run: First Monday of each month at 10:00 AM
   schedule:
-    - cron: '0 10 1-7 * 1'  # First Monday of month
+    - cron: '36 10 1-7 * 1'  # First Monday of month, 10:36 UTC — off the top of the hour (':00' delayed)
 
   # Manual trigger for testing or emergency runs
   workflow_dispatch:

--- a/.github/workflows/doc-drift-auditor.yml
+++ b/.github/workflows/doc-drift-auditor.yml
@@ -2,7 +2,7 @@ name: Doc Drift Auditor
 
 on:
   schedule:
-    - cron: '0 8 * * 1'   # Monday 08:00 UTC
+    - cron: '27 8 * * 1'   # Monday 08:27 UTC — off the top of the hour (':00' crons get delayed)
   workflow_dispatch:
     inputs:
       since:

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -13,8 +13,10 @@ name: Nightly E2E (full @gate suite)
 
 on:
   schedule:
-    # 03:00 UTC daily — low-traffic window (BATbern runs ~3 events/year).
-    - cron: '0 3 * * *'
+    # 01:17 UTC daily (~02:17 CET / 03:17 CEST — genuine Swiss night). Off the top of the hour
+    # deliberately: ':00' crons are heavily congested and GitHub delays them by hours (this '0 3'
+    # cron was actually firing ~07-08 UTC = 9-10am Swiss). An uncommon minute runs near schedule.
+    - cron: '17 1 * * *'
   workflow_dispatch:
     inputs:
       scope:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -31,8 +31,9 @@ on:
         options:
           - staging
   schedule:
-    # Every Monday at 03:00 UTC
-    - cron: '0 3 * * 1'
+    # Every Monday at 02:42 UTC — off the top of the hour (':00' crons get delayed by GitHub),
+    # and de-collided from the nightly-e2e schedule.
+    - cron: '42 2 * * 1'
 
 env:
   API_BASE_URL: https://api.batbern.ch

--- a/docs/api/events-api.openapi.yml
+++ b/docs/api/events-api.openapi.yml
@@ -9360,7 +9360,23 @@ components:
         postedByUsername:
           type: string
           nullable: true
-          description: Poster username; null if removed.
+          description: Poster username (stable id / takedown target); null if removed.
+        postedByFirstName:
+          type: string
+          nullable: true
+          description: Poster first name (enriched from the user profile); null if removed/unknown.
+        postedByLastName:
+          type: string
+          nullable: true
+          description: Poster last name (enriched from the user profile); null if removed/unknown.
+        postedByCompanyName:
+          type: string
+          nullable: true
+          description: Poster company display name; null if removed, unknown, or hidden by preference.
+        postedByCompanyLogoUrl:
+          type: string
+          nullable: true
+          description: Poster company logo CDN URL; null if removed, unknown, or hidden by preference.
         body:
           type: string
           nullable: true

--- a/services/event-management-service/src/main/java/ch/batbern/events/dto/QnaPostResponse.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/dto/QnaPostResponse.java
@@ -6,14 +6,21 @@ import java.util.UUID;
 /**
  * A single Q&A post in the thread response (Story 7.5).
  *
- * <p>When {@code removed} is true the post is an organizer-takedown tombstone: {@code body} and
- * {@code postedByUsername} are nulled out (the public archive shows "removed by organizer"), while
- * the post still occupies its place so replies stay coherent.
+ * <p>The poster is shown by display name + company logo (enriched from user_profiles/companies);
+ * {@code postedByUsername} is retained as a stable id and the organizer-takedown target.
+ *
+ * <p>When {@code removed} is true the post is an organizer-takedown tombstone: {@code body},
+ * {@code postedByUsername} and the enriched display fields are nulled out (the public archive shows
+ * "removed by organizer"), while the post still occupies its place so replies stay coherent.
  */
 public record QnaPostResponse(
         UUID id,
         UUID parentPostId,
         String postedByUsername,
+        String postedByFirstName,
+        String postedByLastName,
+        String postedByCompanyName,
+        String postedByCompanyLogoUrl,
         String body,
         boolean removed,
         Instant createdAt) {

--- a/services/event-management-service/src/main/java/ch/batbern/events/repository/QnaAuthorProjection.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/repository/QnaAuthorProjection.java
@@ -1,0 +1,28 @@
+package ch.batbern.events.repository;
+
+/**
+ * Projection to enrich Q&A posts with the poster's display name + company logo (Story 7.5).
+ *
+ * <p>Same intentional, read-only cross-service DB join as {@link UserPortraitProjection}: the
+ * Q&A GET is PUBLIC (anonymous-readable), so it cannot call the JWT-propagating
+ * {@code UserApiClient}. Reading {@code user_profiles}/{@code companies}/{@code logos} directly
+ * (all in the shared monorepo DB) resolves first/last name + company logo without auth and in a
+ * single batched query. Ownership of those tables stays with company-user-management-service.
+ */
+public interface QnaAuthorProjection {
+
+    String getUsername();
+
+    String getFirstName();
+
+    String getLastName();
+
+    /** Whether the user opted to show their company (user_profiles.settings_show_company). */
+    Boolean getShowCompany();
+
+    /** Human-readable company name (companies.display_name → name → company_id). */
+    String getCompanyDisplayName();
+
+    /** Company logo CloudFront URL (logos.cloudfront_url for the COMPANY entity), or null. */
+    String getCompanyLogoUrl();
+}

--- a/services/event-management-service/src/main/java/ch/batbern/events/repository/SessionUserRepository.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/repository/SessionUserRepository.java
@@ -195,4 +195,28 @@ public interface SessionUserRepository extends JpaRepository<SessionUser, UUID> 
            nativeQuery = true)
     List<UserPortraitProjection> findUserPortraitsByUsernames(
             @Param("usernames") java.util.Collection<String> usernames);
+
+    /**
+     * Batch-load Q&A author display data (first/last name + company logo) for a set of usernames.
+     * Same intentional, read-only cross-service join as {@link #findUserPortraitsByUsernames} —
+     * used to enrich the PUBLIC Q&A thread without a JWT (see {@link QnaAuthorProjection}).
+     *
+     * @param usernames distinct poster usernames from session_qna_post
+     * @return username → { firstName, lastName, showCompany, companyDisplayName, companyLogoUrl }
+     */
+    @Query(value = "SELECT up.username AS username, "
+            + "up.first_name AS firstName, "
+            + "up.last_name AS lastName, "
+            + "up.settings_show_company AS showCompany, "
+            + "COALESCE(c.display_name, c.name, up.company_id) AS companyDisplayName, "
+            + "(SELECT l.cloudfront_url FROM logos l "
+            + " WHERE l.associated_entity_id = c.id::text "
+            + "   AND l.associated_entity_type = 'COMPANY' "
+            + " LIMIT 1) AS companyLogoUrl "
+            + "FROM user_profiles up "
+            + "LEFT JOIN companies c ON c.name = up.company_id "
+            + "WHERE up.username IN :usernames",
+           nativeQuery = true)
+    List<QnaAuthorProjection> findQnaAuthorPortraitsByUsernames(
+            @Param("usernames") java.util.Collection<String> usernames);
 }

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/SessionQnaService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/SessionQnaService.java
@@ -13,6 +13,8 @@ import ch.batbern.events.repository.EventRepository;
 import ch.batbern.events.repository.SessionQnaPostRepository;
 import ch.batbern.events.repository.SessionQnaWindowRepository;
 import ch.batbern.events.repository.SessionRepository;
+import ch.batbern.events.repository.SessionUserRepository;
+import ch.batbern.events.repository.QnaAuthorProjection;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,8 +23,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Service for per-session Q&A (Story 7.5 "The Apéro Continues").
@@ -41,6 +48,7 @@ public class SessionQnaService {
     private final SessionQnaPostRepository postRepository;
     private final SessionRepository sessionRepository;
     private final EventRepository eventRepository;
+    private final SessionUserRepository sessionUserRepository;
 
     /**
      * Story 7.5 rework: open a Q&A window for every session of an event, but ONLY when the event's
@@ -172,7 +180,7 @@ public class SessionQnaService {
                 .body(body)
                 .build());
         log.info("Q&A post by {} on session {} (event {})", username, sessionSlug, eventCode);
-        return toPostResponse(saved);
+        return toPostResponse(saved, loadAuthorPortraits(List.of(username)));
     }
 
     /**
@@ -233,23 +241,51 @@ public class SessionQnaService {
     }
 
     private QnaWindowResponse toWindowResponse(SessionQnaWindow window) {
-        List<QnaPostResponse> posts = postRepository
-                .findByWindowIdOrderByCreatedAtAsc(window.getId())
-                .stream()
-                .map(this::toPostResponse)
-                .toList();
+        List<SessionQnaPost> postEntities =
+                postRepository.findByWindowIdOrderByCreatedAtAsc(window.getId());
+        // Enrich each (non-removed) poster with display name + company logo in ONE batched,
+        // anonymous-safe local DB query (the Q&A GET is public — no JWT for UserApiClient).
+        Set<String> authorUsernames = postEntities.stream()
+                .filter(p -> !p.isRemoved())
+                .map(SessionQnaPost::getPostedByUsername)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        Map<String, QnaAuthorProjection> portraits = loadAuthorPortraits(authorUsernames);
+        List<QnaPostResponse> posts =
+                postEntities.stream().map(p -> toPostResponse(p, portraits)).toList();
         return new QnaWindowResponse(window.getStatus().name(), window.getOpensAt(),
                 window.getClosesAt(), posts);
     }
 
-    private QnaPostResponse toPostResponse(SessionQnaPost post) {
-        boolean removed = post.isRemoved();
+    /** Batch-load poster portraits keyed by username (empty map for no usernames). */
+    private Map<String, QnaAuthorProjection> loadAuthorPortraits(Collection<String> usernames) {
+        if (usernames.isEmpty()) {
+            return Map.of();
+        }
+        return sessionUserRepository.findQnaAuthorPortraitsByUsernames(usernames).stream()
+                .collect(Collectors.toMap(QnaAuthorProjection::getUsername, p -> p, (a, b) -> a));
+    }
+
+    private QnaPostResponse toPostResponse(SessionQnaPost post,
+                                           Map<String, QnaAuthorProjection> portraits) {
+        if (post.isRemoved()) {
+            // Tombstone — null out identity + content (the UI shows "removed by organizer").
+            return new QnaPostResponse(post.getId(), post.getParentPostId(),
+                    null, null, null, null, null, null, true, post.getCreatedAt());
+        }
+        QnaAuthorProjection a = portraits.get(post.getPostedByUsername());
+        // Honour the user's "show company" preference; absent projection → no enrichment.
+        boolean showCompany = a != null && !Boolean.FALSE.equals(a.getShowCompany());
         return new QnaPostResponse(
                 post.getId(),
                 post.getParentPostId(),
-                removed ? null : post.getPostedByUsername(),
-                removed ? null : post.getBody(),
-                removed,
+                post.getPostedByUsername(),
+                a != null ? a.getFirstName() : null,
+                a != null ? a.getLastName() : null,
+                showCompany ? a.getCompanyDisplayName() : null,
+                showCompany ? a.getCompanyLogoUrl() : null,
+                post.getBody(),
+                false,
                 post.getCreatedAt());
     }
 }

--- a/services/event-management-service/src/test/java/ch/batbern/events/controller/SessionQnaIntegrationTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/controller/SessionQnaIntegrationTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
@@ -82,6 +83,9 @@ class SessionQnaIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     private SessionQnaScheduledService scheduledService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @MockBean
     private LockProvider lockProvider;
@@ -149,6 +153,41 @@ class SessionQnaIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status", is("OPEN")))
                 .andExpect(jsonPath("$.posts.length()", is(1)));
+    }
+
+    @Test
+    @DisplayName("Q&A poster is enriched with display name + company logo (not the raw username)")
+    void should_enrichPoster_withNameAndCompanyLogo() throws Exception {
+        SessionQnaWindow window = openWindow(QnaWindowStatus.FROZEN, Instant.now().minus(1, ChronoUnit.DAYS));
+        seedAuthor(ATTENDEE, "Jane", "Attendee", "bkw", true,
+                "BKW Energie AG", "https://cdn.batbern.ch/logos/bkw.png");
+        postRepository.save(SessionQnaPost.builder().windowId(window.getId())
+                .postedByUsername(ATTENDEE).body("Great talk").build());
+
+        mockMvc.perform(get("/api/v1/events/{e}/sessions/{s}/qna", EVENT_CODE, SLUG))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts[0].postedByUsername", is(ATTENDEE)))
+                .andExpect(jsonPath("$.posts[0].postedByFirstName", is("Jane")))
+                .andExpect(jsonPath("$.posts[0].postedByLastName", is("Attendee")))
+                .andExpect(jsonPath("$.posts[0].postedByCompanyName", is("BKW Energie AG")))
+                .andExpect(jsonPath("$.posts[0].postedByCompanyLogoUrl",
+                        is("https://cdn.batbern.ch/logos/bkw.png")));
+    }
+
+    @Test
+    @DisplayName("Poster who opted out of showing company → name kept, company fields suppressed")
+    void should_suppressCompany_when_showCompanyFalse() throws Exception {
+        SessionQnaWindow window = openWindow(QnaWindowStatus.FROZEN, Instant.now().minus(1, ChronoUnit.DAYS));
+        seedAuthor(ATTENDEE, "Jane", "Attendee", "bkw", false,
+                "BKW Energie AG", "https://cdn.batbern.ch/logos/bkw.png");
+        postRepository.save(SessionQnaPost.builder().windowId(window.getId())
+                .postedByUsername(ATTENDEE).body("Great talk").build());
+
+        mockMvc.perform(get("/api/v1/events/{e}/sessions/{s}/qna", EVENT_CODE, SLUG))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts[0].postedByFirstName", is("Jane")))
+                .andExpect(jsonPath("$.posts[0].postedByCompanyName", nullValue()))
+                .andExpect(jsonPath("$.posts[0].postedByCompanyLogoUrl", nullValue()));
     }
 
     // ==================== AC3: anonymous cannot post; can read ====================
@@ -359,6 +398,27 @@ class SessionQnaIntegrationTest extends AbstractIntegrationTest {
     }
 
     // ==================== Helpers ====================
+
+    /**
+     * Seed the cross-service rows the Q&A poster-enrichment native query reads: a company, the
+     * poster's user_profiles row (with the show-company privacy flag), and an ASSOCIATED company
+     * logo. These live in CUMS-owned tables stubbed for the EMS test container.
+     */
+    private void seedAuthor(String username, String firstName, String lastName, String companyKey,
+                            boolean showCompany, String companyDisplayName, String logoUrl) {
+        java.util.UUID companyId = java.util.UUID.randomUUID();
+        jdbcTemplate.update("INSERT INTO companies (id, name, display_name) VALUES (?, ?, ?)",
+                companyId, companyKey, companyDisplayName);
+        jdbcTemplate.update(
+                "INSERT INTO user_profiles (username, company_id, first_name, last_name, settings_show_company) "
+                        + "VALUES (?, ?, ?, ?, ?)",
+                username, companyKey, firstName, lastName, showCompany);
+        jdbcTemplate.update(
+                "INSERT INTO logos (upload_id, s3_key, cloudfront_url, file_extension, file_size, mime_type, "
+                        + "status, associated_entity_type, associated_entity_id) "
+                        + "VALUES (?, ?, ?, 'png', 1024, 'image/png', 'ASSOCIATED', 'COMPANY', ?)",
+                "upl-" + companyKey, "logos/" + companyKey + ".png", logoUrl, companyId.toString());
+    }
 
     private SessionQnaWindow openWindow(QnaWindowStatus status, Instant closesAt) {
         Event event = saveEvent(EventWorkflowState.EVENT_COMPLETED);

--- a/services/event-management-service/src/test/resources/db/testmigration/V100__create_user_profiles_stub.sql
+++ b/services/event-management-service/src/test/resources/db/testmigration/V100__create_user_profiles_stub.sql
@@ -22,6 +22,8 @@ CREATE TABLE IF NOT EXISTS user_profiles (
     last_name VARCHAR(100) DEFAULT '',
     profile_picture_url VARCHAR(2048),
     bio TEXT,
+    -- Privacy flag honored by SessionQnaService when enriching Q&A poster portraits:
+    settings_show_company BOOLEAN NOT NULL DEFAULT TRUE,
     is_active BOOLEAN NOT NULL DEFAULT TRUE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/web-frontend/src/components/public/Event/SessionQnaThread.tsx
+++ b/web-frontend/src/components/public/Event/SessionQnaThread.tsx
@@ -17,6 +17,13 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth/useAuth';
 import { useSessionQna, useAddQnaPost, useRemoveQnaPost } from '@/hooks/useQna/useQna';
 import type { QnaPostResponse } from '@/services/qnaService';
+import { buildCdnImageUrl } from '@/utils/cdnImage';
+
+/** Poster display name: "First Last", falling back to the username when the name is unknown. */
+function posterName(post: QnaPostResponse): string {
+  const name = [post.postedByFirstName, post.postedByLastName].filter(Boolean).join(' ').trim();
+  return name || post.postedByUsername || '';
+}
 
 interface SessionQnaThreadProps {
   eventCode: string;
@@ -86,7 +93,23 @@ export function SessionQnaThread({ eventCode, sessionSlug }: SessionQnaThreadPro
         ) : (
           <>
             <p className="whitespace-pre-wrap text-sm text-zinc-200">{post.body}</p>
-            <p className="mt-1 text-xs text-zinc-500">{post.postedByUsername}</p>
+            <div
+              className="mt-1 flex items-center gap-1.5 text-xs text-zinc-500"
+              data-testid="qna-post-author"
+            >
+              {post.postedByCompanyLogoUrl && (
+                <img
+                  src={
+                    buildCdnImageUrl(post.postedByCompanyLogoUrl, { h: 32, fit: 'inside' }) ??
+                    post.postedByCompanyLogoUrl
+                  }
+                  alt={post.postedByCompanyName ?? ''}
+                  className="h-4 w-auto max-w-[64px] object-contain"
+                  loading="lazy"
+                />
+              )}
+              <span>{posterName(post)}</span>
+            </div>
           </>
         )}
         {isOrganizer && !post.removed && (

--- a/web-frontend/src/components/public/Event/__tests__/SessionQnaThread.test.tsx
+++ b/web-frontend/src/components/public/Event/__tests__/SessionQnaThread.test.tsx
@@ -45,6 +45,10 @@ type Post = {
   id: string;
   parentPostId: string | null;
   postedByUsername: string | null;
+  postedByFirstName?: string | null;
+  postedByLastName?: string | null;
+  postedByCompanyName?: string | null;
+  postedByCompanyLogoUrl?: string | null;
   body: string | null;
   removed: boolean;
   createdAt: string;
@@ -210,5 +214,29 @@ describe('SessionQnaThread', () => {
     const takedown = screen.getByTestId('qna-takedown');
     fireEvent.click(takedown);
     expect(removeMutate).toHaveBeenCalledWith('p1');
+  });
+
+  it('shows the poster name + company logo, not the raw username', () => {
+    mockThread('FROZEN', [
+      {
+        id: 'p1',
+        parentPostId: null,
+        postedByUsername: 'jane.doe',
+        postedByFirstName: 'Jane',
+        postedByLastName: 'Doe',
+        postedByCompanyName: 'BKW',
+        postedByCompanyLogoUrl: 'https://cdn.batbern.ch/logos/bkw.png',
+        body: 'Great talk',
+        removed: false,
+        createdAt: '',
+      },
+    ]);
+    mockAuth(false);
+    renderThread();
+    expandThread();
+    const author = screen.getByTestId('qna-post-author');
+    expect(author).toHaveTextContent('Jane Doe');
+    expect(author).not.toHaveTextContent('jane.doe');
+    expect(author.querySelector('img')).toHaveAttribute('alt', 'BKW');
   });
 });

--- a/web-frontend/src/types/generated/events-api.types.ts
+++ b/web-frontend/src/types/generated/events-api.types.ts
@@ -5001,8 +5001,16 @@ export interface components {
        * @description Parent question id; null for a top-level question.
        */
       parentPostId?: string | null;
-      /** @description Poster username; null if removed. */
+      /** @description Poster username (stable id / takedown target); null if removed. */
       postedByUsername?: string | null;
+      /** @description Poster first name (enriched from the user profile); null if removed/unknown. */
+      postedByFirstName?: string | null;
+      /** @description Poster last name (enriched from the user profile); null if removed/unknown. */
+      postedByLastName?: string | null;
+      /** @description Poster company display name; null if removed, unknown, or hidden by preference. */
+      postedByCompanyName?: string | null;
+      /** @description Poster company logo CDN URL; null if removed, unknown, or hidden by preference. */
+      postedByCompanyLogoUrl?: string | null;
       /** @description Post text; null if removed. */
       body?: string | null;
       /** @description True if the post was taken down by an organizer. */


### PR DESCRIPTION
## What & why

Two small fixes bundled per request.

### 1. Q&A posts show the poster, not a username (Story 7.5)
Per-session Q&A questions/answers rendered the raw username (e.g. `jane.doe`). They now show the poster's **display name** ("First Last") and **company logo**.

- Backend enriches each post via one batch native query joining `user_profiles` + `companies` + `logos` (one round-trip per thread, keyed by the posters in the window).
- Falls back to the username when no name is known.
- Honours the user's `settings_show_company` privacy flag — company name + logo suppressed when the user opted out (display name still shown).
- Tombstoned (organizer-removed) posts null all identity fields, unchanged.
- `QnaPostResponse` gains `postedByFirstName` / `postedByLastName` / `postedByCompanyName` / `postedByCompanyLogoUrl` (all nullable, additive); `events-api.openapi.yml` + generated FE types updated.
- Frontend renders the CDN-resized logo (`fit=inside`, no black bars) + name.

### 2. Stagger CI crons off the top of the hour
The "nightly" run drifted to ~09:00 local because several workflows fired at `:00` UTC (a congested slot). Moved four schedules to off-peak minutes:
| workflow | was | now |
|---|---|---|
| nightly-e2e | `0 3 * * *` | `17 1 * * *` |
| security-scan | `0 3 * * 1` | `42 2 * * 1` |
| doc-drift-auditor | `0 8 * * 1` | `27 8 * * 1` |
| dependabot-batch-merge | `0 10 1-7 * 1` | `36 10 1-7 * 1` |

## Tests
- `SessionQnaIntegrationTest` (PostgreSQL/Testcontainers): added the test-schema `settings_show_company` stub column; two new ITs seed `companies`/`user_profiles`/`logos` and assert enrichment + the show-company=false suppression path. 16/16 pass.
- Frontend `SessionQnaThread` unit tests + `type-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)