### PR TITLE
docs(ux): event detail page redesign — spec + clickable prototypes

### DIFF
--- a/docs/ux/event-detail-redesign-mobile.html
+++ b/docs/ux/event-detail-redesign-mobile.html
@@ -1,0 +1,462 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>BATbern · Event Page Redesign (Mobile)</title>
+<style>
+  :root{
+    --bg:#f4f6fa; --surface:#ffffff; --ink:#1a2330; --ink-soft:#5b6675;
+    --line:#e3e8f0; --line-soft:#eef1f6;
+    --primary:#0a4d8c; --primary-soft:#e7f0fb;
+    --accent:#1f8a5b; --accent-soft:#e4f4ec;
+    --warn:#b9770a; --warn-soft:#fdf3e0; --warn-line:#f0d9ac;
+    --danger:#c0392b; --danger-soft:#fbeae8;
+    --muted:#9aa6b6; --shadow:0 1px 2px rgba(16,30,54,.06),0 4px 16px rgba(16,30,54,.06);
+  }
+  *{box-sizing:border-box}
+  body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    background:#e9edf3;color:var(--ink);-webkit-font-smoothing:antialiased;line-height:1.4}
+  .proto{background:#0e1b2e;color:#cdd8e6;font-size:12.5px;padding:8px 18px;display:flex;gap:12px;
+    align-items:center;justify-content:center;flex-wrap:wrap}
+  .proto b{color:#fff}.proto a{color:#7fb2ee}.proto .pill{background:#1b2c44;border-radius:999px;padding:2px 10px;color:#9fc1ec}
+
+  .stage{display:flex;gap:40px;flex-wrap:wrap;justify-content:center;align-items:flex-start;padding:34px 20px 60px}
+  .col-notes{max-width:340px;font-size:13.5px;color:#33414f}
+  .col-notes h2{font-size:17px;margin:0 0 12px}
+  .col-notes h3{font-size:13.5px;margin:18px 0 5px;color:var(--primary)}
+  .col-notes p{margin:0 0 10px}
+  .col-notes code{background:#dde5ef;border-radius:5px;padding:1px 5px;font-size:12px}
+  .col-notes li{margin-bottom:6px}
+
+  /* phone */
+  .phone{width:380px;height:780px;background:#0e1b2e;border-radius:42px;padding:11px;box-shadow:0 22px 60px rgba(16,30,54,.32);flex:0 0 auto}
+  .screen{position:relative;width:100%;height:100%;background:var(--bg);border-radius:32px;overflow:hidden;display:flex;flex-direction:column}
+  .notch{position:absolute;top:0;left:50%;transform:translateX(-50%);width:140px;height:26px;background:#0e1b2e;border-radius:0 0 16px 16px;z-index:30}
+
+  /* app header */
+  .ah{background:var(--surface);border-bottom:1px solid var(--line);padding:30px 14px 10px;flex:0 0 auto;z-index:20}
+  .ah .top{display:flex;align-items:center;gap:8px}
+  .ah .bk{font-size:18px;color:var(--ink-soft);background:none;border:none;cursor:pointer}
+  .ah .ti{font-weight:700;font-size:15px;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .ah .more{font-size:18px;background:none;border:none;cursor:pointer;color:var(--ink-soft)}
+  .ah .sub{display:flex;align-items:center;gap:8px;margin-top:7px;flex-wrap:wrap}
+  .chip{display:inline-flex;align-items:center;gap:5px;background:var(--primary-soft);color:var(--primary);font-weight:600;font-size:11px;padding:3px 9px;border-radius:999px}
+  .chip .dot{width:6px;height:6px;border-radius:50%;background:var(--primary)}
+  .ah .sub .meta{font-size:11.5px;color:var(--ink-soft)}
+
+  /* scroll body */
+  .body{flex:1;overflow-y:auto;padding:14px 13px 80px}
+  .scr{display:none}.scr.show{display:block}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:13px;box-shadow:var(--shadow);padding:13px 14px;margin-bottom:12px}
+  .lbl{font-size:10.5px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);margin:0 0 9px}
+  .ctitle{font-size:14px;font-weight:700;margin:0 0 3px}.csub{font-size:12px;color:var(--ink-soft);margin:0}
+
+  .miniprog{display:flex;align-items:center;gap:9px}
+  .miniprog .bar{flex:1;height:8px;border-radius:6px;background:var(--line-soft);overflow:hidden}
+  .miniprog .bar>i{display:block;height:100%;background:var(--primary);border-radius:6px}
+  .miniprog .pct{font-size:12px;font-weight:700;color:var(--primary)}
+  .stepname{font-size:12.5px;color:var(--ink-soft);margin-top:7px}
+
+  .task{display:flex;gap:10px;padding:11px 0;border-bottom:1px solid var(--line-soft)}
+  .task:last-child{border:none}
+  .task .strip{width:4px;border-radius:4px;align-self:stretch}
+  .task.over .strip{background:var(--danger)}.task.soon .strip{background:var(--warn)}.task.ok .strip{background:var(--accent)}
+  .task .b{flex:1}.task .tn{font-weight:700;font-size:13px;margin:0 0 4px}
+  .due{font-weight:700;font-size:11px;padding:2px 7px;border-radius:999px}
+  .due.over{background:var(--danger-soft);color:var(--danger)}.due.soon{background:var(--warn-soft);color:var(--warn)}.due.ok{background:var(--accent-soft);color:var(--accent)}
+  .task .go{font-size:11.5px;color:var(--primary);font-weight:700;background:none;border:none;padding:6px 0 0;cursor:pointer}
+
+  .tiles2{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+  .tile{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:12px;box-shadow:var(--shadow)}
+  .tile .tl{font-size:11.5px;color:var(--ink-soft);margin-bottom:6px}
+  .tile .num{font-size:19px;font-weight:800}.tile .num small{font-size:12px;color:var(--muted);font-weight:600}
+  .tile .bar{height:6px;border-radius:5px;background:var(--line-soft);margin-top:7px;overflow:hidden}
+  .tile .bar>i{display:block;height:100%;border-radius:5px;background:var(--primary)}
+  .tile .bar>i.g{background:var(--accent)}.tile .bar>i.w{background:var(--warn)}
+
+  .btn{display:inline-flex;align-items:center;justify-content:center;gap:6px;font:inherit;font-size:13px;font-weight:600;
+    border-radius:9px;padding:9px 13px;border:1px solid var(--line);background:var(--surface);color:var(--ink);cursor:pointer;width:100%}
+  .btn.primary{background:var(--primary);border-color:var(--primary);color:#fff}
+  .btn.sm{width:auto;padding:6px 11px;font-size:12px}
+  .btn.warn{color:var(--warn);border-color:var(--warn-line)}
+  .btn.danger{color:var(--danger);border-color:var(--danger)}
+
+  /* segmented (sub-nav, scrollable) */
+  .segm{display:flex;gap:6px;overflow-x:auto;padding-bottom:4px;margin-bottom:12px}
+  .segm button{flex:0 0 auto;font:inherit;font-size:12.5px;font-weight:600;padding:7px 13px;border-radius:999px;
+    border:1px solid var(--line);background:var(--surface);color:var(--ink-soft);cursor:pointer;white-space:nowrap}
+  .segm button.on{background:var(--primary);border-color:var(--primary);color:#fff}
+
+  .lane{margin-bottom:12px}
+  .lane h4{font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:var(--ink-soft);margin:0 0 7px;display:flex;justify-content:space-between}
+  .scard{background:var(--surface);border:1px solid var(--line);border-radius:10px;padding:10px 11px;margin-bottom:7px;box-shadow:var(--shadow)}
+  .scard .nm{font-weight:600;font-size:13px}.scard .co{font-size:11.5px;color:var(--ink-soft);margin-top:2px}
+  .scard .act{font-size:11.5px;color:var(--primary);font-weight:700;margin-top:6px;display:inline-block}
+
+  /* tap-to-assign */
+  .tray{background:var(--warn-soft);border:1px solid var(--warn-line);border-radius:11px;padding:11px;margin-bottom:12px}
+  .tray .th{font-size:11.5px;font-weight:700;color:var(--warn);margin-bottom:8px}
+  .schip{background:#fff;border:1px solid var(--line);border-radius:9px;padding:9px 10px;margin-bottom:7px;display:flex;align-items:center;gap:9px;cursor:pointer}
+  .schip.sel{border-color:var(--primary);box-shadow:0 0 0 2px var(--primary-soft)}
+  .schip .nm{font-weight:600;font-size:12.5px}.schip .co{font-size:11px;color:var(--ink-soft)}
+  .schip .pick{margin-left:auto;font-size:11px;font-weight:700;color:var(--primary)}
+  .slot{border:1.5px dashed var(--line);border-radius:10px;padding:10px 11px;margin-bottom:8px;display:flex;align-items:center;gap:10px;min-height:46px}
+  .slot.filled{border-style:solid;border-color:var(--primary-soft);background:var(--primary-soft)}
+  .slot.struct{border-style:solid;background:var(--line-soft);border-color:var(--line)}
+  .slot .tm{font-size:11.5px;font-weight:700;color:var(--ink-soft);width:62px;flex:0 0 auto}
+  .slot .ss{font-size:12.5px;font-weight:600}.slot.empty .ss{color:var(--muted);font-style:italic;font-weight:500}
+  .slot.armed{border-color:var(--accent);background:var(--accent-soft);cursor:pointer}
+  .hintbar{font-size:11.5px;color:var(--accent);font-weight:600;margin-bottom:10px;display:none}
+  .hintbar.show{display:block}
+
+  /* registrations */
+  table{width:100%;border-collapse:collapse;font-size:12.5px}
+  th{text-align:left;font-size:10px;text-transform:uppercase;color:var(--muted);padding:6px 4px;border-bottom:1px solid var(--line)}
+  td{padding:9px 4px;border-bottom:1px solid var(--line-soft)}
+  .tag{font-size:10.5px;font-weight:700;padding:2px 7px;border-radius:999px}
+  .tag.g{background:var(--accent-soft);color:var(--accent)}.tag.w{background:var(--warn-soft);color:var(--warn)}
+  .tag.b{background:var(--primary-soft);color:var(--primary)}.tag.n{background:var(--line-soft);color:var(--ink-soft)}
+  .rcard{display:flex;align-items:center;gap:10px;padding:10px 0;border-bottom:1px solid var(--line-soft)}
+  .av{width:30px;height:30px;border-radius:50%;background:var(--primary-soft);color:var(--primary);font-size:11px;font-weight:700;display:flex;align-items:center;justify-content:center;flex:0 0 auto}
+  .rcard .ri{flex:1;min-width:0}.rcard .rn{font-weight:600;font-size:13px}.rcard .rc{font-size:11.5px;color:var(--ink-soft);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+  .field{margin-bottom:11px}.field label{display:block;font-size:11.5px;font-weight:600;color:var(--ink-soft);margin-bottom:4px}
+  .field select,.field input,.field textarea{width:100%;font:inherit;font-size:13px;padding:9px 10px;border:1px solid var(--line);border-radius:9px;background:#fff}
+  .seg2{display:flex;gap:6px;overflow-x:auto;margin-bottom:10px}
+  .seg2 button{flex:0 0 auto;font:inherit;font-size:12px;font-weight:600;padding:8px 12px;border-radius:9px;border:1px solid var(--line);background:#fff;color:var(--ink-soft);cursor:pointer;white-space:nowrap}
+  .seg2 button.on{background:var(--primary);border-color:var(--primary);color:#fff}
+  .anote{font-size:11.5px;padding:9px 11px;border-radius:9px;margin-bottom:12px;background:var(--primary-soft);color:var(--primary)}
+  .preview{border:1px solid var(--line);border-radius:10px;height:150px;background:linear-gradient(#fff,#f8fafd);display:flex;align-items:center;justify-content:center;color:var(--muted);font-size:12px;margin-bottom:12px}
+  .switch{width:36px;height:21px;border-radius:999px;background:var(--line);position:relative;display:inline-block;flex:0 0 auto}
+  .switch.on{background:var(--accent)}.switch::after{content:"";position:absolute;top:2px;left:2px;width:17px;height:17px;border-radius:50%;background:#fff;transition:.15s}.switch.on::after{left:17px}
+  .note{padding:11px;border:1px solid var(--line);border-radius:11px;margin-bottom:10px}
+  .note .nq{font-size:12.5px;font-style:italic;margin:0 0 6px}.note .nf{font-size:11px;color:var(--ink-soft);display:flex;justify-content:space-between;align-items:center}
+
+  /* bottom nav */
+  .bnav{position:absolute;bottom:0;left:0;right:0;background:var(--surface);border-top:1px solid var(--line);
+    display:flex;padding:7px 4px 9px;z-index:25}
+  .bnav button{flex:1;background:none;border:none;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:2px;
+    font:inherit;font-size:10px;font-weight:600;color:var(--muted);position:relative}
+  .bnav button .bi{font-size:19px}
+  .bnav button.on{color:var(--primary)}
+  .bnav button .bdg{position:absolute;top:-2px;right:50%;margin-right:-16px;background:var(--warn);color:#fff;font-size:9px;font-weight:700;min-width:15px;height:15px;border-radius:999px;display:flex;align-items:center;justify-content:center;padding:0 3px}
+  .bnav button .rdot{position:absolute;top:0;right:50%;margin-right:-13px;width:7px;height:7px;border-radius:50%;background:var(--danger)}
+
+  /* more sheet */
+  .sheet-ov{position:absolute;inset:0;background:rgba(14,27,46,.45);display:none;z-index:35}
+  .sheet-ov.show{display:block}
+  .sheet{position:absolute;left:0;right:0;bottom:0;background:#fff;border-radius:20px 20px 0 0;padding:8px 14px 22px;z-index:36;transform:translateY(100%);transition:.22s}
+  .sheet.show{transform:none}
+  .sheet .grab{width:38px;height:4px;border-radius:4px;background:var(--line);margin:8px auto 12px}
+  .sheet h4{margin:0 0 8px;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
+  .sheet .item{display:flex;align-items:center;gap:12px;padding:13px 6px;border-bottom:1px solid var(--line-soft);font-size:14.5px;font-weight:600;cursor:pointer}
+  .sheet .item:last-child{border:none}.sheet .item .si{font-size:19px}
+  .sheet .item .lock{margin-left:auto;font-size:12px;color:var(--muted);font-weight:500}
+
+  @media(max-width:840px){.stage{flex-direction:column-reverse;align-items:center}.col-notes{max-width:380px}}
+</style>
+</head>
+<body>
+
+<div class="proto">
+  <b>PROTOTYPE · MOBILE</b>
+  <span class="pill">live phone — tap the bottom nav</span>
+  <a href="event-detail-redesign-prototype.html">→ open desktop prototype</a>
+</div>
+
+<div class="stage">
+
+  <!-- explanatory column -->
+  <div class="col-notes">
+    <h2>📱 The mobile strategy</h2>
+    <p>Seven destinations don’t fit a phone tab bar (4–5 max is the platform norm), so the IA changes shape — it doesn’t just shrink.</p>
+
+    <h3>1 · Bottom nav + “More”</h3>
+    <p>The four <b>day-to-day</b> destinations live in the bottom bar — <b>Cockpit, Speakers, Registrations, Communications</b>. The three <b>occasional</b> ones (Publishing, Wrap-up, Settings) live behind <b>⋯ More</b>, which opens a sheet. Badges/dots ride on the nav icons. Tap <b>⋯ More</b> to see it.</p>
+
+    <h3>2 · Cockpit is the answer to “what now?”</h3>
+    <p>On a phone the cockpit matters <i>more</i>, not less — the organizer checks it on the train. Lifecycle collapses to a single <code>Step 4/9</code> bar; attention tasks stack full-width; metrics go 2-up.</p>
+
+    <h3>3 · Drag → tap-to-assign</h3>
+    <p>Drag-drop is hostile on touch. In <b>Speakers → Slots</b>, tap an unassigned session, then tap a highlighted slot. Same model, thumb-friendly. <b>Try it.</b></p>
+
+    <h3>4 · Tables → cards</h3>
+    <p>Registrations becomes a search box + stacked cards (the real app already does responsive cards), with row actions in an overflow menu.</p>
+
+    <h3>5 · Lifecycle dimming holds</h3>
+    <p>Wrap-up shows a 🔒 in the More sheet until <code>EVENT_LIVE</code> — same adaptive rule as desktop.</p>
+  </div>
+
+  <!-- live phone -->
+  <div class="phone">
+    <div class="screen">
+      <div class="notch"></div>
+
+      <!-- header -->
+      <div class="ah">
+        <div class="top">
+          <button class="bk">‹</button>
+          <div class="ti">BATbern 76 — Cloud Native…</div>
+          <button class="more" id="moreBtn">⋯</button>
+        </div>
+        <div class="sub">
+          <span class="chip"><span class="dot"></span> Slot Assignment · 4/9</span>
+          <span class="meta">📅 18 Sep · ⏳ 34d</span>
+        </div>
+      </div>
+
+      <!-- body -->
+      <div class="body" id="body">
+
+        <!-- COCKPIT -->
+        <div class="scr show" id="s-cockpit">
+          <div class="card" style="display:flex;gap:10px;align-items:center;font-size:12px;color:var(--ink-soft)">
+            <span style="font-size:17px;opacity:.55">🎬</span>
+            <span><b style="color:var(--ink)">Event-day controls</b> — on 18 Sep, Present &amp; Live Control appear as cards in “Needs your attention”.</span>
+          </div>
+          <div class="card">
+            <p class="lbl">Where this event is</p>
+            <div class="miniprog"><span class="pct">44%</span><div class="bar"><i style="width:44%"></i></div></div>
+            <div class="stepname">Step 4 of 9 · <b>Slot Assignment</b> → next: Agenda Published</div>
+          </div>
+          <div class="card">
+            <p class="ctitle">Needs your attention</p>
+            <p class="csub" style="margin-bottom:8px">Overdue first, then due soon.</p>
+            <div class="task over"><div class="strip"></div><div class="b"><p class="tn">Assign moderator</p>
+              <span class="due over">Overdue · 3d</span><button class="go" data-go="settings">Open Settings →</button></div></div>
+            <div class="task soon"><div class="strip"></div><div class="b"><p class="tn">Send “Speaker line-up” newsletter</p>
+              <span class="due soon">Due in 4d</span><button class="go" data-go="comms">Open Communications →</button></div></div>
+            <div class="task soon"><div class="strip"></div><div class="b"><p class="tn">Finalize &amp; publish agenda</p>
+              <span class="due soon">Locks in 6d</span><button class="go" data-go="publishing">Open Publishing →</button></div></div>
+          </div>
+          <p class="lbl">At a glance · tap to jump</p>
+          <div class="tiles2">
+            <div class="tile" data-mtile="registrations" style="cursor:pointer"><div class="tl">🎟️ Registrations</div><div class="num">128 <small>/180</small></div><div class="bar"><i style="width:71%"></i></div></div>
+            <div class="tile" data-mtile="pool" style="cursor:pointer"><div class="tl">🎤 Speakers</div><div class="num">6 <small>/6</small></div><div class="bar"><i class="g" style="width:100%"></i></div></div>
+            <div class="tile" data-mtile="agenda" style="cursor:pointer"><div class="tl">📋 Materials</div><div class="num">3 <small>/6</small></div><div class="bar"><i class="w" style="width:50%"></i></div></div>
+            <div class="tile" data-mtile="slots" style="cursor:pointer"><div class="tl">🗓️ Agenda</div><div class="num">4 <small>/6</small></div><div class="bar"><i class="w" style="width:66%"></i></div></div>
+          </div>
+        </div>
+
+        <!-- SPEAKERS -->
+        <div class="scr" id="s-speakers">
+          <div class="segm" id="spkSeg">
+            <button class="on" data-sp="pool">🗂️ Pool</button>
+            <button data-sp="agenda">🗓️ Agenda</button>
+            <button data-sp="slots">🧩 Slots</button>
+          </div>
+
+          <div id="sp-pool">
+            <div class="lane"><h4>Contacted <span>1</span></h4>
+              <div class="scard"><div class="nm">Dr. Amir Roth</div><div class="co">ETH Zürich</div><span class="act">Promote →</span></div></div>
+            <div class="lane"><h4>Accepted <span>3</span></h4>
+              <div class="scard"><div class="nm">Sophie Meier</div><div class="co">Google ZH</div><span class="act">Enter content →</span></div>
+              <div class="scard"><div class="nm">Tobias Brun</div><div class="co">Swisscom</div></div>
+              <div class="scard"><div class="nm">Nadia Kex</div><div class="co">Zühlke</div></div></div>
+            <div class="lane"><h4>Reviewed <span>3</span></h4>
+              <div class="scard"><div class="nm">Jan Keller</div><div class="co">Adnovum</div></div></div>
+          </div>
+
+          <div id="sp-agenda" style="display:none">
+            <div class="scard"><div class="nm">Platform Engineering at Scale</div><div class="co">Sophie Meier · <span class="tag b">17:35</span> · <span class="tag g">Approved</span></div></div>
+            <div class="scard"><div class="nm">GitOps in Regulated Banking</div><div class="co">Tobias Brun · <span class="tag b">18:10</span> · <span class="tag w">In review</span></div></div>
+            <div class="scard"><div class="nm">Multi-cluster Service Mesh</div><div class="co">Pia Stöckli · <span class="tag n">no slot</span> · <span class="tag w">Pending</span></div></div>
+            <div class="scard"><div class="nm">Edge-native Workloads</div><div class="co">Nadia Kex · <span class="tag n">no slot</span> · <span class="tag w">Pending</span></div></div>
+          </div>
+
+          <div id="sp-slots" style="display:none">
+            <div class="tray">
+              <div class="th">⏳ UNASSIGNED — tap one, then tap a slot</div>
+              <div class="schip" data-s="Multi-cluster Service Mesh"><div><div class="nm">Multi-cluster Service Mesh</div><div class="co">Pia Stöckli · 30 min</div></div><span class="pick">tap →</span></div>
+              <div class="schip" data-s="Edge-native Workloads"><div><div class="nm">Edge-native Workloads</div><div class="co">Nadia Kex · 30 min</div></div><span class="pick">tap →</span></div>
+            </div>
+            <div class="hintbar" id="hint">↓ Now tap a highlighted slot to place it</div>
+            <div class="slot struct"><div class="tm">17:30</div><div class="ss">🎙️ Moderation</div></div>
+            <div class="slot filled"><div class="tm">17:35</div><div class="ss">Platform Eng. — S. Meier</div></div>
+            <div class="slot filled"><div class="tm">18:10</div><div class="ss">GitOps — T. Brun</div></div>
+            <div class="slot filled"><div class="tm">18:45</div><div class="ss">eBPF — R. Costa</div></div>
+            <div class="slot struct"><div class="tm">19:15</div><div class="ss">🍷 Apéro</div></div>
+            <div class="slot filled"><div class="tm">19:35</div><div class="ss">FinOps — J. Keller</div></div>
+            <div class="slot empty target"><div class="tm">20:10</div><div class="ss">empty slot</div></div>
+            <div class="slot empty target"><div class="tm">20:45</div><div class="ss">empty slot</div></div>
+            <button class="btn primary" style="margin-top:6px">✨ Auto-assign the rest</button>
+          </div>
+        </div>
+
+        <!-- REGISTRATIONS -->
+        <div class="scr" id="s-registrations">
+          <div class="card">
+            <p class="ctitle">Registrations <span class="tag b">140 active</span></p>
+            <p class="csub" style="margin:4px 0 10px">128 confirmed / 180 · 12 waitlist</p>
+            <div class="field" style="margin:0 0 10px"><input placeholder="🔍 Search name / email / company"></div>
+            <div class="seg2"><button class="on">All</button><button>Confirmed</button><button>Registered</button><button>Waitlisted</button><button>Cancelled</button></div>
+            <div class="rcard"><span class="av">AB</span><div class="ri"><div class="rn">Anna Brunner</div><div class="rc">Mobiliar · 02 Aug</div></div><span class="tag g">Confirmed</span><button class="more" style="font-size:16px">⋯</button></div>
+            <div class="rcard"><span class="av">FW</span><div class="ri"><div class="rn">Felix Wyss</div><div class="rc">SIX · 05 Aug</div></div><span class="tag b">Reg.</span><button class="more" style="font-size:16px">⋯</button></div>
+            <div class="rcard"><span class="av">UG</span><div class="ri"><div class="rn">Urs Gerber</div><div class="rc">Die Post · 14 Aug</div></div><span class="tag g">Confirmed</span><button class="more" style="font-size:16px">⋯</button></div>
+            <div style="text-align:center;font-size:12px;color:var(--ink-soft);padding:10px 0">Showing 1–25 of 140</div>
+          </div>
+          <div class="card">
+            <div style="display:flex;gap:8px;margin-bottom:8px"><button class="btn sm" style="flex:1">⬇ Badges XLSX</button><button class="btn sm" style="flex:1">⬇ Badges DOCX</button></div>
+            <button class="btn sm" style="width:100%">👥 Enroll organizers &amp; partners</button>
+          </div>
+        </div>
+
+        <!-- COMMUNICATIONS -->
+        <div class="scr" id="s-comms">
+          <div class="card">
+            <p class="ctitle" style="margin-bottom:9px">Who are you emailing?</p>
+            <div class="seg2" id="audM">
+              <button class="on" data-a="subs">📰 Subscribers</button>
+              <button data-a="regs">🎟️ Registrants</button>
+              <button data-a="spk">🎤 Speakers</button>
+              <button data-a="venue">🏛️ Venue/Caterer</button>
+            </div>
+            <div class="anote" id="anoteM">Global newsletter list (~2,400). Newsletter + Reminder, with history &amp; retry.</div>
+            <div class="field"><label>Template</label><select id="tmplM"><option>Speaker line-up announcement</option><option>Final agenda</option></select></div>
+            <div class="field"><label>Preview language</label><select><option>Deutsch</option><option>English</option></select></div>
+            <div class="preview">📧 Email preview</div>
+            <button class="btn primary" id="sendM">✉️ Send Newsletter…</button>
+          </div>
+        </div>
+
+        <!-- PUBLISHING -->
+        <div class="scr" id="s-publishing">
+          <div class="card"><p class="ctitle" style="margin-bottom:9px">Validation</p>
+            <div style="font-size:13px;line-height:2"><div>✅ Topic defined</div><div>✅ Speakers confirmed (6)</div><div>⚠️ 2 sessions need a slot</div><div>⚠️ 3 materials in review</div></div></div>
+          <div class="card"><p class="ctitle" style="margin-bottom:9px">Phases</p>
+            <div class="slot filled"><div class="tm">Topic</div><div class="ss">Live ✓</div></div>
+            <div class="slot filled" style="margin-top:8px"><div class="tm">Speakers</div><div class="ss">Live ✓</div></div>
+            <div class="slot" style="margin-top:8px"><div class="tm">Agenda</div><div class="ss empty">Blocked</div></div>
+            <button class="btn primary" style="margin-top:12px">📢 Publish agenda</button></div>
+        </div>
+
+        <!-- WRAP-UP -->
+        <div class="scr" id="s-wrapup">
+          <div class="card" style="background:var(--warn-soft);border-color:var(--warn-line);font-size:12.5px">🔒 <b>Locked until EVENT_LIVE.</b> Previewing layout.</div>
+          <div class="card"><p class="ctitle" style="margin-bottom:9px">📸 Photos</p>
+            <div class="tiles2"><div class="preview" style="height:70px;margin:0">🖼️</div><div class="preview" style="height:70px;margin:0">＋</div></div>
+            <button class="btn" style="margin-top:10px">⬆ Upload photos</button></div>
+          <div class="card"><p class="ctitle" style="margin-bottom:9px">💌 Thank-you notes (2)</p>
+            <div class="note"><p class="nq">“Best BATbern in years!”</p><div class="nf"><span>Anna B. · Mobiliar</span><span class="tag g">♥ Featured</span></div></div>
+            <div class="note"><p class="nq">“Loved the venue. Thank you!”</p><div class="nf"><span>Anonymous</span><span class="switch" style="opacity:.4"></span></div></div></div>
+        </div>
+
+        <!-- DETAILS -->
+        <div class="scr" id="s-details">
+          <div class="card" style="overflow:hidden;padding:0">
+            <div style="height:90px;background:linear-gradient(120deg,#0a4d8c,#1f8a5b);display:flex;align-items:center;justify-content:center;color:rgba(255,255,255,.8);font-size:12px">🖼️ Theme image</div>
+            <div style="padding:12px 13px"><div style="display:flex;gap:8px"><button class="btn sm" style="flex:1">⬆ Replace</button><button class="btn sm" style="flex:1">✨ AI</button></div></div>
+          </div>
+          <div class="card"><p class="ctitle" style="margin-bottom:9px">📝 Event details</p>
+            <div class="field"><label>Title</label><input value="Cloud Native Architecture"></div>
+            <div class="field" style="margin:0"><label>Description</label><textarea rows="4">A deep-dive into platform engineering, GitOps &amp; cloud-native ops in Swiss enterprises…</textarea></div></div>
+          <div class="card"><p class="ctitle" style="margin-bottom:9px">🏷️ Topic</p><div style="display:flex;align-items:center;gap:9px"><span class="tag b">Cloud Native Architecture</span><button class="btn sm" style="margin-left:auto">Change</button></div></div>
+          <div class="card"><p class="ctitle" style="margin-bottom:9px">📅 When &amp; where</p>
+            <div class="field"><label>Date &amp; time</label><input value="2026-09-18 · 17:30"></div>
+            <div class="field"><label>Venue</label><input value="Welle 7, Bern"></div>
+            <div class="field" style="margin:0"><label>Registration deadline</label><input value="2026-09-15"></div></div>
+        </div>
+
+        <!-- SETTINGS -->
+        <div class="scr" id="s-settings">
+          <div class="card"><p class="ctitle" style="margin-bottom:9px">👤 Moderator</p><div class="field" style="margin:0"><select><option>Nissim Buchs</option></select></div></div>
+          <div class="card"><p class="ctitle" style="margin-bottom:9px">👥 Registration capacity</p><div class="field" style="margin:0 0 9px"><input value="180"></div><button class="btn sm">Save</button></div>
+          <div class="card"><p class="ctitle" style="margin-bottom:9px">💬 Session Q&amp;A</p><div style="display:flex;align-items:center;gap:9px"><span class="switch on"></span><span class="csub">Enabled · opens after event · 14d</span></div></div>
+          <div class="card" style="border-color:var(--danger);background:var(--danger-soft)"><p class="ctitle" style="color:var(--danger);margin-bottom:9px">⚠️ Danger zone</p>
+            <button class="btn warn" style="margin-bottom:8px">Cancel event</button><button class="btn danger">Delete event</button></div>
+        </div>
+
+      </div>
+
+      <!-- bottom nav -->
+      <div class="bnav" id="bnav">
+        <button class="on" data-nav="cockpit"><span class="bi">🧭</span>Cockpit</button>
+        <button data-nav="speakers"><span class="bi">🎤</span>Speakers<span class="bdg">2</span></button>
+        <button data-nav="registrations"><span class="bi">🎟️</span>Regs</button>
+        <button data-nav="comms"><span class="bi">✉️</span>Comms<span class="rdot"></span></button>
+        <button id="navMore"><span class="bi">⋯</span>More</button>
+      </div>
+
+      <!-- more sheet -->
+      <div class="sheet-ov" id="sheetOv"></div>
+      <div class="sheet" id="sheet">
+        <div class="grab"></div>
+        <h4>More</h4>
+        <div class="item" data-nav="publishing"><span class="si">📢</span> Publishing</div>
+        <div class="item" data-nav="wrapup"><span class="si">🎁</span> Wrap-up <span class="lock">🔒 unlocks at event</span></div>
+        <div class="item" data-nav="details"><span class="si">📝</span> Details</div>
+        <div class="item" data-nav="settings"><span class="si">⚙️</span> Settings</div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script>
+  const screens=['cockpit','speakers','registrations','comms','publishing','wrapup','details','settings'];
+  const primaryNav=['cockpit','speakers','registrations','comms'];
+  function show(id){
+    screens.forEach(s=>document.getElementById('s-'+s).classList.toggle('show',s===id));
+    document.querySelectorAll('#bnav button[data-nav]').forEach(b=>b.classList.toggle('on',b.dataset.nav===id));
+    // if a "More" screen, mark More active
+    document.getElementById('navMore').classList.toggle('on',!primaryNav.includes(id));
+    document.getElementById('body').scrollTop=0;
+    closeSheet();
+  }
+  document.getElementById('bnav').addEventListener('click',e=>{const b=e.target.closest('button[data-nav]');if(!b)return;show(b.dataset.nav);});
+  document.querySelectorAll('[data-go]').forEach(b=>b.addEventListener('click',()=>show(b.dataset.go)));
+
+  // more sheet
+  const ov=document.getElementById('sheetOv'),sheet=document.getElementById('sheet');
+  function openSheet(){ov.classList.add('show');sheet.classList.add('show');}
+  function closeSheet(){ov.classList.remove('show');sheet.classList.remove('show');}
+  document.getElementById('navMore').addEventListener('click',openSheet);
+  document.getElementById('moreBtn').addEventListener('click',openSheet);
+  ov.addEventListener('click',closeSheet);
+  document.querySelectorAll('.sheet .item').forEach(i=>i.addEventListener('click',()=>show(i.dataset.nav)));
+
+  // speakers sub-seg
+  document.getElementById('spkSeg').addEventListener('click',e=>{const b=e.target.closest('button');if(!b)return;
+    document.querySelectorAll('#spkSeg button').forEach(x=>x.classList.remove('on'));b.classList.add('on');
+    ['pool','agenda','slots'].forEach(s=>document.getElementById('sp-'+s).style.display=(b.dataset.sp===s)?'block':'none');});
+
+  // tap-to-assign
+  let selected=null;
+  document.querySelectorAll('#sp-slots .schip').forEach(c=>c.addEventListener('click',()=>{
+    document.querySelectorAll('#sp-slots .schip').forEach(x=>x.classList.remove('sel'));
+    c.classList.add('sel');selected=c;
+    document.getElementById('hint').classList.add('show');
+    document.querySelectorAll('#sp-slots .slot.target').forEach(s=>s.classList.add('armed'));
+  }));
+  document.querySelectorAll('#sp-slots .slot.target').forEach(s=>s.addEventListener('click',()=>{
+    if(!selected)return;
+    const name=selected.dataset.s;
+    s.classList.remove('empty','armed','target');s.classList.add('filled');
+    s.querySelector('.ss').textContent=name;s.querySelector('.ss').style.fontStyle='normal';
+    selected.remove();selected=null;
+    document.getElementById('hint').classList.remove('show');
+    document.querySelectorAll('#sp-slots .slot.target').forEach(x=>x.classList.remove('armed'));
+    const left=document.querySelectorAll('#sp-slots .schip').length;
+    if(left===0){document.querySelector('.tray .th').textContent='✓ All sessions placed';}
+  }));
+
+  // comms audience (mobile)
+  document.getElementById('audM').addEventListener('click',e=>{const b=e.target.closest('button');if(!b)return;
+    document.querySelectorAll('#audM button').forEach(x=>x.classList.remove('on'));b.classList.add('on');
+    const a=b.dataset.a,note=document.getElementById('anoteM'),tmpl=document.getElementById('tmplM'),send=document.getElementById('sendM');
+    if(a==='subs'){note.textContent='Global newsletter list (~2,400). Newsletter + Reminder, history & retry.';tmpl.innerHTML='<option>Speaker line-up announcement</option><option>Final agenda</option>';send.textContent='✉️ Send Newsletter…';}
+    if(a==='regs'){note.textContent='128 active registrants — each in their own language. Single send.';tmpl.innerHTML='<option>Slides are online</option><option>Room change</option>';send.textContent='✉️ Send to registrants…';}
+    if(a==='spk'){note.textContent='6 confirmed speakers. Individual invites stay on each speaker card.';tmpl.innerHTML='<option>Content-deadline reminder</option><option>Logistics & arrival info</option><option>Thank-you to speakers</option>';send.textContent='✉️ Send to speakers…';}
+    if(a==='venue'){note.textContent='Venue + caterer contacts (Welle 7 · Gastro AG). Reply-To: coordinator. Moved here from Settings.';tmpl.innerHTML='<option>Booking confirmation</option><option>Catering headcount</option><option>Setup & logistics</option>';send.textContent='✉️ Send to venue/caterer…';}
+  });
+
+  // mobile cockpit tiles → deep-link
+  document.querySelectorAll('[data-mtile]').forEach(t=>t.addEventListener('click',()=>{
+    const d=t.dataset.mtile;
+    if(d==='registrations'){show('registrations');}
+    else{show('speakers');document.querySelector('#spkSeg button[data-sp="'+d+'"]').click();}
+  }));
+</script>
+</body>
+</html>

--- a/docs/ux/event-detail-redesign-prototype.html
+++ b/docs/ux/event-detail-redesign-prototype.html
@@ -1,0 +1,869 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>BATbern · Event Page Redesign (Desktop)</title>
+<style>
+  :root{
+    --bg:#f4f6fa; --surface:#ffffff; --ink:#1a2330; --ink-soft:#5b6675;
+    --line:#e3e8f0; --line-soft:#eef1f6;
+    --primary:#0a4d8c; --primary-soft:#e7f0fb; --primary-ink:#0a4d8c;
+    --accent:#1f8a5b; --accent-soft:#e4f4ec;
+    --warn:#b9770a; --warn-soft:#fdf3e0; --warn-line:#f0d9ac;
+    --danger:#c0392b; --danger-soft:#fbeae8; --danger-line:#f1c9c3;
+    --muted:#9aa6b6;
+    --radius:12px; --shadow:0 1px 2px rgba(16,30,54,.06),0 4px 16px rgba(16,30,54,.05);
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0}
+  body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    background:var(--bg);color:var(--ink);line-height:1.45;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1200px;margin:0 auto;padding:20px 24px 80px}
+  a{color:var(--primary);text-decoration:none}
+  .proto{background:#0e1b2e;color:#cdd8e6;font-size:12.5px;padding:8px 24px;display:flex;
+    gap:14px;align-items:center;justify-content:center;flex-wrap:wrap}
+  .proto b{color:#fff}.proto .pill{background:#1b2c44;border-radius:999px;padding:2px 10px;color:#9fc1ec}
+  .proto a{color:#7fb2ee}
+
+  .crumb{font-size:13px;color:var(--ink-soft);margin:6px 0 14px}
+  .crumb a{color:var(--ink-soft)}
+  .head{display:flex;justify-content:space-between;align-items:flex-start;gap:18px;flex-wrap:wrap}
+  .head h1{font-size:25px;margin:0 0 6px;letter-spacing:-.2px}
+  .head .meta{display:flex;gap:14px;align-items:center;flex-wrap:wrap;color:var(--ink-soft);font-size:13.5px}
+  .state-chip{display:inline-flex;align-items:center;gap:6px;background:var(--primary-soft);
+    color:var(--primary-ink);font-weight:600;font-size:12.5px;padding:4px 11px;border-radius:999px}
+  .state-chip .dot{width:7px;height:7px;border-radius:50%;background:var(--primary)}
+  .head .actions{display:flex;gap:9px}
+  .btn{display:inline-flex;align-items:center;gap:7px;font:inherit;font-size:13.5px;font-weight:600;
+    border-radius:9px;padding:8px 14px;border:1px solid var(--line);background:var(--surface);
+    color:var(--ink);cursor:pointer;transition:.12s}
+  .btn:hover{border-color:#c7d2e2;background:#fafcff}
+  .btn.primary{background:var(--primary);border-color:var(--primary);color:#fff}
+  .btn.primary:hover{background:#0c5aa3}
+  .btn.danger{color:var(--danger);border-color:var(--danger-line)}
+  .btn.danger:hover{background:var(--danger-soft)}
+  .btn.warn{color:var(--warn);border-color:var(--warn-line)}
+  .btn.sm{padding:5px 11px;font-size:12.5px}
+
+  .rail{display:flex;gap:2px;border-bottom:1px solid var(--line);margin:20px 0 24px;overflow-x:auto}
+  .tab{position:relative;display:inline-flex;align-items:center;gap:8px;padding:12px 15px;
+    font-size:14px;font-weight:600;color:var(--ink-soft);cursor:pointer;white-space:nowrap;
+    border-bottom:2.5px solid transparent;background:none;border-top:none;border-left:none;border-right:none;font-family:inherit}
+  .tab .ico{font-size:16px;opacity:.85}
+  .tab:hover{color:var(--ink)}
+  .tab.active{color:var(--primary);border-bottom-color:var(--primary)}
+  .tab.dim{opacity:.42;cursor:not-allowed}
+  .tab .count{font-size:12px;font-weight:700;color:var(--muted)}
+  .tab.active .count{color:var(--primary)}
+  .tab .badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;
+    padding:0 5px;border-radius:999px;font-size:11px;font-weight:700;background:var(--warn);color:#fff}
+  .tab .dotmark{position:absolute;top:9px;right:7px;width:7px;height:7px;border-radius:50%;background:var(--danger)}
+
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow)}
+  .card.pad{padding:18px 20px}
+  .card-title{font-size:15px;font-weight:700;margin:0 0 2px}
+  .card-sub{font-size:13px;color:var(--ink-soft);margin:0}
+  .sec-label{font-size:12px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);margin:0 0 12px}
+  .grid{display:grid;gap:16px}
+  .panel{display:none}.panel.show{display:block;animation:fade .18s ease}
+  @keyframes fade{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+
+  .stepper{display:flex;align-items:center;overflow-x:auto;padding:4px 2px}
+  .step{display:flex;align-items:center;flex:0 0 auto}
+  .step .node{display:flex;flex-direction:column;align-items:center;gap:6px;min-width:92px;text-align:center}
+  .step .bub{width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-size:12px;font-weight:700;background:#fff;border:2px solid var(--line);color:var(--muted)}
+  .step.done .bub{background:var(--accent);border-color:var(--accent);color:#fff}
+  .step.current .bub{background:var(--primary);border-color:var(--primary);color:#fff;box-shadow:0 0 0 4px var(--primary-soft)}
+  .step .lbl{font-size:11px;color:var(--ink-soft);max-width:88px}
+  .step.current .lbl{color:var(--primary);font-weight:700}
+  .step .bar{width:34px;height:2.5px;background:var(--line);margin-bottom:20px}
+  .step.done .bar{background:var(--accent)}
+
+  .attn{display:grid;grid-template-columns:repeat(auto-fill,minmax(290px,1fr));gap:14px}
+  .task{display:flex;gap:12px;padding:14px 15px;border-radius:11px;border:1px solid var(--line);background:var(--surface);align-items:flex-start}
+  .task .strip{width:4px;align-self:stretch;border-radius:4px;background:var(--muted)}
+  .task.over .strip{background:var(--danger)}.task.soon .strip{background:var(--warn)}.task.ok .strip{background:var(--accent)}
+  .task .body{flex:1;min-width:0}
+  .task .tname{font-weight:700;font-size:14px;margin:0 0 3px}
+  .task .tmeta{font-size:12.5px;color:var(--ink-soft);display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+  .due{font-weight:700;font-size:12px;padding:2px 8px;border-radius:999px}
+  .due.over{background:var(--danger-soft);color:var(--danger)}.due.soon{background:var(--warn-soft);color:var(--warn)}.due.ok{background:var(--accent-soft);color:var(--accent)}
+  .who{display:inline-flex;align-items:center;gap:5px}
+  .who .av{width:18px;height:18px;border-radius:50%;background:var(--primary-soft);color:var(--primary);font-size:10px;font-weight:700;display:flex;align-items:center;justify-content:center}
+  .task .go{margin-top:9px}
+
+  .tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:14px}
+  .tile{padding:16px 17px}
+  .tile .tl{font-size:12.5px;color:var(--ink-soft);display:flex;gap:7px;align-items:center;margin-bottom:8px}
+  .tile .num{font-size:23px;font-weight:800;letter-spacing:-.5px}
+  .tile .num small{font-size:14px;font-weight:600;color:var(--muted)}
+  .prog{height:7px;border-radius:6px;background:var(--line-soft);margin-top:9px;overflow:hidden}
+  .prog>i{display:block;height:100%;border-radius:6px;background:var(--primary)}
+  .prog>i.g{background:var(--accent)}.prog>i.w{background:var(--warn)}.prog>i.r{background:var(--danger)}
+  .tile .cap{font-size:11.5px;color:var(--muted);margin-top:6px}
+
+  .subtoggle{display:inline-flex;border:1px solid var(--line);border-radius:9px;overflow:hidden;background:var(--surface)}
+  .subtoggle button{font:inherit;font-size:13px;font-weight:600;padding:7px 15px;border:none;background:none;color:var(--ink-soft);cursor:pointer;display:inline-flex;gap:7px;align-items:center;border-right:1px solid var(--line)}
+  .subtoggle button:last-child{border-right:none}
+  .subtoggle button.on{background:var(--primary);color:#fff}
+  table{width:100%;border-collapse:collapse;font-size:13.5px}
+  th{text-align:left;font-size:11.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);padding:9px 12px;border-bottom:1px solid var(--line)}
+  td{padding:10px 12px;border-bottom:1px solid var(--line-soft)}
+  tr:last-child td{border-bottom:none}
+  .tag{font-size:11.5px;font-weight:700;padding:2px 9px;border-radius:999px}
+  .tag.g{background:var(--accent-soft);color:var(--accent)}.tag.w{background:var(--warn-soft);color:var(--warn)}
+  .tag.n{background:var(--line-soft);color:var(--ink-soft)}.tag.b{background:var(--primary-soft);color:var(--primary)}
+  .tag.r{background:var(--danger-soft);color:var(--danger)}
+  .avatar{width:24px;height:24px;border-radius:50%;background:var(--primary-soft);color:var(--primary);font-size:10px;font-weight:700;display:inline-flex;align-items:center;justify-content:center;margin-right:8px;vertical-align:middle}
+  .iconbtn{border:none;background:none;cursor:pointer;font-size:15px;padding:3px 5px;border-radius:6px;color:var(--ink-soft)}
+  .iconbtn:hover{background:var(--line-soft)}
+
+  .kan{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+  .lane{background:var(--bg);border:1px solid var(--line);border-radius:10px;padding:10px;min-height:160px}
+  .lane h4{margin:0 0 9px;font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--ink-soft);display:flex;justify-content:space-between}
+  .scard{background:#fff;border:1px solid var(--line);border-radius:8px;padding:9px 10px;margin-bottom:8px;font-size:13px;box-shadow:0 1px 1px rgba(16,30,54,.04)}
+  .scard .nm{font-weight:600}.scard .co{font-size:12px;color:var(--ink-soft)}
+  .scard .st{font-size:9px;font-weight:800;letter-spacing:.05em;text-transform:uppercase;color:var(--muted);display:block;margin-bottom:3px}
+  .scard.act{border-left:3px solid var(--primary);padding-left:8px}
+  .scard.act .act-link{color:var(--primary);font-weight:700}
+  .scard.wait{opacity:.74}
+  .lane h4 .sub2{font-weight:500;color:var(--muted)}
+  .waithdr{font-size:9.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);margin:2px 0 7px;display:flex;align-items:center;gap:6px}
+  .waithdr::before,.waithdr::after{content:"";flex:1;height:1px;background:var(--line)}
+  .declined{margin-top:14px;border:1px solid var(--line);border-radius:10px;background:var(--bg)}
+  .declined summary{cursor:pointer;padding:10px 14px;font-size:12.5px;font-weight:700;color:var(--ink-soft);list-style:none}
+  .declined summary::-webkit-details-marker{display:none}
+  .declined .dbody{padding:2px 14px 13px;display:flex;gap:10px;flex-wrap:wrap}
+  .declined .scard{margin:0;min-width:170px;opacity:.68}
+  .dragnote{font-size:12px;color:var(--ink-soft);background:var(--bg);border:1px dashed var(--line);border-radius:9px;padding:8px 12px;margin-bottom:13px}
+
+  /* slots 2-col */
+  .slotbar{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:12px 14px;background:var(--bg);border:1px solid var(--line);border-radius:11px;margin-bottom:14px}
+  .slotbar .sum{font-size:13px;color:var(--ink-soft)}
+  .slotbar .sum b{color:var(--ink)}
+  .slots2{display:grid;grid-template-columns:300px 1fr;gap:16px;align-items:start}
+  .tray h5,.tl5{margin:0 0 10px;font-size:11.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
+  .chipdrag{background:#fff;border:1px solid var(--line);border-radius:9px;padding:9px 11px;margin-bottom:9px;font-size:13px;cursor:grab;box-shadow:0 1px 1px rgba(16,30,54,.05)}
+  .chipdrag .nm{font-weight:600}.chipdrag .co{font-size:12px;color:var(--ink-soft)}
+  .timeline{display:flex;flex-direction:column;gap:8px}
+  .slot{border:1.5px dashed var(--line);border-radius:9px;padding:10px 12px;display:flex;gap:12px;align-items:center;min-height:50px}
+  .slot .time{font-size:12px;font-weight:700;color:var(--ink-soft);width:96px}
+  .slot.filled{border-style:solid;border-color:var(--primary-soft);background:var(--primary-soft)}
+  .slot.struct{border-style:solid;border-color:var(--line);background:var(--line-soft)}
+  .slot .ses{font-weight:600;font-size:13.5px}.slot .ses small{font-weight:500;color:var(--ink-soft)}
+  .slot.empty .ses{color:var(--muted);font-style:italic;font-weight:500}
+  .match{margin-left:auto;font-size:11.5px;color:var(--accent);font-weight:700}
+
+  .seg{display:inline-flex;background:var(--bg);border:1px solid var(--line);border-radius:10px;padding:3px;flex-wrap:wrap}
+  .seg button{font:inherit;font-size:13px;font-weight:600;border:none;background:none;color:var(--ink-soft);padding:7px 14px;border-radius:7px;cursor:pointer;display:inline-flex;gap:6px;align-items:center}
+  .seg button.on{background:#fff;color:var(--primary);box-shadow:var(--shadow)}
+  .audience-note{font-size:13px;padding:10px 13px;border-radius:9px;margin-top:14px}
+  .audience-note.subs{background:var(--primary-soft);color:var(--primary-ink)}
+  .audience-note.regs{background:var(--accent-soft);color:#15694a}
+  .audience-note.spk{background:#f3edfb;color:#5a3a8c}
+  .preview-frame{border:1px solid var(--line);border-radius:11px;height:280px;background:linear-gradient(#fff,#f8fafd);display:flex;align-items:center;justify-content:center;color:var(--muted);font-size:13px;text-align:center}
+  .switch{width:38px;height:22px;border-radius:999px;background:var(--line);position:relative;display:inline-block;cursor:pointer;flex:0 0 auto}
+  .switch.on{background:var(--accent)}
+  .switch::after{content:"";position:absolute;top:2px;left:2px;width:18px;height:18px;border-radius:50%;background:#fff;transition:.15s}
+  .switch.on::after{left:18px}
+
+  .checkitem{display:flex;align-items:center;gap:10px;padding:9px 0;border-bottom:1px solid var(--line-soft);font-size:14px}
+  .checkitem:last-child{border:none}
+  .ckbox{width:20px;height:20px;border-radius:6px;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:800;flex:0 0 auto}
+  .ckbox.g{background:var(--accent);color:#fff}.ckbox.w{background:var(--warn);color:#fff}.ckbox.n{background:var(--line);color:var(--muted)}
+
+  .photos{display:grid;grid-template-columns:repeat(auto-fill,minmax(130px,1fr));gap:10px}
+  .photo{aspect-ratio:4/3;border-radius:10px;background:linear-gradient(135deg,#dce6f3,#eef2f8);display:flex;align-items:center;justify-content:center;color:#a9b8cc;font-size:24px;border:1px solid var(--line);position:relative}
+  .note{padding:13px 15px;border:1px solid var(--line);border-radius:11px;margin-bottom:11px;display:flex;gap:12px;align-items:flex-start}
+  .note .nb{flex:1}.note .nq{font-size:14px;margin:0 0 7px;font-style:italic}
+  .note .nf{font-size:12.5px;color:var(--ink-soft);display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+
+  .field{margin-bottom:14px}
+  .field label{display:block;font-size:12.5px;font-weight:600;color:var(--ink-soft);margin-bottom:5px}
+  .field input,.field textarea,.field select{width:100%;font:inherit;font-size:14px;padding:9px 11px;border:1px solid var(--line);border-radius:9px;background:#fff;color:var(--ink)}
+  .settings-sec{padding:16px 18px;margin-bottom:14px}
+  .settings-sec h3{font-size:14.5px;margin:0 0 4px;display:flex;gap:8px;align-items:center}
+  .settings-sec p.h{font-size:12.5px;color:var(--ink-soft);margin:0 0 12px}
+  .danger-zone{border-color:var(--danger-line)!important;background:var(--danger-soft)}
+  .dz-row{display:flex;align-items:center;gap:12px;padding:11px 13px;border-radius:9px;background:rgba(255,255,255,.6);margin-bottom:9px}
+  .dz-row .sp{flex:1}.dz-row .t{font-weight:700;font-size:13.5px}.dz-row .d{font-size:12.5px;color:var(--ink-soft)}
+
+  .row{display:flex;gap:8px;align-items:center}.sp{flex:1}.hint{font-size:12.5px;color:var(--ink-soft)}
+  .footrow{display:flex;justify-content:space-between;align-items:center;padding:11px 4px 2px;font-size:12.5px;color:var(--ink-soft)}
+  /* clickable metric tiles */
+  .tile.clk{cursor:pointer;transition:.12s;position:relative}
+  .tile.clk:hover{border-color:#c7d2e2;box-shadow:0 5px 20px rgba(16,30,54,.1);transform:translateY(-1px)}
+  .tile.clk .arrow{position:absolute;top:13px;right:14px;color:var(--muted);font-size:14px}
+  .tile.clk:hover .arrow{color:var(--primary)}
+  /* event-day card */
+  .eventday{display:flex;align-items:center;gap:14px;padding:12px 16px;border-radius:12px;border:1px dashed var(--line);background:var(--bg);box-shadow:var(--shadow)}
+  .eventday .ed-ico{font-size:20px;opacity:.55}
+  .eventday .ed-txt{flex:1;font-size:13px;color:var(--ink-soft)}.eventday .ed-txt b{color:var(--ink)}
+  .ed-pre-actions .btn{opacity:.55}
+  .eventday.live{border:none;background:linear-gradient(100deg,#c0392b,#e0533f);box-shadow:0 8px 30px rgba(192,57,43,.28)}
+  .eventday.live .ed-ico{opacity:1}
+  .eventday.live .ed-txt,.eventday.live .ed-txt b{color:#fff}
+  .eventday.live .ed-pre-actions .btn{opacity:1;background:#fff;border-color:#fff;color:#c0392b}
+  .eventday.live .ed-pre-actions .btn.l2{background:rgba(255,255,255,.16);color:#fff;border-color:rgba(255,255,255,.55)}
+  .eventday.live #edToggle{background:rgba(255,255,255,.16);color:#fff;border-color:rgba(255,255,255,.55)}
+  /* topic overlay */
+  .tov{position:fixed;inset:0;background:rgba(14,27,46,.55);display:none;z-index:50;backdrop-filter:blur(2px)}
+  .tov.show{display:block}
+  .tfocus{position:fixed;inset:16px;background:var(--surface);border-radius:16px;box-shadow:0 8px 44px rgba(16,30,54,.28);z-index:51;display:none;flex-direction:column;overflow:hidden}
+  .tfocus.show{display:flex}
+  .tbar{display:flex;align-items:center;justify-content:space-between;padding:13px 18px;border-bottom:1px solid var(--line)}
+  .tbar .ttl{font-weight:700;font-size:15px}
+  .tbody{flex:1;overflow:auto;padding:18px 20px}
+  .topbar{display:flex;gap:10px;align-items:center;flex-wrap:wrap;padding:12px 14px;background:var(--bg);border:1px solid var(--line);border-radius:11px;margin-bottom:16px}
+  .topbar input,.topbar select{font:inherit;font-size:13px;padding:8px 10px;border:1px solid var(--line);border-radius:8px;background:#fff}
+  .topicgrid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
+  .tcard{border:1px solid var(--line);border-left-width:4px;border-radius:11px;padding:13px 14px;background:#fff;box-shadow:var(--shadow)}
+  .tcard.green{border-left-color:var(--accent)}.tcard.yellow{border-left-color:var(--warn)}.tcard.red{border-left-color:var(--danger)}
+  .tcard .tt{font-weight:700;font-size:14px;margin:0 0 6px}
+  .tcard .tmeta{font-size:12px;color:var(--ink-soft);margin-bottom:9px;display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+  .tcard .tsim{font-size:11.5px;color:var(--warn);background:var(--warn-soft);border-radius:7px;padding:5px 9px;margin-bottom:10px}
+  .tcard .tact{display:flex;gap:7px;align-items:center}
+  .selected-topic{display:flex;align-items:center;gap:12px;padding:14px 16px;border-radius:12px;background:var(--accent-soft);border:1px solid #bfe3cf;margin-bottom:18px}
+  .selected-topic .big{font-size:16px;font-weight:700}
+  .brain2{display:grid;grid-template-columns:360px 1fr;gap:18px;align-items:start}
+  .brain-foot{display:flex;justify-content:flex-end;gap:10px;margin-top:18px;padding-top:14px;border-top:1px solid var(--line)}
+  .poolrow{display:flex;align-items:center;gap:10px;padding:10px 0;border-bottom:1px solid var(--line-soft)}.poolrow:last-child{border:none}
+  /* interactive lifecycle map */
+  .step{cursor:pointer}
+  .step .node:hover .bub{box-shadow:0 0 0 3px var(--primary-soft)}
+  .tab.dim{opacity:.5;cursor:pointer}
+  .tab.lock{opacity:.36;cursor:not-allowed}
+  .stepname{font-size:13px;color:var(--ink-soft);margin-top:10px}
+  .maphint{font-size:12px;color:var(--primary);font-weight:600;margin:0 0 12px}
+  @media(max-width:880px){.slots2{grid-template-columns:1fr}.kan{grid-template-columns:1fr 1fr}.topicgrid{grid-template-columns:1fr}.brain2{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="proto">
+  <b>PROTOTYPE · DESKTOP</b>
+  <span class="pill">state = SLOT_ASSIGNMENT · step 4/9</span>
+  <span>Speakers&amp;Agenda now has 3 sub-views (Pool · Agenda · Slots). Communications has 3 audiences.</span>
+  <a href="event-detail-redesign-mobile.html">→ open mobile prototype</a>
+</div>
+
+<div class="wrap">
+  <div class="crumb"><a href="#">Events</a> &nbsp;›&nbsp; <span>BATbern 76 — Cloud Native Architecture</span></div>
+
+  <div class="head">
+    <div>
+      <h1>BATbern 76 — Cloud Native Architecture</h1>
+      <div class="meta">
+        <span class="state-chip"><span class="dot"></span> Slot Assignment · Step 4 of 9</span>
+        <span>📅 Thu, 18 Sep 2026 · 17:30</span>
+        <span>📍 Welle 7, Bern</span>
+        <span>⏳ in 34 days</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="rail" id="rail">
+    <button class="tab active" data-tab="cockpit"><span class="ico">🧭</span> Cockpit</button>
+    <button class="tab" data-tab="speakers"><span class="ico">🎤</span> Speakers &amp; Agenda <span class="badge" id="badgeSpeakers">2</span></button>
+    <button class="tab" data-tab="registrations"><span class="ico">🎟️</span> Registrations <span class="count">140</span></button>
+    <button class="tab" data-tab="comms"><span class="ico">✉️</span> Communications <span class="dotmark" id="dotComms"></span></button>
+    <button class="tab" data-tab="publishing"><span class="ico">📢</span> Publishing</button>
+    <button class="tab" data-tab="wrapup" title="Unlocks after the event goes live"><span class="ico">🎁</span> Wrap-up <span class="lk" id="wrapLk" style="display:none">🔒</span></button>
+    <button class="tab" data-tab="details"><span class="ico">📝</span> Details</button>
+    <button class="tab" data-tab="settings"><span class="ico">⚙️</span> Settings</button>
+  </div>
+
+  <!-- COCKPIT -->
+  <section class="panel show" id="p-cockpit">
+    <div class="grid" style="grid-template-columns:1fr">
+
+      <div class="card pad">
+        <p class="sec-label">Where this event is</p>
+        <p class="maphint">▶ Tap any step to preview that state — the tasks below and the tab rail above update to match the lifecycle map.</p>
+        <div class="stepper" id="stepper"></div>
+        <div class="stepname" id="cockpitNow"></div>
+      </div>
+
+      <div class="card pad">
+        <div class="row" style="margin-bottom:14px">
+          <div><p class="card-title">Needs your attention</p>
+            <p class="card-sub">From the event task list — overdue first, then due soon. (GET /events/&#123;code&#125;/tasks)</p></div>
+          <div class="sp"></div>
+          <button class="btn sm">＋ Add task</button>
+        </div>
+        <div class="attn" id="attnList"></div>
+      </div>
+
+      <div>
+        <p class="sec-label">At a glance</p>
+        <div class="tiles">
+          <div class="card tile clk" data-tile="registrations"><span class="arrow">→</span><div class="tl">🎟️ Registrations</div><div class="num">128 <small>/ 180</small></div><div class="prog"><i style="width:71%"></i></div><div class="cap">71% filled · 12 on waitlist</div></div>
+          <div class="card tile clk" data-tile="pool"><span class="arrow">→</span><div class="tl">🎤 Speakers</div><div class="num">6 <small>/ 6</small></div><div class="prog"><i class="g" style="width:100%"></i></div><div class="cap">All slots confirmed ✓</div></div>
+          <div class="card tile clk" data-tile="agenda"><span class="arrow">→</span><div class="tl">📋 Materials</div><div class="num">3 <small>/ 6</small></div><div class="prog"><i class="w" style="width:50%"></i></div><div class="cap">50% sessions complete</div></div>
+          <div class="card tile clk" data-tile="slots"><span class="arrow">→</span><div class="tl">🗓️ Agenda</div><div class="num">4 <small>/ 6</small></div><div class="prog"><i class="w" style="width:66%"></i></div><div class="cap">2 sessions need a slot</div></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SPEAKERS & AGENDA -->
+  <section class="panel" id="p-speakers">
+    <div class="card pad" style="margin-bottom:16px">
+      <div class="row">
+        <div class="subtoggle" id="sub">
+          <button class="on" data-sub="pool">🗂️ Pool (Kanban)</button>
+          <button data-sub="agenda">🗓️ Agenda (Sessions)</button>
+          <button data-sub="slots">🧩 Slots</button>
+        </div>
+        <div class="sp"></div>
+        <button class="btn sm">＋ Add speakers</button>
+      </div>
+    </div>
+
+    <div id="sub-pool" class="card pad">
+      <div class="dragnote">🃏 <b>4 phase columns</b>, not 8 state columns. Each card keeps its exact state as a chip + its primary action. Within a column, <b>“your move”</b> cards (accent border) sit above <b>“waiting on speaker”</b> cards. Dragging a card forward runs its primary action (opening any confirm) — one step, never a silent email.</div>
+      <div class="kan">
+
+        <div class="lane"><h4>Sourcing <span class="sub2">3</span></h4>
+          <div class="scard act"><span class="st">Identified</span><div class="nm">Lena Vogt</div><div class="co">Postfinance · <span class="act-link">Log outreach →</span></div></div>
+          <div class="scard act"><span class="st">Identified</span><div class="nm">Marco Frei</div><div class="co">SBB · <span class="act-link">Log outreach →</span></div></div>
+          <div class="scard act"><span class="st">Contacted</span><div class="nm">Dr. Amir Roth</div><div class="co">ETH Zürich · <span class="act-link">Promote →</span></div></div>
+        </div>
+
+        <div class="lane"><h4>Inviting <span class="sub2">2</span></h4>
+          <div class="scard act"><span class="st">Ready</span><div class="nm">Klara Brun</div><div class="co">Mobiliar · <span class="act-link">Send invitation →</span></div></div>
+          <div class="waithdr">waiting on speaker</div>
+          <div class="scard wait"><span class="st">Invited</span><div class="nm">Felix Roth</div><div class="co">SBB · awaiting response · <span style="color:var(--primary)">Remind</span></div></div>
+        </div>
+
+        <div class="lane"><h4>Content <span class="sub2">3</span></h4>
+          <div class="scard act"><span class="st">Content submitted</span><div class="nm">Tobias Brun</div><div class="co">Swisscom · <span class="act-link">Review content →</span></div></div>
+          <div class="waithdr">waiting on speaker</div>
+          <div class="scard wait"><span class="st">Accepted</span><div class="nm">Sophie Meier</div><div class="co">Google ZH · no content yet · <span style="color:var(--primary)">Enter on behalf</span></div></div>
+          <div class="scard wait"><span class="st">Accepted</span><div class="nm">Nadia Kex</div><div class="co">Zühlke · no content yet</div></div>
+        </div>
+
+        <div class="lane"><h4>Confirmed <span class="sub2">3</span></h4>
+          <div class="scard act"><span class="st">Quality reviewed</span><div class="nm">Pia Stöckli</div><div class="co">Mimacom · <span class="act-link">⚠ Needs a slot →</span></div></div>
+          <div class="waithdr">done</div>
+          <div class="scard wait"><span class="st">Quality reviewed</span><div class="nm">Jan Keller</div><div class="co">Adnovum · ✓ slot 19:35</div></div>
+          <div class="scard wait"><span class="st">Quality reviewed</span><div class="nm">Rui Costa</div><div class="co">VSHN · ✓ slot 18:45</div></div>
+        </div>
+      </div>
+
+      <details class="declined">
+        <summary>▸ Declined (2) — collapsed by default</summary>
+        <div class="dbody">
+          <div class="scard"><span class="st">Declined</span><div class="nm">Anna Frei</div><div class="co">Helvetia · “no capacity this quarter”</div></div>
+          <div class="scard"><span class="st">Declined</span><div class="nm">Beat Iten</div><div class="co">AXA · withdrew after accepting</div></div>
+        </div>
+      </details>
+    </div>
+
+    <div id="sub-agenda" class="card pad" style="display:none">
+      <div class="row" style="margin-bottom:14px">
+        <div><p class="card-title">Session agenda</p><p class="card-sub">Edit titles, abstracts, durations &amp; materials. 2 of 6 still need a slot.</p></div>
+        <div class="sp"></div>
+        <button class="btn sm" onclick="goSub('slots')">🧩 Arrange slots →</button>
+      </div>
+      <table>
+        <thead><tr><th>Session</th><th>Speaker</th><th>Slot</th><th>Materials</th><th></th></tr></thead>
+        <tbody>
+          <tr><td>Platform Engineering at Scale</td><td>Sophie Meier</td><td><span class="tag b">17:35–18:05</span></td><td><span class="tag g">Approved</span></td><td><button class="iconbtn">✏️</button></td></tr>
+          <tr><td>GitOps in Regulated Banking</td><td>Tobias Brun</td><td><span class="tag b">18:10–18:40</span></td><td><span class="tag w">In review</span></td><td><button class="iconbtn">✏️</button></td></tr>
+          <tr><td>eBPF for Observability</td><td>Rui Costa</td><td><span class="tag b">18:45–19:15</span></td><td><span class="tag g">Approved</span></td><td><button class="iconbtn">✏️</button></td></tr>
+          <tr><td>FinOps &amp; Kubernetes Cost</td><td>Jan Keller</td><td><span class="tag b">19:35–20:05</span></td><td><span class="tag g">Approved</span></td><td><button class="iconbtn">✏️</button></td></tr>
+          <tr><td>Multi-cluster Service Mesh</td><td>Pia Stöckli</td><td><span class="tag n">— no slot —</span></td><td><span class="tag w">Pending</span></td><td><button class="iconbtn">✏️</button></td></tr>
+          <tr><td>Edge-native Workloads</td><td>Nadia Kex</td><td><span class="tag n">— no slot —</span></td><td><span class="tag w">Pending</span></td><td><button class="iconbtn">✏️</button></td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- SLOTS as a sub-tab, 2 columns, action bar on top -->
+    <div id="sub-slots" class="card pad" style="display:none">
+      <div class="slotbar">
+        <button class="btn sm">🧱 Generate structure</button>
+        <button class="btn sm primary">✨ Auto-assign</button>
+        <button class="btn sm warn">🗑️ Clear all timings</button>
+        <div class="sp"></div>
+        <div class="sum">Total <b>6</b> · Assigned <b>4</b> · Pending <b style="color:var(--warn)">2</b></div>
+      </div>
+      <div class="slots2">
+        <div class="tray">
+          <h5>Unassigned sessions (2)</h5>
+          <div class="chipdrag"><div class="nm">Multi-cluster Service Mesh</div><div class="co">Pia Stöckli · 30 min</div></div>
+          <div class="chipdrag"><div class="nm">Edge-native Workloads</div><div class="co">Nadia Kex · 30 min</div></div>
+          <p class="hint" style="margin-top:12px">Drag a session onto a slot. Hover shows the speaker’s preference-match %.</p>
+        </div>
+        <div>
+          <p class="tl5">Timeline — Thu 18 Sep · Main Hall</p>
+          <div class="timeline">
+            <div class="slot struct"><div class="time">17:30</div><div class="ses">🎙️ Welcome &amp; moderation</div></div>
+            <div class="slot filled"><div class="time">17:35–18:05</div><div class="ses">Platform Engineering at Scale <small>· Sophie Meier</small></div></div>
+            <div class="slot filled"><div class="time">18:10–18:40</div><div class="ses">GitOps in Regulated Banking <small>· Tobias Brun</small></div></div>
+            <div class="slot filled"><div class="time">18:45–19:15</div><div class="ses">eBPF for Observability <small>· Rui Costa</small></div></div>
+            <div class="slot struct"><div class="time">19:15</div><div class="ses">🍷 Apéro break</div></div>
+            <div class="slot filled"><div class="time">19:35–20:05</div><div class="ses">FinOps &amp; Kubernetes Cost <small>· Jan Keller</small></div></div>
+            <div class="slot empty"><div class="time">20:10–20:40</div><div class="ses">drop a session here…</div><span class="match">92% match</span></div>
+            <div class="slot empty"><div class="time">20:45–21:15</div><div class="ses">drop a session here…</div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- REGISTRATIONS -->
+  <section class="panel" id="p-registrations">
+    <div class="card pad" style="margin-bottom:16px">
+      <div class="row" style="margin-bottom:12px">
+        <p class="card-title">Registrations <span class="tag b" style="margin-left:6px">140 active</span></p>
+        <div class="sp"></div>
+        <button class="btn sm">⬇ Name badges (XLSX)</button>
+        <button class="btn sm">⬇ Name badges (DOCX)</button>
+        <button class="btn sm">👥 Enroll organizers &amp; partners</button>
+      </div>
+      <div class="hint" style="margin-bottom:6px">128 confirmed / 180 cap · 12 on waitlist</div>
+      <div class="prog"><i style="width:71%"></i></div>
+      <div class="row" style="margin-top:14px;flex-wrap:wrap">
+        <input class="field" style="margin:0;max-width:240px" placeholder="🔍 Search name / email / company">
+        <div class="seg" id="regFilter" style="padding:2px">
+          <button class="on" data-f="all">All</button><button data-f="confirmed">Confirmed</button><button data-f="registered">Registered</button>
+          <button data-f="attended">Attended</button><button data-f="cancelled">Cancelled</button><button data-f="wait">Waitlisted</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="card pad">
+      <!-- default list -->
+      <div id="reg-all">
+        <table>
+          <thead><tr><th>Name</th><th>Email</th><th>Company</th><th>Status</th><th>Registered</th><th>Actions</th></tr></thead>
+          <tbody>
+            <tr><td><span class="avatar">AB</span>Anna Brunner</td><td>anna.b@mobiliar.ch</td><td>Mobiliar</td><td><span class="tag g">Confirmed</span></td><td>02 Aug</td><td><button class="iconbtn" title="Resend confirmation">✉️</button><button class="iconbtn" title="Cancel">🚫</button><button class="iconbtn" title="Delete">🗑️</button></td></tr>
+            <tr><td><span class="avatar">FW</span>Felix Wyss</td><td>f.wyss@six.ch</td><td>SIX</td><td><span class="tag b">Registered</span></td><td>05 Aug</td><td><button class="iconbtn" title="Resend confirmation">✉️</button><button class="iconbtn" title="Cancel">🚫</button><button class="iconbtn" title="Delete">🗑️</button></td></tr>
+            <tr><td><span class="avatar">UG</span>Urs Gerber</td><td>urs.gerber@post.ch</td><td>Die Post</td><td><span class="tag g">Confirmed</span></td><td>14 Aug</td><td><button class="iconbtn" title="Resend confirmation">✉️</button><button class="iconbtn" title="Cancel">🚫</button><button class="iconbtn" title="Delete">🗑️</button></td></tr>
+            <tr><td><span class="avatar">MR</span>Mara Roth</td><td>mara@adnovum.ch</td><td>Adnovum</td><td><span class="tag n">Cancelled</span></td><td>09 Aug</td><td><button class="iconbtn" title="Delete">🗑️</button></td></tr>
+          </tbody>
+        </table>
+        <div class="footrow"><span>Showing 1–25 of 140</span><span class="row"><button class="btn sm">‹ Prev</button><button class="btn sm">Next ›</button></span></div>
+      </div>
+      <!-- Waitlisted filter = the SAME list, ordered by queue position with Promote. No separate table. -->
+      <div id="reg-wait" style="display:none">
+        <div class="hint" style="margin-bottom:10px">⏳ Waitlisted registrants in <b>queue order</b>. “Promote” pulls the next person into a freed seat — the only behavior the separate table added, now inline.</div>
+        <table>
+          <thead><tr><th>#</th><th>Name</th><th>Email</th><th>Company</th><th>Registered</th><th>Actions</th></tr></thead>
+          <tbody>
+            <tr><td>1</td><td><span class="avatar">CI</span>Carla Item</td><td>carla@helvetia.ch</td><td>Helvetia</td><td>11 Aug</td><td><button class="btn sm primary">Promote</button> <button class="iconbtn" title="Delete">🗑️</button></td></tr>
+            <tr><td>2</td><td><span class="avatar">BL</span>Beat Lüthi</td><td>b.luethi@axa.ch</td><td>AXA</td><td>12 Aug</td><td><button class="btn sm primary">Promote</button> <button class="iconbtn" title="Delete">🗑️</button></td></tr>
+            <tr><td>3</td><td><span class="avatar">RM</span>Rita Moser</td><td>rita@mobiliar.ch</td><td>Mobiliar</td><td>13 Aug</td><td><button class="btn sm primary">Promote</button> <button class="iconbtn" title="Delete">🗑️</button></td></tr>
+          </tbody>
+        </table>
+        <div class="footrow"><span>12 on the waitlist</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- COMMUNICATIONS -->
+  <section class="panel" id="p-comms">
+    <div class="card pad" style="margin-bottom:16px">
+      <p class="card-title" style="margin-bottom:10px">Who are you emailing?</p>
+      <div class="seg" id="aud">
+        <button class="on" data-aud="subs">📰 Newsletter subscribers</button>
+        <button data-aud="regs">🎟️ Event registrants</button>
+        <button data-aud="spk">🎤 Speakers</button>
+        <button data-aud="venue">🏛️ Venue &amp; Caterer</button>
+      </div>
+      <div class="audience-note subs" id="note-subs">Global <b>newsletter list</b> (~2,400). Templates: <i>newsletter-event</i>. Test-mode toggle sends to organizers only. Supports <b>Send Newsletter</b> + <b>Send Reminder</b>, with a send-history table &amp; retry.</div>
+      <div class="audience-note regs" id="note-regs" style="display:none">This event’s <b>active registrants only</b> (128). Templates: <i>REGISTRANT_NOTICE</i> (e.g. “slides are online”). Each registrant receives it in <b>their own language</b> — the picker only changes your preview. Single send, no history.</div>
+      <div class="audience-note spk" id="note-spk" style="display:none"><b>Speakers of this event.</b> Replaces the ad-hoc “send from my mail client” workflow. Bulk templates: <i>content-deadline reminder</i>, <i>logistics &amp; arrival info</i>, <i>thank-you</i>. Individual invitation &amp; per-speaker reminders still live on a speaker’s card in <b>Speakers &amp; Agenda</b>.</div>
+      <div class="audience-note" id="note-venue" style="display:none;background:#fef0e7;color:#8a4b1f">Templated email to the <b>venue and/or caterer contacts</b> (Welle 7 · Gastro AG). Templates: <i>VENUE_COORDINATION</i> (booking confirmation, catering headcount, setup &amp; logistics). Reply-To is the configured venue coordinator. <b>Moved here from Settings</b> — it’s a communication, so it belongs with the others.</div>
+    </div>
+
+    <div class="grid" style="grid-template-columns:340px 1fr">
+      <div class="card pad" id="comm-form">
+        <div class="field"><label>Template</label><select id="tmplSel"><option>Speaker line-up announcement</option><option>Final agenda</option></select></div>
+        <div class="field"><label>Preview language</label><select><option>Deutsch</option><option>English</option></select></div>
+        <div class="row" id="testRow" style="margin-bottom:14px"><span class="switch"></span><span class="hint">Test mode — send to organizers only</span></div>
+        <div id="recipBox" class="hint" style="margin-bottom:12px"></div>
+        <button class="btn primary" style="width:100%;margin-bottom:8px">✉️ <span id="sendLbl">Send Newsletter…</span></button>
+        <button class="btn" id="reminderBtn" style="width:100%">🔔 Send Reminder…</button>
+        <p class="hint" id="spkLink" style="margin-top:12px;display:none">Need to invite a single speaker? → use the speaker’s card in Speakers &amp; Agenda.</p>
+      </div>
+      <div>
+        <div class="card pad" style="margin-bottom:16px">
+          <p class="sec-label">Preview</p>
+          <div class="preview-frame">📧 Rendered email preview (iframe)</div>
+        </div>
+        <div class="card pad" id="histCard">
+          <p class="sec-label">Send history</p>
+          <table>
+            <thead><tr><th>Date</th><th>Type</th><th>Recipients</th><th>Status</th><th></th></tr></thead>
+            <tbody>
+              <tr><td>30 Jul · 09:12</td><td>Newsletter</td><td>2,388</td><td><span class="tag g">Completed</span></td><td></td></tr>
+              <tr><td>01 Aug · 14:05</td><td>Reminder <span class="tag n">TEST</span></td><td>4</td><td><span class="tag w">Partial</span></td><td><button class="btn sm">Retry</button></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- PUBLISHING -->
+  <section class="panel" id="p-publishing">
+    <div class="grid" style="grid-template-columns:1fr 1fr">
+      <div class="card pad">
+        <p class="card-title" style="margin-bottom:6px">Validation</p>
+        <p class="card-sub" style="margin-bottom:12px">Content auto-validates before each phase can publish.</p>
+        <div class="checkitem"><span class="ckbox g">✓</span> Topic defined</div>
+        <div class="checkitem"><span class="ckbox g">✓</span> Speakers added &amp; confirmed (6)</div>
+        <div class="checkitem"><span class="ckbox w">!</span> 2 sessions not yet assigned to a slot</div>
+        <div class="checkitem"><span class="ckbox w">!</span> 3 sessions awaiting material review</div>
+      </div>
+      <div class="card pad">
+        <p class="card-title" style="margin-bottom:12px">Publishing phases</p>
+        <div class="timeline">
+          <div class="slot filled"><div class="time">Topic</div><div class="ses">Published immediately</div><span class="match">Live ✓</span></div>
+          <div class="slot filled"><div class="time">Speakers</div><div class="ses">Auto-published 30 days before</div><span class="match">Live ✓</span></div>
+          <div class="slot"><div class="time">Agenda</div><div class="ses empty">Blocked — finish validation</div><span class="match" style="color:var(--warn)">Blocked</span></div>
+          <div class="slot"><div class="time">Final</div><div class="ses empty">Locks &amp; prints 14 days before</div></div>
+        </div>
+        <button class="btn primary" style="margin-top:14px;width:100%">📢 Publish agenda phase</button>
+      </div>
+    </div>
+    <div class="card pad" style="margin-top:16px">
+      <p class="sec-label">Live preview — current published content</p>
+      <div class="preview-frame">🌐 Public event page preview (iframe)</div>
+    </div>
+  </section>
+
+  <!-- WRAP-UP -->
+  <section class="panel" id="p-wrapup">
+    <div class="card pad" style="margin-bottom:16px;background:var(--warn-soft);border-color:var(--warn-line)">
+      🔒 <b>Locked until the event is live.</b> Post-event tools light up at <b>EVENT_LIVE</b>. Previewed here for layout.
+    </div>
+    <div class="grid" style="grid-template-columns:1fr 1fr">
+      <div class="card pad">
+        <div class="row" style="margin-bottom:12px"><p class="card-title">📸 Photos <span class="hint">0 / —</span></p><div class="sp"></div><button class="btn sm">⬆ Upload photos</button></div>
+        <div class="photos"><div class="photo">🖼️</div><div class="photo">🖼️</div><div class="photo">🖼️</div><div class="photo">🖼️</div><div class="photo">＋</div></div>
+      </div>
+      <div class="card pad">
+        <div class="row" style="margin-bottom:12px"><p class="card-title">💌 Thank-you notes <span class="hint">Total: 2</span></p></div>
+        <div class="note"><div class="nb"><p class="nq">“Best BATbern in years — the GitOps talk alone was worth it.”</p>
+          <div class="nf"><span>Anna Brunner · Mobiliar</span><span class="tag g">♥ Featured</span></div></div>
+          <span class="switch on" title="Feature on public marquee"></span></div>
+        <div class="note"><div class="nb"><p class="nq">“Loved the venue and the networking. Thank you!”</p>
+          <div class="nf"><span>Anonymous</span><span class="tag n">Anonymous</span></div></div>
+          <span class="switch" title="Cannot feature anonymous notes" style="opacity:.4"></span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- DETAILS (event identity / setup — touched once at the start, then frozen) -->
+  <section class="panel" id="p-details">
+    <div class="card pad" style="margin-bottom:16px;background:var(--primary-soft);border-color:#cfe0f5;color:var(--primary-ink);font-size:13px">
+      📝 The event’s <b>identity</b> — set once at the start (title, description, date, theme image, topic), then it rarely changes. Lives here next to Settings rather than competing with the Cockpit’s “what now?”. The title still shows in the page header on every tab.
+    </div>
+    <div class="grid" style="grid-template-columns:1fr 1fr">
+      <div>
+        <div class="card" style="overflow:hidden;margin-bottom:16px">
+          <div style="height:170px;background:linear-gradient(120deg,#0a4d8c,#1f8a5b);display:flex;align-items:center;justify-content:center;color:rgba(255,255,255,.8);font-size:13px">🖼️ Event theme image</div>
+          <div class="pad"><div class="row"><span class="hint">Shown on the public page &amp; cockpit header.</span><div class="sp"></div><button class="btn sm">⬆ Replace</button><button class="btn sm">✨ Generate (AI)</button></div></div>
+        </div>
+        <div class="card settings-sec">
+          <h3>📝 Event details</h3>
+          <div class="field"><label>Title</label><input value="Cloud Native Architecture"></div>
+          <div class="field" style="margin-bottom:8px"><label>Description</label><textarea rows="4">A deep-dive into platform engineering, GitOps and cloud-native operations in Swiss enterprises — practitioner talks, real-world case studies, and an extended apéro for the community.</textarea></div>
+          <button class="btn sm">✨ Generate description with AI</button>
+        </div>
+      </div>
+      <div>
+        <div class="card settings-sec">
+          <h3>🏷️ Topic</h3>
+          <p class="h">Pick from the backlog (with duplicate-detection). The one decision after the basics.</p>
+          <div class="row"><span class="tag b">Cloud Native Architecture</span><div class="sp"></div><button class="btn sm" id="openTopic">Change topic</button></div>
+        </div>
+        <div class="card settings-sec">
+          <h3>📅 When &amp; where</h3>
+          <div class="field"><label>Date &amp; start time</label><input value="2026-09-18 · 17:30"></div>
+          <div class="field"><label>Event type</label><select><option>Evening event</option><option>Afternoon</option><option>Full day</option></select></div>
+          <div class="field"><label>Registration deadline</label><input value="2026-09-15"></div>
+          <div class="field"><label>Venue</label><input value="Welle 7, Bern"></div>
+          <div class="field" style="margin:0"><label>Address</label><input value="Schanzenstrasse 5, 3008 Bern"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SETTINGS -->
+  <section class="panel" id="p-settings">
+    <div class="grid" style="grid-template-columns:1fr 1fr">
+      <div>
+        <div class="card settings-sec"><h3>👤 Event moderator</h3><p class="h">The organizer responsible for moderating this event.</p>
+          <div class="field"><select><option>Nissim Buchs</option><option>Sandra Keller</option></select></div></div>
+
+        <div class="card settings-sec"><h3>👥 Registration capacity</h3><p class="h">Leave blank for unlimited. Cannot exceed venue capacity (220).</p>
+          <div class="field"><input value="180"></div><button class="btn sm">Save</button></div>
+
+        <div class="card settings-sec"><h3>💬 Session Q&amp;A <span class="hint">(“The Apéro Continues”)</span></h3>
+          <p class="h">Per-session Q&amp;A threads that freeze into the archive.</p>
+          <div class="row" style="margin-bottom:12px"><span class="switch on"></span><span class="hint">Enable per-session Q&amp;A</span></div>
+          <div class="field"><label>Open the Q&amp;A</label><select><option>After the event (afterglow)</option><option>When speakers published (pre-event)</option></select></div>
+          <div class="field"><label>Open for (days after event)</label><input value="14"></div>
+          <div class="row"><button class="btn sm primary">Save</button><button class="btn sm warn">Close Q&amp;A now</button><button class="btn sm">Open Q&amp;A</button></div></div>
+      </div>
+      <div>
+        <div class="card settings-sec"><h3>🖼️ Teaser images <span class="hint">3 / 10</span></h3>
+          <p class="h">Full-screen slides on the presentation page.</p>
+          <div class="photos" style="grid-template-columns:repeat(3,1fr)"><div class="photo">🖼️</div><div class="photo">🖼️</div><div class="photo">＋</div></div></div>
+
+        <div class="card settings-sec danger-zone"><h3 style="color:var(--danger)">⚠️ Danger zone</h3>
+          <p class="h">These actions are irreversible.</p>
+          <div class="dz-row"><div><div class="t">Cancel event</div><div class="d">Cancels &amp; notifies all 128 registrants</div></div><div class="sp"></div><button class="btn warn sm">Cancel event</button></div>
+          <div class="dz-row"><div><div class="t">Delete event</div><div class="d">Only if no attendee registrations</div></div><div class="sp"></div><button class="btn danger sm">Delete event</button></div></div>
+      </div>
+    </div>
+  </section>
+</div>
+
+<!-- ===== TOPIC SELECTION + BRAINSTORMING overlay (opens from Details → Change topic) ===== -->
+<div class="tov" id="topicOv"></div>
+<div class="tfocus" id="topicFocus">
+  <div class="tbar">
+    <div class="ttl">🏷️ Topic for BATbern 76</div>
+    <button class="btn sm" id="topicClose">✕ Close</button>
+  </div>
+  <div class="tbody">
+
+    <!-- STATE A — pick a topic (filters on top, actions on the card, single grid) -->
+    <div id="topicPick">
+      <div class="topbar">
+        <input placeholder="🔍 Search topics" style="flex:1;min-width:150px">
+        <select><option>All categories</option><option>Technical</option><option>Management</option><option>Soft skills</option><option>Industry trends</option></select>
+        <select><option>All statuses</option><option>Available</option><option>Caution</option><option>Unavailable</option></select>
+        <select><option>Sort: Safest first</option><option>Recent first</option><option>Newest</option><option>Title A–Z</option><option>Most used</option></select>
+        <div class="subtoggle"><button class="on">☰ List</button><button>▦ Heat-map</button></div>
+        <button class="btn sm primary">＋ New topic</button>
+      </div>
+      <div class="topicgrid">
+        <div class="tcard green"><p class="tt">Platform Engineering &amp; IDPs</p>
+          <div class="tmeta"><span class="tag g">staleness 88 · safe</span><span>Technical</span><span>never used</span></div>
+          <div class="tact"><button class="btn sm primary selectbtn" data-t="Platform Engineering &amp; IDPs">Select for event</button><button class="btn sm">✏️ Edit</button><button class="btn sm">🗑️</button></div></div>
+        <div class="tcard green"><p class="tt">Developer Experience (DevEx)</p>
+          <div class="tmeta"><span class="tag g">staleness 91 · safe</span><span>Soft skills</span><span>never used</span></div>
+          <div class="tact"><button class="btn sm primary selectbtn" data-t="Developer Experience (DevEx)">Select for event</button><button class="btn sm">✏️ Edit</button><button class="btn sm">🗑️</button></div></div>
+        <div class="tcard green"><p class="tt">AI-Assisted Software Delivery</p>
+          <div class="tmeta"><span class="tag g">staleness 79 · safe</span><span>Industry trends</span><span>used 1×</span></div>
+          <div class="tact"><button class="btn sm primary selectbtn" data-t="AI-Assisted Software Delivery">Select for event</button><button class="btn sm">✏️ Edit</button><button class="btn sm" title="Used — can’t delete" style="opacity:.35">🗑️</button></div></div>
+        <div class="tcard yellow"><p class="tt">Event-Driven Architecture</p>
+          <div class="tmeta"><span class="tag w">staleness 58 · caution</span><span>Technical</span><span>last used 14 mo ago · 2×</span></div>
+          <div class="tsim">⚠ 82% similar to “Async Messaging Patterns” — possible duplicate</div>
+          <div class="tact"><button class="btn sm primary selectbtn" data-t="Event-Driven Architecture">Select for event</button><button class="btn sm">✏️ Edit</button><button class="btn sm" style="opacity:.35">🗑️</button></div></div>
+        <div class="tcard yellow"><p class="tt">FinOps &amp; Cloud Cost</p>
+          <div class="tmeta"><span class="tag w">staleness 61 · caution</span><span>Management</span><span>last used 13 mo ago · 1×</span></div>
+          <div class="tact"><button class="btn sm primary selectbtn" data-t="FinOps &amp; Cloud Cost">Select for event</button><button class="btn sm">✏️ Edit</button><button class="btn sm" style="opacity:.35">🗑️</button></div></div>
+        <div class="tcard red"><p class="tt">Kubernetes in Production</p>
+          <div class="tmeta"><span class="tag r">staleness 32 · too recent</span><span>Technical</span><span>last used 6 mo ago · 4×</span></div>
+          <div class="tsim" style="color:var(--danger);background:var(--danger-soft)">⚠ High duplication risk — used recently &amp; often</div>
+          <div class="tact"><button class="btn sm warn selectbtn" data-t="Kubernetes in Production">Select anyway…</button><button class="btn sm">✏️ Edit</button><button class="btn sm" style="opacity:.35">🗑️</button></div></div>
+      </div>
+    </div>
+
+    <!-- STATE B — topic pinned on top, view becomes speaker brainstorming (1–2 columns) -->
+    <div id="topicBrain" style="display:none">
+      <div class="selected-topic">
+        <span style="font-size:22px">✓</span>
+        <div style="flex:1"><div class="big" id="selTopicName">Platform Engineering &amp; IDPs</div><div class="hint">staleness 88 · safe to use · selected for BATbern 76</div></div>
+        <button class="btn sm" id="changeTopic">↩ Change topic</button>
+      </div>
+      <p class="sec-label">Now brainstorm speakers — add candidates to the pool</p>
+      <div class="brain2">
+        <div class="card pad">
+          <p class="card-title" style="margin-bottom:12px">Add a potential speaker</p>
+          <div class="field"><label>Name *</label><input placeholder="e.g. Sophie Meier"></div>
+          <div class="field"><label>Company</label><input placeholder="e.g. Google ZH"></div>
+          <div class="field"><label>Expertise</label><input placeholder="e.g. Platform engineering"></div>
+          <div class="field"><label>Assign to organizer</label><select><option>Unassigned</option><option>Nissim Buchs</option><option>Sandra Keller</option></select></div>
+          <div class="field"><label>Notes</label><textarea rows="2" placeholder="why they’d be great…"></textarea></div>
+          <button class="btn primary" style="width:100%">＋ Add to pool</button>
+        </div>
+        <div class="card pad">
+          <p class="card-title" style="margin-bottom:5px">Speaker pool (3)</p>
+          <p class="card-sub" style="margin-bottom:11px">Promote a contacted speaker when they’re ready — that provisions their account.</p>
+          <div class="poolrow"><span class="avatar">SM</span><div style="flex:1"><div style="font-weight:600">Sophie Meier</div><div class="hint">Google ZH · Platform engineering</div></div><span class="tag n">Identified</span></div>
+          <div class="poolrow"><span class="avatar">AR</span><div style="flex:1"><div style="font-weight:600">Dr. Amir Roth</div><div class="hint">ETH Zürich · Distributed systems</div></div><button class="btn sm primary">Promote</button></div>
+          <div class="poolrow"><span class="avatar">TB</span><div style="flex:1"><div style="font-weight:600">Tobias Brun</div><div class="hint">Swisscom · GitOps</div></div><span class="tag n">Identified</span></div>
+        </div>
+      </div>
+      <div class="brain-foot">
+        <button class="btn" id="brainSkip">Skip for now</button>
+        <button class="btn primary" id="brainContinue">Continue to outreach →</button>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  const rail=document.getElementById('rail');
+  function activate(id){
+    document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));
+    const tab=document.querySelector('.tab[data-tab="'+id+'"]'); tab.classList.add('active');
+    document.querySelectorAll('.panel').forEach(p=>p.classList.remove('show'));
+    document.getElementById('p-'+id).classList.add('show');
+    window.scrollTo({top:0,behavior:'smooth'});
+  }
+  rail.addEventListener('click',e=>{const t=e.target.closest('.tab');if(!t)return;
+    if(t.classList.contains('lock'))return; activate(t.dataset.tab);});
+  document.querySelectorAll('[data-goto]').forEach(b=>b.addEventListener('click',()=>activate(b.dataset.goto)));
+
+  function goSub(s){document.querySelector('#sub button[data-sub="'+s+'"]').click();}
+  document.getElementById('sub').addEventListener('click',e=>{const b=e.target.closest('button');if(!b)return;
+    document.querySelectorAll('#sub button').forEach(x=>x.classList.remove('on'));b.classList.add('on');
+    ['pool','agenda','slots'].forEach(s=>document.getElementById('sub-'+s).style.display=(b.dataset.sub===s)?'block':'none');});
+
+  document.getElementById('aud').addEventListener('click',e=>{const b=e.target.closest('button');if(!b)return;
+    document.querySelectorAll('#aud button').forEach(x=>x.classList.remove('on'));b.classList.add('on');
+    const a=b.dataset.aud;
+    ['subs','regs','spk','venue'].forEach(x=>document.getElementById('note-'+x).style.display=(a===x)?'block':'none');
+    // adapt the compose form per audience
+    const tmpl=document.getElementById('tmplSel'), sendLbl=document.getElementById('sendLbl'),
+      reminderBtn=document.getElementById('reminderBtn'), testRow=document.getElementById('testRow'),
+      hist=document.getElementById('histCard'), recip=document.getElementById('recipBox'), spkLink=document.getElementById('spkLink');
+    if(a==='subs'){tmpl.innerHTML='<option>Speaker line-up announcement</option><option>Final agenda</option>';
+      sendLbl.textContent='Send Newsletter…';reminderBtn.style.display='';testRow.style.display='';hist.style.display='';recip.textContent='~2,400 subscribers';spkLink.style.display='none';}
+    if(a==='regs'){tmpl.innerHTML='<option>Slides are online</option><option>Room change</option><option>Reminder: tomorrow</option>';
+      sendLbl.textContent='Send to registrants…';reminderBtn.style.display='none';testRow.style.display='none';hist.style.display='none';recip.textContent='128 active registrants · each in their own language';spkLink.style.display='none';}
+    if(a==='spk'){tmpl.innerHTML='<option>Content-deadline reminder</option><option>Logistics &amp; arrival info</option><option>Thank-you to speakers</option>';
+      sendLbl.textContent='Send to speakers…';reminderBtn.style.display='none';testRow.style.display='none';hist.style.display='';recip.textContent='6 confirmed speakers';spkLink.style.display='block';}
+  });
+
+  // registrations status filter — Waitlisted swaps to the ordered + promote view (no separate table)
+  const regFilter=document.getElementById('regFilter');
+  if(regFilter){regFilter.addEventListener('click',e=>{const b=e.target.closest('button');if(!b)return;
+    document.querySelectorAll('#regFilter button').forEach(x=>x.classList.remove('on'));b.classList.add('on');
+    const w=b.dataset.f==='wait';
+    document.getElementById('reg-all').style.display=w?'none':'block';
+    document.getElementById('reg-wait').style.display=w?'block':'none';});}
+
+  // venue audience branch (added to the comms form handler)
+  document.querySelector('#aud button[data-aud="venue"]').addEventListener('click',()=>{
+    const tmpl=document.getElementById('tmplSel'),sendLbl=document.getElementById('sendLbl'),
+      reminderBtn=document.getElementById('reminderBtn'),testRow=document.getElementById('testRow'),
+      hist=document.getElementById('histCard'),recip=document.getElementById('recipBox'),spkLink=document.getElementById('spkLink');
+    tmpl.innerHTML='<option>Booking confirmation</option><option>Catering headcount</option><option>Setup &amp; logistics</option>';
+    sendLbl.textContent='Send to venue/caterer…';reminderBtn.style.display='none';testRow.style.display='none';
+    hist.style.display='none';recip.textContent='Welle 7 + Gastro AG · Reply-To: coordinator';spkLink.style.display='none';
+  });
+
+  // cockpit metric tiles → deep-link to the matching tab/sub-view
+  document.querySelectorAll('[data-tile]').forEach(t=>t.addEventListener('click',()=>{
+    const d=t.dataset.tile;
+    if(d==='registrations'){activate('registrations');}
+    else{activate('speakers');goSub(d);}   // pool | agenda | slots
+  }));
+
+  // ===== Interactive lifecycle map: click a state → cockpit tasks + tab rail update =====
+  const STATES=[
+    {label:'Created',now:'Define the event — fill in the details and pick a topic.',
+     tasks:[{n:'Add event details & pick a topic',d:'soon',o:'NB',go:'details'}],
+     dim:['speakers','registrations','comms','publishing'],lock:['wrapup'],bs:'',dot:false},
+    {label:'Topic',now:'Confirm the topic, assign a moderator, and start the speaker pool.',
+     tasks:[{n:'Confirm the topic',d:'soon',o:'NB',go:'details'},
+            {n:'Assign the moderator',d:'soon',o:'NB',go:'settings'},
+            {n:'Send the topic-announcement newsletter',d:'ok',o:'SK',go:'comms'},
+            {n:'Add the first speakers to the pool',d:'ok',o:'NB',go:'pool'}],
+     dim:['registrations','publishing'],lock:['wrapup'],bs:'',dot:true},
+    {label:'Speakers',now:'Fill the speaker pool; review submissions and start slotting as speakers confirm.',
+     tasks:[{n:'Fill the speaker pool — 3 / 12 confirmed',d:'soon',o:'NB',go:'pool'},
+            {n:'Assign the moderator',d:'soon',o:'NB',go:'settings'},
+            {n:'Review speaker submissions',d:'soon',o:'NB',go:'agenda'},
+            {n:'2 sessions still need a slot',d:'ok',o:'NB',go:'slots'},
+            {n:'Schedule the partner meeting',d:'ok',o:'SK',go:'comms'}],
+     dim:['registrations'],lock:['wrapup'],bs:'2',dot:false},
+    {label:'Slot Assignment',now:'Assign speakers to time slots and finish reviews, then publish the agenda.',
+     tasks:[{n:'Assign the moderator',d:'over',o:'NB',go:'settings'},
+            {n:'2 sessions still need a slot',d:'soon',o:'NB',go:'slots'},
+            {n:'Review speaker submissions',d:'soon',o:'NB',go:'agenda'},
+            {n:'Send the “Speaker line-up” newsletter',d:'soon',o:'SK',go:'comms'},
+            {n:'Finalize & publish the agenda',d:'soon',o:'NB',go:'publishing'}],
+     dim:['registrations'],lock:['wrapup'],bs:'2',dot:false},
+    {label:'Agenda Published',now:'Agenda is live — collect any outstanding presentations and watch registrations fill.',
+     tasks:[{n:'Registrations 128 / 180 — watch capacity & waitlist',d:'ok',o:'SK',go:'registrations'},
+            {n:'Collect any outstanding presentations',d:'soon',o:'NB',go:'agenda'}],
+     dim:[],lock:['wrapup'],bs:'',dot:false},
+    {label:'Agenda Finalized',now:'Final newsletter, request the catering offer, print the agenda. Day-of controls are now available for rehearsal.',
+     tasks:[{n:'Send the final newsletter (14 days before)',d:'over',o:'SK',go:'comms'},
+            {n:'Send mail to request the catering offer',d:'soon',o:'SK',go:'comms'},
+            {n:'▶ Open presentation (rehearsal)',d:'ok',o:'NB',go:'present'},
+            {n:'📡 Live Control (test run)',d:'ok',o:'NB',go:'live'}],
+     dim:[],lock:['wrapup'],bs:'',dot:true},
+    {label:'Live',now:'🔴 Run the event — present the deck or open Live Control.',
+     tasks:[{n:'🔴 Start the presentation',d:'live',o:'NB',go:'present'},
+            {n:'📡 Open Live Control',d:'live',o:'NB',go:'live'},
+            {n:'Check-in & print walk-in badges',d:'soon',o:'SK',go:'registrations'}],
+     dim:[],lock:[],bs:'',dot:false},
+    {label:'Completed',now:'Send “slides are online”, upload photos, curate thank-yous, and book the venue for the years ahead.',
+     tasks:[{n:'Send “slides are online” to registrants',d:'soon',o:'SK',go:'comms'},
+            {n:'Book the venue for the next 2 years (annual)',d:'ok',o:'SK',go:'comms'},
+            {n:'Upload event photos',d:'ok',o:'NB',go:'wrapup'},
+            {n:'Curate & feature thank-you notes',d:'ok',o:'NB',go:'wrapup'},
+            {n:'Open session Q&A',d:'ok',o:'SK',go:'settings'}],
+     dim:['speakers'],lock:[],bs:'',dot:true},
+    {label:'Archived',now:'Event archived — read-only.',
+     tasks:[{n:'Nothing to do — the event is archived',d:'ok',o:'',go:''}],
+     dim:['speakers','registrations','comms','publishing'],lock:[],bs:'',dot:false},
+  ];
+  const DUE={over:['over','Overdue'],soon:['soon','Due soon'],ok:['ok','Upcoming'],live:['over','Now · live']};
+  const stepper=document.getElementById('stepper'),cockpitNow=document.getElementById('cockpitNow'),
+    attnList=document.getElementById('attnList'),badgeSpeakers=document.getElementById('badgeSpeakers'),
+    dotComms=document.getElementById('dotComms'),wrapLk=document.getElementById('wrapLk');
+  function renderState(idx){
+    const s=STATES[idx];
+    stepper.innerHTML=STATES.map((st,i)=>{
+      const cls=i<idx?'done':(i===idx?'current':'');
+      const bub=i<idx?'✓':(i+1);
+      const bar=i<STATES.length-1?'<div class="bar"></div>':'';
+      return `<div class="step ${cls}" data-si="${i}"><div class="node"><div class="bub">${bub}</div><div class="lbl">${st.label}</div></div>${bar}</div>`;
+    }).join('');
+    cockpitNow.innerHTML=`<b>Step ${idx+1} of ${STATES.length} · ${s.label}</b> — ${s.now}`;
+    attnList.innerHTML=s.tasks.map(t=>{
+      const due=DUE[t.d];
+      const go=t.go?`<button class="btn sm ${t.d==='live'?'primary ':''}go" data-go="${t.go}">Open →</button>`:'';
+      const who=t.o?`<span class="who"><span class="av">${t.o}</span></span>`:'';
+      return `<div class="task ${due[0]}"><div class="strip"></div><div class="body"><p class="tname">${t.n}</p><div class="tmeta"><span class="due ${due[0]}">${due[1]}</span>${who}</div>${go}</div></div>`;
+    }).join('');
+    document.querySelectorAll('.tab').forEach(tab=>{const id=tab.dataset.tab;tab.classList.remove('dim','lock');
+      if(s.lock.includes(id))tab.classList.add('lock');
+      else if(s.dim.includes(id))tab.classList.add('dim');});
+    badgeSpeakers.style.display=s.bs?'inline-flex':'none';if(s.bs)badgeSpeakers.textContent=s.bs;
+    dotComms.style.display=s.dot?'block':'none';
+    wrapLk.style.display=s.lock.includes('wrapup')?'inline':'none';
+  }
+  stepper.addEventListener('click',e=>{const st=e.target.closest('.step');if(!st)return;renderState(+st.dataset.si);});
+  function goTask(t){
+    if(['pool','agenda','slots'].includes(t)){activate('speakers');goSub(t);}
+    else if(['registrations','comms','publishing','wrapup','details','settings','speakers'].includes(t)){activate(t);}
+    // present / live have no destination in this prototype
+  }
+  attnList.addEventListener('click',e=>{const b=e.target.closest('[data-go]');if(!b)return;goTask(b.dataset.go);});
+  renderState(3); // start at SLOT_ASSIGNMENT, matching the rest of the prototype
+
+  // topic overlay
+  const topicOv=document.getElementById('topicOv'),topicFocus=document.getElementById('topicFocus');
+  function topicState(s){document.getElementById('topicPick').style.display=s==='pick'?'block':'none';
+    document.getElementById('topicBrain').style.display=s==='brain'?'block':'none';}
+  function openTopicFn(){topicOv.classList.add('show');topicFocus.classList.add('show');topicState('pick');}
+  function closeTopicFn(){topicOv.classList.remove('show');topicFocus.classList.remove('show');}
+  document.getElementById('openTopic').addEventListener('click',openTopicFn);
+  document.getElementById('topicClose').addEventListener('click',closeTopicFn);
+  topicOv.addEventListener('click',closeTopicFn);
+  document.querySelectorAll('.selectbtn').forEach(b=>b.addEventListener('click',()=>{
+    document.getElementById('selTopicName').innerHTML=b.dataset.t;topicState('brain');}));
+  document.getElementById('changeTopic').addEventListener('click',()=>topicState('pick'));
+  document.getElementById('brainSkip').addEventListener('click',closeTopicFn);
+  document.getElementById('brainContinue').addEventListener('click',()=>{closeTopicFn();activate('speakers');goSub('pool');});
+</script>
+</body>
+</html>

--- a/docs/ux/event-detail-redesign-spec.md
+++ b/docs/ux/event-detail-redesign-spec.md
@@ -1,0 +1,452 @@
+# Event Detail Page — UX Redesign Specification
+
+**Author:** Sally (UX) with Nissim
+**Date:** 2026-06-13
+**Status:** Draft for review — design agreed via interactive prototyping
+**Prototypes:**
+- Desktop — [`event-detail-redesign-prototype.html`](./event-detail-redesign-prototype.html)
+- Mobile — [`event-detail-redesign-mobile.html`](./event-detail-redesign-mobile.html)
+
+> These prototypes are the visual source of truth for this spec. Every behavior below is
+> demonstrated there. This document is the written hand-off to architecture & development.
+
+---
+
+## 1. Problem & goals
+
+### The problem
+The organizer event page (`/organizer/events/:eventCode`, `EventPage.tsx`) is **10 flat tabs**,
+all visual peers, with the Speakers tab silently carrying four tools (kanban, sessions, a
+*separate* slot-assignment route, a detail drawer). Two compounding issues:
+
+1. **The navigation ignores time, but the work is entirely about time.** The PRD models a
+   9-state event workflow and a task table where every task is pinned to a moment ("Venue
+   booking 90 days before", "Speaker newsletter 30 days before", "Catering 30 days before",
+   "Final newsletter 14 days"). The organizer's real question is never "which of 10 tabs?" —
+   it's *"what's due now, and what's next?"* Flat tabs can't answer that.
+2. **Only ~3 events per year.** Organizers use the page intensely for ~3 months, then don't
+   see it for ~4 months. No muscle memory forms. The page must **re-orient them every time**
+   and hide what isn't relevant yet.
+
+### Goals
+- Replace flat-tab navigation with a **lifecycle-aware** structure: a task-driven cockpit
+  + tabs that dim/badge by workflow state.
+- **Consolidate** overlapping tabs (10 → 8, with the last 2 a "set-and-forget" cluster).
+- **De-tangle** the Speakers tab and bring slot assignment back in-tab.
+- Make the page **self-explanatory on return** and **mobile-usable**.
+
+### Guardrails / non-negotiables
+- **No silent consequential actions.** Provisioning a Cognito account and sending invitation
+  emails have real side-effects; *staging is production*. Any drag/shortcut that would trigger
+  one must open the same confirm/modal as the explicit button.
+- All data the cockpit shows already exists (see §11) — **no new backend required** for the
+  core redesign.
+
+---
+
+## 2. Information architecture
+
+**Tab rail (8 tabs):**
+
+| # | Tab | Purpose | Cluster |
+|---|-----|---------|---------|
+| 1 | **🧭 Cockpit** | "What now?" — lifecycle + due tasks + at-a-glance metrics | work |
+| 2 | **🎤 Speakers & Agenda** | Pool (kanban) · Agenda (sessions) · Slots | work |
+| 3 | **🎟️ Registrations** | Registrants, capacity, waitlist, badges, enrol | work |
+| 4 | **✉️ Communications** | All outbound email, 4 audiences | work |
+| 5 | **📢 Publishing** | Progressive publish validation & phases | work |
+| 6 | **🎁 Wrap-up** | Post-event: photos + thank-you notes | work (late) |
+| 7 | **📝 Details** | Event identity + topic — set once, then frozen | config |
+| 8 | **⚙️ Settings** | Moderator, capacity, Q&A, teaser images, danger zone | config |
+
+**Rationale for the split:** tabs 1–6 are where an organizer *works* across a cycle; tabs 7–8
+are the "set-and-forget" config cluster, visually grouped at the end. The event **title stays
+in the page header on every tab**, so identity is never lost despite living in Details.
+
+**Consolidations from the old 10 tabs:**
+- Newsletter + Registrant Notices → **Communications** (audience switch).
+- Photos + Appreciation → **Wrap-up**.
+- Venue/Catering composer → **Communications** (it's a communication, 4th audience) — *not* Settings.
+- Old **Overview** → split: lifecycle/tasks/metrics → **Cockpit**; identity/topic → **Details**.
+- **Slot assignment** (was a separate `/slot-assignment` route) → 3rd sub-view of Speakers & Agenda.
+
+---
+
+## 3. Lifecycle-awareness model
+
+The page adapts to `event.workflowState` (9 states: `CREATED → TOPIC_SELECTION →
+SPEAKER_IDENTIFICATION → SLOT_ASSIGNMENT → AGENDA_PUBLISHED → AGENDA_FINALIZED → EVENT_LIVE →
+EVENT_COMPLETED → ARCHIVED`).
+
+- **Tab dimming:** tabs not yet relevant for the current state render dimmed + 🔒 and are
+  non-interactive (e.g. **Wrap-up** is locked until `EVENT_LIVE`).
+- **Attention badges:** tabs needing action show a count badge or red dot (e.g. Speakers shows
+  the count of sessions needing a slot; Communications shows a dot for an overdue newsletter).
+- **NEW artifact required:** a single **workflow-state → relevance map**. The same declarative
+  table drives *two* things per state: (a) what the **Cockpit emphasizes** as "what now", and
+  (b) which **tabs are active / dimmed / locked / badged**. `workflowState.ts` has the states +
+  progress helpers (`getWorkflowProgress`, `getWorkflowStepNumber`, `isEarlyStage`,
+  `isLateStage`) but **no** such mapping today — it must be authored.
+
+### 3.1 The map (draft)
+
+| State | Cockpit emphasis ("what now") | Focus tab(s) | Dimmed | Locked |
+|---|---|---|---|---|
+| **CREATED** | Define the event — fill details & pick a topic | Details | Speakers, Registrations, Communications, Publishing | Wrap-up |
+| **TOPIC_SELECTION** | Confirm the topic; assign a moderator; start the pool | Details, Speakers·Pool | Registrations, Publishing | Wrap-up |
+| **SPEAKER_IDENTIFICATION** | Fill the pool; review submissions & start slotting | Speakers·Pool | Registrations | Wrap-up |
+| **SLOT_ASSIGNMENT** | Finish slotting & reviews; publish the agenda | Speakers·Slots | Registrations | Wrap-up |
+| **AGENDA_PUBLISHED** | Collect outstanding presentations; watch registrations | Registrations, Speakers·Agenda | — | Wrap-up |
+| **AGENDA_FINALIZED** | Final newsletter; request the catering offer; print agenda | Communications, Publishing | — | Wrap-up |
+| **EVENT_LIVE** | 🔴 Run the event — present / live control | Cockpit (event-day cards), Registrations (check-in) | — | — *(Wrap-up unlocks)* |
+| **EVENT_COMPLETED** | "Slides online"; photos; thank-yous; **book the venue ahead** | Wrap-up, Communications | Speakers | — |
+| **ARCHIVED** | Archived — read-only | — | most | — |
+
+**Badges (independent of the focus column, driven by counts):** Speakers badge = sessions
+needing a slot or a content review; Communications dot = an overdue comms task; Publishing
+badge = a phase that passes validation and is ready to publish. Cockpit, Details, and Settings
+are always active.
+
+**Non-obvious task placements (confirmed 2026-06-13; the prototype's `STATES` array is the
+draft task table):**
+- **Review speaker submissions** and **"N sessions need a slot"** span **Speakers +
+  Slot Assignment** — *not* Agenda Published. By the time the agenda publishes, all submissions
+  must be reviewed and all sessions slotted (Publishing validation blocks otherwise), so there's
+  nothing left to surface there.
+- **Assign the moderator** appears from **Topic** onward (PRD trigger = `TOPIC_SELECTION`), and
+  persists into Speakers / Slot Assignment until done.
+- **Catering** is two distinct touchpoints: at **Agenda Finalized** the task is **"request the
+  catering offer"** (send mail). (Headcount confirmation, if modelled, also belongs at Finalized —
+  never earlier.)
+- **Venue booking** is **annual** (booked once a year for the upcoming ~2 years), so it is **not**
+  a per-event speaker-phase task — it surfaces at **Event Completed** as forward planning.
+
+---
+
+## 4. Cockpit (tab 1)
+
+The home/landing tab. Three stacked regions, top to bottom:
+
+### 4.1 Lifecycle spine
+Horizontal stepper of the 9 states; completed = green check, current = highlighted with step
+number ("Step 4 of 9"). Uses existing `WorkflowProgressBar` / `getWorkflowProgress`.
+
+### 4.2 "Needs your attention" (task cards)
+- Driven by the **event task list** (`taskService`, `GET /events/{code}/tasks` and/or
+  `GET /tasks/my-tasks?critical=true`).
+- Cards sorted **overdue first, then due-soon, then upcoming**. Colour strip: red (overdue),
+  amber (due soon), green (comfortable).
+- Each card shows: task name, due chip ("Overdue · 3 days", "Due in 4 days", "Locks in 6 days"),
+  assigned organizer avatar, and a **deep-link button** to the relevant tab
+  ("Open Communications →", "Open Publishing →", "Open Settings →").
+- "**＋ Add task**" affordance (tasks are configurable per the PRD task-template system).
+- **Only OPEN cards show.** A card whose work is already done must disappear from the list —
+  otherwise the cockpit shows stale "to-dos" and loses its whole "what's actually left?" value.
+  The completion signal differs per card and is **not** always a task status — see the Scrum
+  Master deliverable in §12.1.
+
+**Event-day controls live here.** "Start Presentation" and "Live Control" are **not** in the
+page header (they're irrelevant 99% of the time). On the event day they appear as **two
+attention cards** at the top of this list ("🔴 Start the presentation", "📡 Open Live Control",
+due "Now · event is live"). The prototype has a "▶ Preview event-day" toggle to demonstrate.
+Implementation: emit these as (virtual) tasks from `workflowState === AGENDA_FINALIZED` onward
+(confirmed 2026-06-13 — allows rehearsal/opening before doors), styled urgent.
+
+### 4.3 "At a glance" (metric tiles — clickable)
+Four tiles, each a **deep-link**:
+
+| Tile | Shows | Click → |
+|------|-------|---------|
+| 🎟️ Registrations | `confirmedCount / registrationCapacity`, % filled, waitlist | **Registrations** tab |
+| 🎤 Speakers | `confirmedSpeakersCount / maxSpeakerSlots` | **Speakers & Agenda → Pool** |
+| 📋 Materials | `sessionsWithMaterialsCount / totalSessionsCount` | **Speakers & Agenda → Agenda** |
+| 🗓️ Agenda | sessions slotted / total | **Speakers & Agenda → Slots** |
+
+All values come from `useEvent(..., ['metrics','registrations','workflow'])` — already available.
+
+> **Event identity is NOT on the Cockpit** (moved to Details, §8). The Cockpit is purely
+> "what now?". The header title covers orientation.
+
+---
+
+## 5. Speakers & Agenda (tab 2)
+
+A summary bar (progress: accepted/min, acceptance rate, "Add speakers") sits above a
+**sub-view toggle** with three views. Clicking a speaker anywhere opens the **Speaker Detail
+Drawer** (Details · History · Content tabs + primary-action surface — unchanged from Epic 11).
+
+### 5.1 Pool — 4-phase kanban (redesigned)
+**Was** 8 columns (one per state). **Now** 4 phase columns, because each card already carries
+its primary-action button, so the column header no longer needs to encode the exact state:
+
+| Phase column | Workflow states inside |
+|---|---|
+| **Sourcing** | IDENTIFIED · CONTACTED |
+| **Inviting** | READY · INVITED |
+| **Content** | ACCEPTED · CONTENT_SUBMITTED |
+| **Confirmed** | QUALITY_REVIEWED |
+
+- **Each card keeps its exact state as a chip** (`Identified`, `Ready`, `Invited`, …) — the
+  8-state granularity is preserved on the card, hidden only from the headers.
+- **Within-column sort = whose move it is:** "your move" cards (organizer action needed) get an
+  accent left border and sit at the top; below a faint "waiting on speaker" divider sit the
+  cards you're blocked on. This recovers the at-a-glance signal the merge would otherwise lose.
+- **Confirmed** surfaces the slot tie-in: a QUALITY_REVIEWED speaker with no slot shows
+  "⚠ Needs a slot →" (links to the Slots sub-view); slotted ones show ✓ + time.
+- **DECLINED** is a **collapsible strip at the bottom** ("▸ Declined (n)", collapsed by
+  default) — not a column.
+
+**Drag-drop rules (critical):**
+- A forward drag invokes the **same handler as the card's primary-action button** — it *opens
+  the relevant confirm/modal* (log-outreach, promote, send-invitation), it does **not**
+  auto-commit.
+- It advances **one** transition, never "however many to reach the column" — dropping an
+  IDENTIFIED card on *Content* must not fire three emails.
+- The two within-pair advances (Identified→Contacted, Ready→Invited, Accepted→Content-submitted)
+  happen via the card button and re-sort the card *inside* its column; only cross-column steps
+  are a drag. This is an intended change to the board's interaction grammar.
+- Backward = only the one legal back-transition (QUALITY_REVIEWED → CONTENT_SUBMITTED) or the
+  Decline/Override affordance; otherwise snap back.
+
+> **Rejected alternative:** a "Your move / Their move / Done" board. Great as a *lens* (it
+> already lives in the Cockpit's attention list), but as the primary kanban it throws away the
+> progression funnel and makes drag-to-advance meaningless. Not adopted.
+
+### 5.2 Agenda — sessions table
+Editable session list (title, speaker, slot chip, materials status, edit). 2-of-6-need-a-slot
+summary. "🧩 Arrange slots →" jumps to the Slots sub-view.
+
+### 5.3 Slots — slot assignment (brought in-tab, redesigned to 2 columns)
+**Was** a separate full-page route (`/slot-assignment`) opened "for space". **Now** the third
+sub-view. Redesigned from 3 columns to **2**, by moving the old right-hand "Quick actions"
+column into a **top action bar**:
+- **Top bar:** `🧱 Generate structure` · `✨ Auto-assign` · `🗑️ Clear all timings` + summary
+  ("Total 6 · Assigned 4 · Pending 2").
+- **Left column:** unassigned-sessions tray (drag source).
+- **Right column:** the timeline (drop targets; structural slots — moderation/break — shown as
+  non-droppable blocks; hover shows preference-match %).
+
+> **Implementation note:** the old separate route existed because the 3-column layout wanted
+> full height (`100vh`). The 2-column redesign (tray + timeline, actions in a top bar)
+> **removes that constraint** — it fits comfortably in the tab body, so slot assignment lives
+> **in-tab** with no separate route and no overlay fallback. `DragDropSlotAssignment` is
+> reworked from 3 columns to 2; the `100vh`/viewport-lock is dropped.
+
+---
+
+## 6. Registrations (tab 3)
+
+- **Tab shows a count** (e.g. "Registrations 140") as a subtle muted number, *not* a heavy
+  badge (a 3-digit pill looks wrong).
+- **Header:** active count chip, capacity bar ("128/180 confirmed, 12 on waitlist", red when
+  full), and the export/action row: **Name badges (XLSX)**, **Name badges (DOCX)**, and
+  **👥 Enrol organizers & partners** (moved here from the old Overview quick-actions — it acts
+  on registrations, so it belongs next to the badge exports).
+- **Filters:** search (name/email/company, debounced) + status segmented control
+  (All · Confirmed · Registered · Attended · Cancelled · Waitlisted).
+- **Table:** Name (avatar) · Email · Company · Status · Registered · Actions. Row actions
+  (`RegistrationActionsMenu`): Resend confirmation (REGISTERED only), Cancel, Delete.
+- **Waitlist = the Waitlisted filter, not a separate table.** Selecting "Waitlisted" swaps the
+  list to **queue-ordered rows (#1, #2, …) with an inline "Promote" action** — the only thing
+  the old separate accordion added. One list, one mental model.
+- **⚠ Implementation note:** the current participant table is **not virtualized**; ~200 rows in
+  one render is sluggish. Add **pagination** (shown as "Showing 1–25 of 140") or virtualization
+  as part of this work.
+
+---
+
+## 7. Communications (tab 4)
+
+One compose surface, an **audience switch** with **4 audiences**; the form adapts per audience.
+
+| Audience | Recipients | Templates | Notes |
+|---|---|---|---|
+| 📰 **Newsletter subscribers** | global list (~2,400) | `NEWSLETTER` | Test-mode toggle (organizers only); **Send Newsletter** + **Send Reminder**; send-history table + retry. |
+| 🎟️ **Event registrants** | this event's active registrants | `REGISTRANT_NOTICE` (e.g. "slides are online") | Sent in **each registrant's own language**; preview picker is organizer-only; single send, no history. |
+| 🎤 **Speakers** | this event's speakers | speaker bulk: content-deadline reminder, logistics & arrival, thank-you | Replaces today's ad-hoc "send from my mail client" workflow. **Individual invitations & per-speaker reminders stay on the speaker card** in Speakers & Agenda (1:1, workflow-bound). NB: a `useSendReminder` hook already exists in code but is wired to no UI — surface it here. |
+| 🏛️ **Venue & Caterer** | venue + caterer contacts | `VENUE_COORDINATION` (booking, headcount, setup) | Reply-To = configured coordinator. **Moved here from Settings** — it's a communication. |
+
+Common compose form: template select, preview language, preview iframe, send + confirm dialog
+(recipient count + template + event title). The "slides are online" mail is just the
+registrant-notice template — it is **not** duplicated on Wrap-up (it shows up as a Cockpit task
+at the right time and deep-links here).
+
+---
+
+## 8. Details (tab 7) — event identity + topic
+
+The event's identity — **set once at the start, then frozen**, which is why it sits next to
+Settings rather than competing with the Cockpit's "what now?".
+
+Contents:
+- **Theme image** (replace / ✨ AI-generate).
+- **Event details:** Title, Description (+ ✨ AI-generate description).
+- **Topic:** the selected topic chip + "**Change topic**" → opens the Topic overlay (§9).
+- **When & where:** date & start time, event type, registration deadline, venue name, address.
+
+Removed from this tab:
+- **"Preview public page"** — redundant; Publishing already has a live preview.
+- **"Enrol organizers & partners"** — moved to Registrations (§6).
+
+---
+
+## 9. Topic selection + brainstorming (overlay, from Details)
+
+**Was** a 4-column adaptive grid (`TopicBacklogManager`: filter sidebar | list/heat-map |
+topic-detail panel | brainstorming). Redesigned into a **focused overlay with two states**:
+
+**State A — pick a topic (1 grid):**
+- **Filters on top** (horizontal bar): search, category, status, sort, list/heat-map toggle,
+  "＋ New topic". The old left filter *column* is gone.
+- **One card grid.** Each topic card shows title, staleness chip + colour-coded left border
+  (green/amber/red per `stalenessScore`/`colorZone`), category, last-used + usage count, and an
+  inline **similarity warning** when relevant (e.g. "82% similar to …"). The old separate
+  right-hand detail *panel* is gone — its content folds onto the card.
+- **Actions on the card:** `Select for event` · `Edit` · `🗑️ Delete` (delete disabled when
+  `usageCount > 0`). A too-recent (red) topic shows "Select anyway…" + keeps the override/
+  justification dialog.
+
+**State B — selected → brainstorm (1–2 columns):**
+- On select, the topic **pins to the top** as a confirmed banner ("✓ Topic selected … ·
+  staleness · Change topic") and the view **becomes speaker brainstorming**
+  (`SpeakerBrainstormingPanel`):
+  - **Add a potential speaker** form (Name*, Company, Expertise, Assign to organizer, Notes,
+    "＋ Add to pool").
+  - **Speaker pool** list with status chips; "Promote" on CONTACTED speakers (provisions the
+    account).
+- Footer: "Skip for now" / "**Continue to outreach →**" (lands on Speakers & Agenda → Pool).
+
+Net: 4 columns → 1 (picking) then 2 (brainstorming).
+
+> **Confirmed 2026-06-13:** this is a **focused overlay** (not the standalone `/organizer/topics`
+> route) — topic-pick → brainstorm is one continuous setup gesture without a page change.
+
+---
+
+## 10. Publishing (tab 5), Wrap-up (tab 6), Settings (tab 8)
+
+### Publishing
+- **Validation** checklist (Topic ✓, Speakers ✓, "N sessions not yet slotted", "N materials
+  awaiting review").
+- **Publishing phases** timeline (Topic → Speakers → Agenda → Final), each Live / Blocked /
+  Pending, with a "Publish agenda phase" action gated on validation.
+- **Live preview** of current published public content.
+
+### Wrap-up (locked until `EVENT_LIVE`)
+- **Photos:** upload (3-phase presigned PUT), grid, delete-with-confirm.
+- **Thank-you notes:** per-note quote + author (name·company / "Anonymous"); ★ Feature toggle
+  for the public marquee — **disabled for anonymous notes** (no name to attribute).
+- The "slides are online" send is **not** duplicated here (Cockpit task → Communications).
+
+### Settings
+- **Event moderator** (organizer select).
+- **Registration capacity** (number; blank = unlimited; ≤ venue capacity).
+- **Session Q&A** ("The Apéro Continues"): enable toggle, open-trigger (after event /
+  speakers-published), days-open; Save / Close-now / Open actions.
+- **Teaser images** (presentation slides; n/10 with per-image "show after" placement).
+- **Danger zone:** Cancel event (notifies registrants) · Delete event (disabled when
+  `realAttendeeCount > 0`).
+- **Logistics (venue/caterer) removed** → now the Venue & Caterer audience in Communications.
+
+---
+
+## 11. Mobile design
+
+Seven+ destinations don't fit a phone tab bar, so the IA **changes shape**, it doesn't shrink:
+
+1. **Bottom nav + "More".** The 4 day-to-day destinations in the bottom bar — **Cockpit,
+   Speakers, Registrations, Communications** (with badges/dots). The occasional ones —
+   **Publishing, Wrap-up, Details, Settings** — live behind **⋯ More** (a bottom sheet). Matches
+   the real app's existing `BottomNavigation` and platform norms. Wrap-up shows 🔒 in the sheet
+   until `EVENT_LIVE`.
+2. **Cockpit matters more on mobile** (checked on the go): lifecycle collapses to a `Step 4/9`
+   bar, tasks stack full-width, metrics go 2-up (and are tappable deep-links).
+3. **Drag → tap-to-assign** for Slots: tap an unassigned session, empty slots light up, tap one
+   to place it. Drag-drop is hostile on touch.
+4. **Tables → cards** (Registrations) with a `⋯` overflow per row.
+5. Event-day controls appear as attention cards on the day (same as desktop).
+
+---
+
+## 12. Grounding — what already exists (no new backend for the core)
+
+| Need | Source | Status |
+|---|---|---|
+| Cockpit task cards | `taskService` · `GET /events/{code}/tasks` · `GET /tasks/my-tasks?critical=true` | ✅ exists (fields: taskName, triggerState, dueDate, assignedOrganizerUsername, status) |
+| Lifecycle spine | `workflowState.ts` (`getWorkflowProgress`, step helpers) | ✅ exists |
+| Metric tiles | `useEvent(['metrics','registrations','workflow'])` (confirmedCount, spotsRemaining, waitlistCount, confirmedSpeakersCount, sessionsWithMaterialsCount, totalSessionsCount, maxSpeakerSlots) | ✅ exists |
+| Templates per audience | `NEWSLETTER`, `REGISTRANT_NOTICE`, `VENUE_COORDINATION` categories | ✅ exist |
+| Speaker reminders | `useSendReminder` hook | ⚠ exists, **unwired** — surface in Communications |
+
+**New work the redesign introduces:**
+- **Workflow-state → relevance map** (cockpit emphasis + tab dimming/locking/badging) — small
+  declarative table, new (drafted in §3.1).
+- **Slot assignment in-tab** — rework `DragDropSlotAssignment` from a `100vh` 3-column layout to
+  a 2-column in-tab view (action bar on top); drop the viewport-lock. No separate route, no
+  overlay.
+- **Registrations pagination/virtualization** — table is not virtualized today.
+- **Event-day controls as virtual tasks** (Cockpit) when `EVENT_LIVE`.
+- **Mobile tap-to-assign** slot interaction.
+
+### 12.1 Scrum Master action — completion signal per card (so "done" cards never show)
+
+**Requirement:** the Cockpit shows a task card only while it is *still open*; a completed card
+must disappear. For **every card in every state** (see the `STATES` map in the prototype), the
+team — Scrum Master to drive — must pin down **how we know it's done**. The signal differs by
+card type and is *not* always a task status:
+
+| Card type | Examples | "Done" signal |
+|---|---|---|
+| **Task-backed** | moderator, partner meeting, newsletters, catering offer | a row in the task system with `status` → hide when `status === 'completed'`. Straightforward. |
+| **Data-derived** (no task row) | "N sessions need a slot", "Review speaker submissions", "Collect outstanding presentations", "Fill the pool 3/12" | a **computed predicate** — e.g. hide "needs a slot" when `sessions.filter(s => !s.startTime).length === 0`; hide "review submissions" when no session is `CONTENT_SUBMITTED`-awaiting-review; hide "outstanding presentations" when `sessionsWithMaterialsCount === totalSessionsCount`; hide "fill the pool" when `acceptedCount >= minSlots`. Each predicate must be defined. |
+| **Workflow-action** | "Confirm the topic", "Finalize & publish the agenda" | done when the underlying field/state changes (e.g. `topicCode` set; `workflowState` advanced). Define the trigger. |
+| **Event-day action** | "Start presentation", "Live Control" | not "completable" — live actions; show while `EVENT_LIVE` (+ `AGENDA_FINALIZED` rehearsal), no done-state. |
+| **No signal yet — needs a decision** | **venue booking** ("book for the next 2 years") | there is no data source today that says "booked". Decide: (a) make it a real task the organizer ticks off, or (b) add/derive a venue-booking record to check. |
+
+**Deliverable:** a per-card table — *card → completion predicate → data source* — covering every
+card in the `STATES` map, with every "no signal yet" card explicitly resolved to (a) a tickable
+task or (b) a derived signal. Without it, the Cockpit will surface already-done cards and the
+"what's left?" promise breaks.
+
+---
+
+## 13. Decisions confirmed (2026-06-13)
+
+All previously-open questions are resolved:
+
+1. **Topic experience → focused overlay** (not the standalone `/organizer/topics` route).
+   Pick → pin → brainstorm in one gesture, lands back on the event with no page change.
+2. **Tab count → keep 8** (6 work + Details + Settings). Identity and operational config are
+   genuinely different jobs; both stay visible, grouped at the end.
+3. **Event-day controls → from `AGENDA_FINALIZED` onward** (not `EVENT_LIVE` only) — so
+   organizers can rehearse / open the presentation before doors, and the cards are already
+   present on the day.
+4. **Slot assignment → in-tab 2-column** (no `100vh`, no separate route, no overlay) — the
+   2-column redesign removed the height constraint that justified the old separate route.
+
+---
+
+## 14. Decisions log (what we settled during prototyping)
+
+- ✅ Full reimagining (cockpit + merges + lifecycle dimming + slots in-tab).
+- ✅ Cockpit = lifecycle + tasks + metrics only; **identity moved out**.
+- ✅ Newsletter+Notices+Speakers+Venue → one **Communications** tab (4 audiences).
+- ✅ Photos+Appreciation → **Wrap-up**; "slides online" via Cockpit task, not duplicated.
+- ✅ Speaker kanban → **4 phase columns**, state chips on cards, your-move/waiting sort,
+  collapsible Declined; **drag = primary action, one step, never a silent email**.
+- ✅ "Whose move" board **rejected** as primary (kept as the cockpit lens).
+- ✅ Slot assignment → **Slots sub-view**, redesigned to **2 columns + top action bar**;
+  the 2-column layout removes the old `100vh` need, so it's **fully in-tab** (no route, no overlay).
+- ✅ Authoring the **workflow-state → relevance map** (cockpit emphasis + tab dimming) — drafted
+  in §3.1.
+- ✅ Registrations: **count on the tab**; **waitlist via the Waitlisted filter** (no separate
+  table); **Enrol organizers & partners** moved here.
+- ✅ **Details** tab (identity + topic) next to **Settings**; "Preview public page" removed.
+- ✅ Topic page → **filters on top + card actions + select→pin→brainstorm** (4 cols → 1–2).
+- ✅ Metric tiles are **clickable deep-links**.
+- ✅ Venue/caterer comms → **Communications**, removed from Settings.
+- ✅ **Start Presentation / Live Control** removed from the header → **attention cards on the
+  event day**.
+- ✅ Mobile: **bottom nav + More sheet**, tap-to-assign slots, tables→cards, lifecycle dimming.
+- ✅ Topic flow = **focused overlay** (not a route); **8 tabs kept** (Details + Settings both
+  visible); **event-day controls show from `AGENDA_FINALIZED`**; **slots fully in-tab** (no `100vh`).


### PR DESCRIPTION
## What this is

A **UX redesign of the organizer event-detail page** — design phase only, **no application code changes**. Three artifacts in `docs/ux/` for team review.

The current page is **10 flat tabs** (with the Speakers tab secretly carrying 4 tools). It's time-blind even though the work is entirely time-driven, and organizers only run ~3 events/year so they never build muscle memory. This redesign makes the page **lifecycle-aware**.

## How to review

1. Open **`docs/ux/event-detail-redesign-prototype.html`** in a browser (desktop). Click around — especially:
   - **Cockpit → tap any lifecycle step** — the "Needs your attention" tasks *and* the tab rail (dim/lock/badges) update per state. This is the live state→relevance map.
   - **Speakers & Agenda** — 4-phase kanban (Pool), Agenda, and **Slots in-tab** (2-column).
   - **Details → Change topic** — the de-overloaded topic picker → pin → brainstorm flow.
   - **Communications** — 4 audiences (subscribers / registrants / speakers / venue & caterer).
2. Open **`docs/ux/event-detail-redesign-mobile.html`** — interactive phone (bottom nav + More, tap-to-assign slots).
3. Read **`docs/ux/event-detail-redesign-spec.md`** — the written hand-off.

## Headline decisions

- **10 → 8 tabs**: Cockpit · Speakers & Agenda · Registrations · Communications · Publishing · Wrap-up · **Details · Settings** (last two = set-and-forget config cluster).
- **Cockpit** = lifecycle spine + task cards (from the existing task system) + clickable metric tiles.
- **Speaker kanban** → 4 phase columns (state chip on each card, your-move/waiting sort, collapsible Declined); **drag = primary action, one step, never a silent email/provision**.
- **Slot assignment** brought in-tab (2-column, no `100vh`, no separate route).
- **Communications** merges Newsletter + Registrant Notices + Speaker mail + Venue/Caterer.
- **Topic selection** = focused overlay (filters on top + card actions + select→pin→brainstorm).
- **Event-day controls** (Present / Live Control) → Cockpit attention cards from `AGENDA_FINALIZED`.
- **Mobile** = bottom nav + More sheet, tap-to-assign, tables→cards.

## ⚠️ Flagged for the Scrum Master (spec §12.1)

Most cockpit cards are **derived**, not task rows — so "is this done?" is not a single field. The spec calls out a required deliverable: a **per-card completion-signal table** (card → predicate → data source) so completed cards are hidden, with the **venue-booking** card explicitly flagged as having *no signal today* (needs a decision).

## Grounding

The core needs **no new backend** — `taskService`, `useEvent` metrics, workflow helpers, and the 3 template categories already exist. New work: the state→relevance map, slot in-tab rework, registrations pagination, event-day virtual tasks, mobile tap-to-assign (spec §12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)