### PR TITLE
feat(email): fix speaker-mail recipients + SES delivery tracking

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-auto-participant-email-aliases-excel-export.md
+++ b/_bmad-output/implementation-artifacts/spec-auto-participant-email-aliases-excel-export.md
@@ -189,6 +189,13 @@ context:
 - Amendment: new resolver/auth tests written in Jest style.
 - KEEP: future specs touching `infrastructure/` should reference Jest.
 
+**§6 — 2026-06-14: speaker alias now includes CO_SPEAKER + single visible broadcast + delivery tracking**
+- Trigger: event-59 incident — an organizer mailed `batbern59-speaker@` and the 5 co-speakers never received it (resolver was PRIMARY_SPEAKER-only). Root-caused via CloudWatch: `Resolved 6 email(s)` = the 6 primaries; co-speakers silently dropped.
+- Amendment A (recipients): `SessionUserRepository.findScheduledPrimarySpeakersByEventId` → renamed `findScheduledSpeakersByEventId`, now `speaker_role IN (PRIMARY_SPEAKER, CO_SPEAKER)` on scheduled sessions (MODERATOR/PANELIST still excluded). `DistributionListService.resolveSpeakers` updated. This supersedes the F2 matrix rows / Code-Map line that say "PRIMARY_SPEAKER emails".
+- Amendment B (delivery shape): the `-speaker` alias now sends ONE visible mail — `To:` all speakers, `Cc:` the auto-resolved event moderator (the `-moderator` alias = organizer) — instead of one isolated copy per recipient, so the moderator can verify the recipient list. PII exposure between speakers is accepted (product decision, 2026-06-14). All other aliases keep the per-recipient (privacy-preserving) path. This supersedes the AC bullet "SES SendRawEmail invoked once per resolved recipient" for the speaker alias only.
+- Amendment C (tracking): dedicated SES configuration set `batbern-{env}-forwarder` (in `inbound-email-stack.ts`) routes delivery/bounce/complaint/reject to CloudWatch, decoupled from the newsletter bounce-SQS so a speaker bounce never auto-suppresses a newsletter recipient. Attached via an `X-SES-CONFIGURATION-SET` header (`email-rewriter.ts`) + `SES_CONFIGURATION_SET` Lambda env. Two event destinations on the set: (1) CloudWatch metrics = aggregate counts; (2) SNS topic `batbern-{env}-ses-forwarder-events` → `ses-event-logger` Lambda → log group `/aws/lambda/batbern-{env}-ses-event-logger` = ONE structured line PER RECIPIENT (`{eventType, recipient, status, diagnostic, messageId}`), so "did <address> deliver/bounce?" is a Logs Insights query. Full recipient address is logged on purpose (the diagnostic use case needs it); 3-month retention.
+- KEEP: "event speakers" = PRIMARY + CO across the codebase (matches `findEventSpeakersByEventId` badge-export definition).
+
 ## Design Notes
 
 **Why inline auto-registration (not async listener):** read-your-write semantics for organizer-facing flows. UserApiClient is cached (15-min); cost < 50ms. If perf later matters, refactor behind `@EventListener @Async` without API contract change.

--- a/_bmad-output/implementation-artifacts/spec-transactional-ses-config-set.md
+++ b/_bmad-output/implementation-artifacts/spec-transactional-ses-config-set.md
@@ -1,0 +1,87 @@
+# Spec — Dedicated Transactional SES Configuration Set (Option 2)
+
+**Status:** in implementation — 2026-06-14
+**Branch:** `feat/speaker-mail-all-roles-and-delivery-tracking`
+**Related:** `spec-auto-participant-email-aliases-excel-export.md` §6 (forwarder config set); this spec is the backend-transactional sibling.
+
+## Intent
+
+Today the shared `EmailService` default config set (`batbern.ses.configuration-set-name`)
+is applied to **every** backend send. In EMS it is set to `batbern-{env}-newsletter`, so
+**all** transactional mail (speaker invitations, reminders, registration confirmations,
+partner-meeting ICS, slides-online, etc.) rides the **newsletter** set AND flows through
+the newsletter bounce pipeline `SNS → SQS → BounceProcessingService` (suppression). That
+is (a) misleadingly named and (b) semantically wrong — a transient speaker-invite bounce
+should not run through newsletter unsubscribe/suppression logic. Meanwhile partner-coord
+and CUMS sends attach **no** config set at all (zero delivery visibility).
+
+**Goal:** a dedicated `batbern-{env}-transactional` configuration set for all
+transactional mail, with delivery tracking (CloudWatch aggregate metrics + per-recipient
+SNS→logger, mirroring the forwarder set) but **no auto-suppression**. The
+`batbern-{env}-newsletter` set is reserved for actual newsletter blasts and keeps its
+bounce→SQS→suppression pipeline.
+
+## Design
+
+### Email paths after this change
+| Path | Config set | Bounce handling |
+|------|-----------|-----------------|
+| Inbound forwarder (Lambda) | `batbern-{env}-forwarder` | CloudWatch + per-recipient SNS logger (no suppression) |
+| **Transactional** (speaker/registration/partner/CUMS/venue/slides) | **`batbern-{env}-transactional`** (NEW) | CloudWatch + per-recipient SNS logger (no suppression) |
+| Newsletter blasts only | `batbern-{env}-newsletter` | SNS → SQS → BounceProcessingService (suppression) |
+
+### Mechanism (minimal footprint)
+The shared `EmailService.configurationSetName` default field already applies to every
+send. We **repoint that default** to the transactional set (one env var across all
+service stacks). Only the newsletter path needs an explicit override.
+
+- **shared-kernel `EmailService`** — no behavior change; default field is now semantically
+  the *transactional* set. Javadoc updated (no longer "routes to BounceProcessingService").
+- **`NewsletterEmailService`** — bind its own `@Value("${batbern.ses.newsletter-configuration-set-name:#{null}}")`
+  and pass it **explicitly on ALL sends** (lines 533, 562 currently use the 3-arg default →
+  add the explicit arg) so newsletter blasts always use the newsletter set regardless of
+  the default.
+- **`SlidesOnlineEmailService`** — already binds `batbern.ses.configuration-set-name`; gets
+  transactional automatically. No code change.
+- **`VenueCoordinationService`** — currently binds an unset `app.email.configuration-set`
+  (→ no tracking today). Rebind to `batbern.ses.configuration-set-name` → transactional.
+
+### Infrastructure (CDK)
+- **`ses-stack.ts`** — add `batbern-{env}-transactional` config set + CloudWatch metrics
+  event destination + SNS topic `batbern-{env}-ses-transactional-events` + a
+  `transactional-event-logger` Lambda (reuses `lambda/ses-event-logger/index.ts`) + its own
+  log group `/aws/lambda/batbern-{env}-transactional-event-logger` + SNS→Lambda
+  subscription. Expose `transactionalConfigurationSetName`. Newsletter set + bounce SQS
+  untouched.
+- **`bin/batbern-infrastructure.ts`** — pass `sesStack.transactionalConfigurationSetName`
+  to EMS, partner-coordination, company-management stacks; keep newsletter name → EMS.
+- **`event-management-stack.ts`** — env `BATBERN_SES_CONFIGURATION_SET_NAME` = transactional
+  (was newsletter); add `BATBERN_SES_NEWSLETTER_CONFIGURATION_SET_NAME` = newsletter. IAM
+  config-set resource widened to `configuration-set/batbern-{env}-*`.
+- **`partner-coordination-stack.ts`, `company-management-stack.ts`** — add
+  `BATBERN_SES_CONFIGURATION_SET_NAME` = transactional + the config-set IAM permission.
+
+## I/O & Edge-Case Matrix
+| Scenario | Expectation |
+|----------|-------------|
+| Speaker invitation send | uses transactional set; delivery/bounce visible in transactional logger; NOT suppressed |
+| Newsletter blast (bulk + retry + uncontacted) | uses newsletter set explicitly; bounce→suppression unchanged |
+| Partner invite (partner-coord) | uses transactional set (was: no config set) |
+| Additional-email verification (CUMS) | uses transactional set (was: no config set) |
+| Local/test (no SES, null config set) | unchanged — null default, no config set attached |
+
+## Tests
+- `ses-stack.test.ts`: transactional config set; CloudWatch + SNS event destinations;
+  logger Lambda + log group; subscription; newsletter set + bounce-SQS destination still present.
+- `event-management-stack.test.ts`: both env vars set; IAM config-set ARN wildcard.
+- `partner-coordination-stack.test.ts`, `company-management-stack.test.ts`: env + IAM.
+- `NewsletterEmailServiceTest` (Java): verify newsletter sends pass the newsletter config set
+  (explicit arg) on the bulk + retry + uncontacted paths.
+
+## Rollout / Risk
+- **Deploys to production** (staging account). The transactional set must exist before EMS
+  boots with the new env (CDK dependency ordering via `addDependency(sesStack)` already present
+  for EMS; add for partner/CUMS).
+- **Suppression-behavior change:** transactional bounces no longer auto-suppress. This is the
+  intent (the previous coupling was accidental). Newsletter suppression is preserved.
+- Frozen-migration rule: N/A (no DB migrations).

--- a/infrastructure/bin/batbern-infrastructure.ts
+++ b/infrastructure/bin/batbern-infrastructure.ts
@@ -283,6 +283,9 @@ if (EnvironmentHelper.shouldDeployWebInfrastructure(config.envName)) {
     // Story 10.29: SES Configuration Set name — required for SES BOUNCE/COMPLAINT events
     // to reach SNS → SQS → BounceProcessingService.
     sesConfigurationSetName: sesStack.configurationSetName,
+    // Transactional config set — becomes the shared EmailService default for all
+    // non-newsletter sends (delivery tracking, no suppression).
+    sesTransactionalConfigurationSetName: sesStack.transactionalConfigurationSetName,
     // Story 10.17: Inbound email SQS queue URL, S3 bucket name, and env-specific reply address
     inboundEmailQueueUrl: inboundEmailStack.inboundQueue.queueUrl,
     inboundEmailBucketName: inboundEmailStack.inboundBucket.bucketName,
@@ -348,6 +351,7 @@ if (EnvironmentHelper.shouldDeployWebInfrastructure(config.envName)) {
     userPoolClient: cognitoStack.userPoolClient,
     eventBus: eventBusStack.eventBus,
     alarmTopic: monitoringStack.alarmTopic,
+    sesTransactionalConfigurationSetName: sesStack.transactionalConfigurationSetName,
     env,
     description: `BATbern Partner Coordination Service - ${config.envName}`,
     tags: config.tags,
@@ -358,6 +362,7 @@ if (EnvironmentHelper.shouldDeployWebInfrastructure(config.envName)) {
   partnerCoordinationStack.addDependency(cognitoStack);
   partnerCoordinationStack.addDependency(eventBusStack);
   partnerCoordinationStack.addDependency(monitoringStack);
+  partnerCoordinationStack.addDependency(sesStack);
 
   // 10d. Attendee Experience Service
   attendeeExperienceStack = new AttendeeExperienceStack(app, `${stackPrefix}-AttendeeExperience`, {
@@ -397,6 +402,7 @@ if (EnvironmentHelper.shouldDeployWebInfrastructure(config.envName)) {
     eventBus: eventBusStack.eventBus,
     alarmTopic: monitoringStack.alarmTopic,
     watchJwtSecret: secretsStack.watchJwtSecret,
+    sesTransactionalConfigurationSetName: sesStack.transactionalConfigurationSetName,
     env,
     description: `BATbern Company & User Management Service (Consolidated) - ${config.envName}`,
     tags: config.tags,
@@ -407,6 +413,7 @@ if (EnvironmentHelper.shouldDeployWebInfrastructure(config.envName)) {
   companyManagementStack.addDependency(cognitoStack);
   companyManagementStack.addDependency(storageStack);
   companyManagementStack.addDependency(eventBusStack);
+  companyManagementStack.addDependency(sesStack);
   companyManagementStack.addDependency(monitoringStack);
   companyManagementStack.addDependency(secretsStack);
 

--- a/infrastructure/lambda/email-forwarder/email-rewriter.ts
+++ b/infrastructure/lambda/email-forwarder/email-rewriter.ts
@@ -13,6 +13,23 @@ export interface RewriteOptions {
   senderName: string;
   senderEmail: string;
   sesSender: string;
+  /**
+   * When set, replaces the visible `To:` header with these addresses. Used by
+   * the single-mail speaker broadcast so every speaker (and the Cc'd moderator)
+   * sees the real recipient list instead of the `batbern{N}-speaker@` alias.
+   */
+  toRecipients?: string[];
+  /**
+   * When set (non-empty), sets/replaces the visible `Cc:` header. Used to put
+   * the event moderator in Cc on the speaker broadcast.
+   */
+  ccRecipients?: string[];
+  /**
+   * When set, injects an `X-SES-CONFIGURATION-SET` header so SES attaches the
+   * configuration set (delivery/bounce/complaint/reject event tracking). SES
+   * consumes and strips this header before delivery.
+   */
+  configurationSet?: string;
 }
 
 /**
@@ -20,7 +37,10 @@ export interface RewriteOptions {
  * Replaces From, adds Reply-To, preserves everything else.
  */
 export function rewriteEmail(rawEmail: string, options: RewriteOptions): string {
-  const { senderName, senderEmail, sesSender } = options;
+  const { senderName, senderEmail, sesSender, toRecipients, ccRecipients, configurationSet } =
+    options;
+  const overrideTo = toRecipients !== undefined && toRecipients.length > 0;
+  const overrideCc = ccRecipients !== undefined;
 
   // Split into header and body sections
   const splitIndex = rawEmail.search(/\r?\n\r?\n/);
@@ -35,11 +55,35 @@ export function rewriteEmail(rawEmail: string, options: RewriteOptions): string 
   const lines = headerSection.split(/\r?\n/);
   const newLines: string[] = [];
   let hasReplyTo = false;
+  let hasCc = false;
   let i = 0;
 
   while (i < lines.length) {
     const line = lines[i];
     const lowerLine = line.toLowerCase();
+
+    // Override the visible To header with the resolved recipient list
+    if (overrideTo && lowerLine.startsWith('to:')) {
+      i++;
+      while (i < lines.length && /^[ \t]/.test(lines[i])) {
+        i++;
+      }
+      newLines.push(`To: ${toRecipients!.join(', ')}`);
+      continue;
+    }
+
+    // Override (or drop) the visible Cc header
+    if (overrideCc && lowerLine.startsWith('cc:')) {
+      hasCc = true;
+      i++;
+      while (i < lines.length && /^[ \t]/.test(lines[i])) {
+        i++;
+      }
+      if (ccRecipients!.length > 0) {
+        newLines.push(`Cc: ${ccRecipients!.join(', ')}`);
+      }
+      continue;
+    }
 
     // Skip original From header (will add new one)
     if (lowerLine.startsWith('from:')) {
@@ -98,6 +142,22 @@ export function rewriteEmail(rawEmail: string, options: RewriteOptions): string 
     } else {
       newLines.push(`Reply-To: ${senderEmail}`);
     }
+  }
+
+  // Add Cc header if requested but not already present (insert after To)
+  if (overrideCc && ccRecipients!.length > 0 && !hasCc) {
+    const toIdx = newLines.findIndex((l) => l.toLowerCase().startsWith('to:'));
+    if (toIdx >= 0) {
+      newLines.splice(toIdx + 1, 0, `Cc: ${ccRecipients!.join(', ')}`);
+    } else {
+      newLines.push(`Cc: ${ccRecipients!.join(', ')}`);
+    }
+  }
+
+  // Attach the SES configuration set (delivery/bounce/complaint/reject tracking).
+  // SES reads and strips this header before delivery.
+  if (configurationSet) {
+    newLines.push(`X-SES-CONFIGURATION-SET: ${configurationSet}`);
   }
 
   return newLines.join('\r\n') + bodySection;

--- a/infrastructure/lambda/email-forwarder/index.ts
+++ b/infrastructure/lambda/email-forwarder/index.ts
@@ -68,9 +68,16 @@ export const handler = async (event: S3Event): Promise<void> => {
     const truncatedSender = truncateEmail(senderEmail);
     console.log('Processing forwarding', { addresses: allAddresses, sender: truncatedSender });
 
-    // Resolve recipients for each authorized address, then deduplicate
-    const recipientSet = new Set<string>();
+    // Resolve recipients per authorized alias. The batbern{N}-speaker alias is
+    // special-cased: a SINGLE visible mail to all speakers (To) with the event
+    // moderator in Cc, so the moderator can verify the recipient list at a glance.
+    // Every other alias keeps the one-copy-per-recipient (privacy-preserving) path.
+    const recipientSet = new Set<string>();   // individual-send recipients
+    const speakerToSet = new Set<string>();   // single-mail visible To (speakers)
+    const moderatorCcSet = new Set<string>(); // single-mail Cc (event moderator)
     let anyAuthorized = false;
+    let speakerMode = false;
+
     for (const addr of allAddresses) {
       const authorized = await isAuthorizedSender(addr, senderEmail);
       if (!authorized) {
@@ -78,15 +85,77 @@ export const handler = async (event: S3Event): Promise<void> => {
         continue;
       }
       anyAuthorized = true;
+
+      const localPart = addr.split('@')[0]?.toLowerCase() ?? '';
+      const speakerMatch = localPart.match(/^batbern(\d+)-speaker$/);
+      const moderatorMatch = localPart.match(/^batbern(\d+)-moderator$/);
       const resolved = await resolveRecipients(addr);
-      for (const r of resolved) {
-        recipientSet.add(r);
+
+      if (speakerMatch) {
+        speakerMode = true;
+        for (const r of resolved) speakerToSet.add(r);
+        // Auto-resolve the event moderator (organizer) and Cc them.
+        const moderatorAddr = `batbern${speakerMatch[1]}-moderator@${forwardingDomain}`;
+        for (const m of await resolveRecipients(moderatorAddr)) moderatorCcSet.add(m);
+      } else if (moderatorMatch) {
+        for (const m of resolved) moderatorCcSet.add(m);
+      } else {
+        for (const r of resolved) recipientSet.add(r);
       }
     }
 
     if (!anyAuthorized) {
       await publishMetric('EmailsRejected');
       return;
+    }
+
+    const configurationSet = process.env.SES_CONFIGURATION_SET;
+
+    // ---- Single-mail speaker broadcast (visible To + moderator Cc) ----
+    if (speakerMode) {
+      // A mixed mail (speaker alias + other aliases) folds the extras into the To list.
+      for (const r of recipientSet) speakerToSet.add(r);
+      const toRecipients = [...speakerToSet];
+      const ccRecipients = [...moderatorCcSet].filter((m) => !speakerToSet.has(m));
+
+      if (toRecipients.length === 0) {
+        console.warn('No recipients resolved', { addresses: allAddresses });
+        await publishMetric('EmailsUnresolved');
+        continue;
+      }
+
+      const rewrittenEmail = rewriteEmail(rawEmail, {
+        originalFrom: headers.from,
+        senderName,
+        senderEmail,
+        sesSender: SES_SENDER,
+        toRecipients,
+        ccRecipients,
+        configurationSet,
+      });
+
+      try {
+        await ses.send(
+          new SendRawEmailCommand({
+            Source: SES_SENDER,
+            Destinations: [...toRecipients, ...ccRecipients],
+            RawMessage: { Data: Buffer.from(rewrittenEmail) },
+          }),
+        );
+        console.log('Forwarded email', {
+          addresses: allAddresses,
+          sender: truncatedSender,
+          recipientCount: toRecipients.length,
+          ccCount: ccRecipients.length,
+          mode: 'single-speaker-broadcast',
+          outcome: 'forwarded',
+        });
+        await publishMetric('EmailsForwarded');
+      } catch (err) {
+        console.error('Failed to send speaker broadcast', { error: err });
+        await publishMetric('EmailsFailed');
+      }
+      continue;
     }
 
     const recipients = [...recipientSet];
@@ -123,6 +192,7 @@ export const handler = async (event: S3Event): Promise<void> => {
       senderName: senderName,
       senderEmail: senderEmail,
       sesSender: SES_SENDER,
+      configurationSet,
     });
 
     // Send to each recipient with rate limiting

--- a/infrastructure/lambda/ses-event-logger/index.ts
+++ b/infrastructure/lambda/ses-event-logger/index.ts
@@ -1,0 +1,105 @@
+/**
+ * SES Event Logger Lambda
+ *
+ * Subscribed (via SNS) to the dedicated forwarder SES configuration set's event
+ * destination. Turns each SES event notification into one structured CloudWatch
+ * log line PER RECIPIENT, so an operator can answer "did <address> deliver /
+ * bounce / get marked as spam?" with a Logs Insights query, e.g.:
+ *
+ *   fields @timestamp, eventType, recipient, status, diagnostic
+ *   | filter recipient = "sue.ajdini@enersuisse.ch"
+ *   | sort @timestamp desc
+ *
+ * Decoupled from the newsletter bounce pipeline (its own topic + log group): a
+ * speaker bounce logged here never reaches BounceProcessingService / suppression.
+ */
+
+import type { SNSEvent } from 'aws-lambda';
+
+interface BouncedRecipient {
+  emailAddress?: string;
+  diagnosticCode?: string;
+}
+
+interface SesNotification {
+  eventType?: string;
+  notificationType?: string; // older SES notifications use this key
+  mail?: { messageId?: string; source?: string; destination?: string[] };
+  delivery?: { recipients?: string[]; smtpResponse?: string };
+  bounce?: { bounceType?: string; bounceSubType?: string; bouncedRecipients?: BouncedRecipient[] };
+  complaint?: { complainedRecipients?: Array<{ emailAddress?: string }>; complaintFeedbackType?: string };
+  reject?: { reason?: string };
+}
+
+interface PerRecipientRow {
+  recipient: string;
+  status: string;
+  diagnostic?: string;
+}
+
+export const handler = async (event: SNSEvent): Promise<void> => {
+  for (const record of event.Records) {
+    let notification: SesNotification;
+    try {
+      notification = JSON.parse(record.Sns.Message) as SesNotification;
+    } catch {
+      console.error('Unparseable SES event message', {
+        raw: record.Sns.Message?.slice(0, 200),
+      });
+      continue;
+    }
+
+    const eventType = (notification.eventType ?? notification.notificationType ?? 'unknown').toLowerCase();
+    const mail = notification.mail ?? {};
+    const base = { eventType, messageId: mail.messageId, source: mail.source };
+
+    const rows = perRecipientRows(eventType, notification, mail.destination ?? []);
+    if (rows.length === 0) {
+      console.log('SES delivery event', base);
+      continue;
+    }
+    for (const row of rows) {
+      console.log('SES delivery event', {
+        ...base,
+        recipient: row.recipient,
+        status: row.status,
+        diagnostic: row.diagnostic,
+      });
+    }
+  }
+};
+
+function perRecipientRows(
+  eventType: string,
+  n: SesNotification,
+  destination: string[],
+): PerRecipientRow[] {
+  switch (eventType) {
+    case 'delivery':
+      return (n.delivery?.recipients ?? destination).map((r) => ({
+        recipient: r,
+        status: 'delivered',
+        diagnostic: n.delivery?.smtpResponse,
+      }));
+    case 'bounce': {
+      const type = `${n.bounce?.bounceType ?? '?'}/${n.bounce?.bounceSubType ?? '?'}`;
+      return (n.bounce?.bouncedRecipients ?? []).map((r) => ({
+        recipient: r.emailAddress ?? 'unknown',
+        status: `bounce:${type}`,
+        diagnostic: r.diagnosticCode,
+      }));
+    }
+    case 'complaint':
+      return (n.complaint?.complainedRecipients ?? []).map((r) => ({
+        recipient: r.emailAddress ?? 'unknown',
+        status: `complaint:${n.complaint?.complaintFeedbackType ?? 'unspecified'}`,
+      }));
+    case 'reject':
+      return destination.map((r) => ({
+        recipient: r,
+        status: `reject:${n.reject?.reason ?? 'unspecified'}`,
+      }));
+    default:
+      return destination.map((r) => ({ recipient: r, status: eventType }));
+  }
+}

--- a/infrastructure/lib/stacks/company-management-stack.ts
+++ b/infrastructure/lib/stacks/company-management-stack.ts
@@ -29,6 +29,12 @@ export interface CompanyManagementStackProps extends cdk.StackProps {
   eventBus?: events.IEventBus;
   alarmTopic?: sns.ITopic;
   watchJwtSecret?: secretsmanager.ISecret;
+  /**
+   * Transactional SES Configuration Set name — shared EmailService default so the
+   * additional-email verification mails are delivery-tracked (no suppression).
+   * See spec-transactional-ses-config-set.md.
+   */
+  sesTransactionalConfigurationSetName?: string;
 }
 
 /**
@@ -74,6 +80,10 @@ export class CompanyManagementStack extends cdk.Stack {
       // EventBridge for domain events
       ...(props.eventBus && {
         EVENT_BUS_NAME: props.eventBus.eventBusName,
+      }),
+      // Transactional SES config set → shared EmailService default (delivery tracking)
+      ...(props.sesTransactionalConfigurationSetName && {
+        BATBERN_SES_CONFIGURATION_SET_NAME: props.sesTransactionalConfigurationSetName,
       }),
       // Additional-email verification (v2): public base URL used to build the
       // {{baseUrl}}/verify-email?token= link in verification emails. Must match
@@ -184,6 +194,8 @@ export class CompanyManagementStack extends cdk.Stack {
           `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:identity/${sesFromDomain}`,
           `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:identity/*@${sesFromDomain}`,
           `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:identity/*`,
+          // Configuration set — required when configurationSetName is attached to SendRawEmail
+          `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:configuration-set/batbern-${envName}-*`,
         ],
       }),
     );

--- a/infrastructure/lib/stacks/event-management-stack.ts
+++ b/infrastructure/lib/stacks/event-management-stack.ts
@@ -43,6 +43,13 @@ export interface EventManagementStackProps extends cdk.StackProps {
    * silently and bouncers stay active in newsletter_subscribers.
    */
   sesConfigurationSetName?: string;
+  /**
+   * Dedicated TRANSACTIONAL SES Configuration Set name. Becomes the shared EmailService
+   * default (BATBERN_SES_CONFIGURATION_SET_NAME) so all non-newsletter mail is tracked
+   * (CloudWatch + per-recipient SNS logger) without newsletter-style suppression.
+   * See spec-transactional-ses-config-set.md.
+   */
+  sesTransactionalConfigurationSetName?: string;
 }
 
 /**
@@ -127,11 +134,15 @@ export class EventManagementStack extends cdk.Stack {
             AWS_BOUNCE_QUEUE_URL: props.bounceQueueUrl,
             AWS_BOUNCE_ENABLED: 'true',
           }),
-          // Story 10.29: SES Configuration Set name — Spring reads this as
-          // batbern.ses.configuration-set-name (NewsletterEmailService:135) and
-          // attaches it to each SendEmail so BOUNCE/COMPLAINT events flow to SNS → SQS.
+          // Transactional set is the shared EmailService default (batbern.ses.configuration-set-name)
+          // → applied to every non-newsletter send for delivery tracking (no suppression).
+          ...(props.sesTransactionalConfigurationSetName && {
+            BATBERN_SES_CONFIGURATION_SET_NAME: props.sesTransactionalConfigurationSetName,
+          }),
+          // Newsletter set (batbern.ses.newsletter-configuration-set-name) → NewsletterEmailService
+          // only, so bulk blasts keep routing BOUNCE/COMPLAINT to SNS → SQS → BounceProcessingService.
           ...(props.sesConfigurationSetName && {
-            BATBERN_SES_CONFIGURATION_SET_NAME: props.sesConfigurationSetName,
+            BATBERN_SES_NEWSLETTER_CONFIGURATION_SET_NAME: props.sesConfigurationSetName,
           }),
         },
         additionalSecrets: {
@@ -205,9 +216,10 @@ export class EventManagementStack extends cdk.Stack {
           // TO identities - all verified emails (required for sandbox mode)
           // This allows sending to any verified recipient in sandbox mode
           `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:identity/*`,
-          // Configuration set — required when configurationSetName is passed to SendRawEmail
-          ...(props.sesConfigurationSetName
-            ? [`arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:configuration-set/${props.sesConfigurationSetName}`]
+          // Configuration sets — required when configurationSetName is passed to SendRawEmail.
+          // Wildcard covers both the newsletter and transactional sets (batbern-{env}-*).
+          ...(props.sesConfigurationSetName || props.sesTransactionalConfigurationSetName
+            ? [`arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:configuration-set/batbern-${envName}-*`]
             : []),
         ],
       })

--- a/infrastructure/lib/stacks/inbound-email-stack.ts
+++ b/infrastructure/lib/stacks/inbound-email-stack.ts
@@ -1,6 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as snsSubscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
 import * as ses from 'aws-cdk-lib/aws-ses';
 import * as sesActions from 'aws-cdk-lib/aws-ses-actions';
 import * as s3n from 'aws-cdk-lib/aws-s3-notifications';
@@ -209,6 +211,82 @@ export class InboundEmailStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
+    // ========================
+    // Delivery tracking (Option A) — dedicated forwarder SES configuration set
+    // ========================
+    // A standalone config set (NOT the newsletter one) so forwarded speaker/
+    // broadcast mail emits delivery/bounce/complaint/reject events to CloudWatch
+    // metrics, isolated from the newsletter bounce-SQS + BounceProcessingService
+    // (a speaker bounce must never auto-suppress a newsletter recipient). The
+    // forwarder Lambda attaches this set via an X-SES-CONFIGURATION-SET header.
+    const forwarderConfigSetName = `batbern-${envName}-forwarder`;
+    const forwarderConfigSet = new ses.CfnConfigurationSet(this, 'ForwarderConfigSet', {
+      name: forwarderConfigSetName,
+    });
+
+    new ses.CfnConfigurationSetEventDestination(this, 'ForwarderEventDest', {
+      configurationSetName: forwarderConfigSet.ref,
+      eventDestination: {
+        name: 'forwarder-delivery-events',
+        enabled: true,
+        matchingEventTypes: ['delivery', 'bounce', 'complaint', 'reject'],
+        cloudWatchDestination: {
+          dimensionConfigurations: [
+            {
+              // Dimension sourced from the message tag SES sets per config set;
+              // defaultDimensionValue keeps metrics populated even without tags.
+              dimensionName: 'ses:configuration-set',
+              dimensionValueSource: 'messageTag',
+              defaultDimensionValue: forwarderConfigSetName,
+            },
+          ],
+        },
+      },
+    });
+
+    // Per-recipient detail: SES events → SNS → small logger Lambda → its own
+    // CloudWatch log group, so an operator can answer "did <address> deliver /
+    // bounce?" by querying the log group by recipient. This is the per-recipient
+    // complement to the aggregate CloudWatch metrics above. A dedicated topic +
+    // log group keeps it decoupled from the newsletter bounce SQS pipeline.
+    const forwarderEventsTopic = new sns.Topic(this, 'ForwarderEventsTopic', {
+      topicName: `batbern-${envName}-ses-forwarder-events`,
+    });
+
+    new ses.CfnConfigurationSetEventDestination(this, 'ForwarderSnsEventDest', {
+      configurationSetName: forwarderConfigSet.ref,
+      eventDestination: {
+        name: 'forwarder-per-recipient-events',
+        enabled: true,
+        matchingEventTypes: ['delivery', 'bounce', 'complaint', 'reject'],
+        snsDestination: { topicArn: forwarderEventsTopic.topicArn },
+      },
+    });
+
+    const sesEventLoggerLogGroup = new logs.LogGroup(this, 'SesEventLoggerLogGroup', {
+      logGroupName: `/aws/lambda/batbern-${envName}-ses-event-logger`,
+      retention: logs.RetentionDays.THREE_MONTHS,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const sesEventLogger = new NodejsFunction(this, 'SesEventLogger', {
+      functionName: `batbern-${envName}-ses-event-logger`,
+      runtime: lambda.Runtime.NODEJS_20_X,
+      entry: path.join(__dirname, '../../lambda/ses-event-logger/index.ts'),
+      handler: 'handler',
+      memorySize: 128,
+      timeout: cdk.Duration.seconds(30),
+      logGroup: sesEventLoggerLogGroup,
+      bundling: {
+        externalModules: ['@aws-sdk/*'],
+        minify: true,
+        sourceMap: false,
+        forceDockerBundling: false,
+      },
+    });
+
+    forwarderEventsTopic.addSubscription(new snsSubscriptions.LambdaSubscription(sesEventLogger));
+
     // API Gateway URL for the forwarder to call existing APIs.
     // ECS Service Connect DNS (api-gateway.batbern-{env}) is only resolvable from within ECS
     // tasks — VPC-native Lambda functions use the standard VPC DNS which cannot resolve it.
@@ -235,6 +313,7 @@ export class InboundEmailStack extends cdk.Stack {
         API_GATEWAY_URL: apiGatewayUrl,
         SES_SENDER_ADDRESS: `noreply@${forwardingDomain}`,
         FORWARDING_DOMAIN: forwardingDomain,
+        SES_CONFIGURATION_SET: forwarderConfigSetName,
       },
       bundling: {
         externalModules: ['@aws-sdk/*'],

--- a/infrastructure/lib/stacks/partner-coordination-stack.ts
+++ b/infrastructure/lib/stacks/partner-coordination-stack.ts
@@ -23,6 +23,12 @@ export interface PartnerCoordinationStackProps extends cdk.StackProps {
   userPoolClient: cognito.IUserPoolClient;
   eventBus?: events.IEventBus;
   alarmTopic?: sns.ITopic;
+  /**
+   * Transactional SES Configuration Set name — shared EmailService default so partner
+   * invite / meeting emails are delivery-tracked (no suppression).
+   * See spec-transactional-ses-config-set.md.
+   */
+  sesTransactionalConfigurationSetName?: string;
 }
 
 /**
@@ -46,6 +52,10 @@ export class PartnerCoordinationStack extends cdk.Stack {
       // EventBridge for domain events (PartnerCreatedEvent, TopicVoteSubmittedEvent, etc.)
       ...(props.eventBus && {
         EVENT_BUS_NAME: props.eventBus.eventBusName,
+      }),
+      // Transactional SES config set → shared EmailService default (delivery tracking)
+      ...(props.sesTransactionalConfigurationSetName && {
+        BATBERN_SES_CONFIGURATION_SET_NAME: props.sesTransactionalConfigurationSetName,
       }),
     };
 
@@ -101,6 +111,8 @@ export class PartnerCoordinationStack extends cdk.Stack {
           `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:identity/${sesFromDomain}`,
           `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:identity/*@${sesFromDomain}`,
           `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:identity/*`,
+          // Configuration set — required when configurationSetName is attached to SendRawEmail
+          `arn:aws:ses:${props.config.region}:${cdk.Stack.of(this).account}:configuration-set/batbern-${envName}-*`,
         ],
       }),
     );

--- a/infrastructure/lib/stacks/ses-stack.ts
+++ b/infrastructure/lib/stacks/ses-stack.ts
@@ -3,6 +3,10 @@ import * as sns from 'aws-cdk-lib/aws-sns';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as ses from 'aws-cdk-lib/aws-ses';
 import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import * as path from 'path';
 import { Construct } from 'constructs';
 import { EnvironmentConfig } from '../config/environment-config';
 
@@ -29,6 +33,16 @@ export class SesStack extends cdk.Stack {
    * silently and the app's BounceProcessingService never sees them.
    */
   public readonly configurationSetName: string;
+
+  /**
+   * Name of the dedicated TRANSACTIONAL SES Configuration Set. All backend transactional
+   * mail (speaker invitations/reminders, registration confirmations, partner invites,
+   * venue/slides notifications, CUMS verification) attaches this set via the shared
+   * EmailService default. It tracks delivery/bounce/complaint/reject to CloudWatch +
+   * a per-recipient SNS→logger, but is intentionally NOT wired to the bounce-processing
+   * SQS — transactional bounces must not run through newsletter suppression.
+   */
+  public readonly transactionalConfigurationSetName: string;
 
   constructor(scope: Construct, id: string, props: SesStackProps) {
     super(scope, id, props);
@@ -77,6 +91,77 @@ export class SesStack extends cdk.Stack {
         snsDestination: { topicArn: bounceTopic.topicArn },
       },
     });
+
+    // ========================
+    // Dedicated TRANSACTIONAL configuration set (Option 2)
+    // ========================
+    // All backend transactional mail attaches this set (via the shared EmailService
+    // default). Delivery/bounce/complaint/reject → (1) CloudWatch metrics (aggregate)
+    // and (2) SNS → ses-event-logger Lambda → its own log group (per-recipient,
+    // queryable by address). Deliberately NOT wired to the bounce-processing SQS:
+    // transactional bounces must not trigger newsletter suppression.
+    this.transactionalConfigurationSetName = `batbern-${envName}-transactional`;
+    const transactionalConfigSet = new ses.CfnConfigurationSet(this, 'TransactionalConfigSet', {
+      name: this.transactionalConfigurationSetName,
+    });
+
+    new ses.CfnConfigurationSetEventDestination(this, 'TransactionalCwEventDest', {
+      configurationSetName: transactionalConfigSet.ref,
+      eventDestination: {
+        name: 'transactional-delivery-metrics',
+        enabled: true,
+        matchingEventTypes: ['delivery', 'bounce', 'complaint', 'reject'],
+        cloudWatchDestination: {
+          dimensionConfigurations: [
+            {
+              dimensionName: 'ses:configuration-set',
+              dimensionValueSource: 'messageTag',
+              defaultDimensionValue: this.transactionalConfigurationSetName,
+            },
+          ],
+        },
+      },
+    });
+
+    const transactionalEventsTopic = new sns.Topic(this, 'TransactionalEventsTopic', {
+      topicName: `batbern-${envName}-ses-transactional-events`,
+    });
+
+    new ses.CfnConfigurationSetEventDestination(this, 'TransactionalSnsEventDest', {
+      configurationSetName: transactionalConfigSet.ref,
+      eventDestination: {
+        name: 'transactional-per-recipient-events',
+        enabled: true,
+        matchingEventTypes: ['delivery', 'bounce', 'complaint', 'reject'],
+        snsDestination: { topicArn: transactionalEventsTopic.topicArn },
+      },
+    });
+
+    const transactionalEventLoggerLogGroup = new logs.LogGroup(this, 'TransactionalEventLoggerLogGroup', {
+      logGroupName: `/aws/lambda/batbern-${envName}-transactional-event-logger`,
+      retention: logs.RetentionDays.THREE_MONTHS,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const transactionalEventLogger = new NodejsFunction(this, 'TransactionalEventLogger', {
+      functionName: `batbern-${envName}-transactional-event-logger`,
+      runtime: lambda.Runtime.NODEJS_20_X,
+      entry: path.join(__dirname, '../../lambda/ses-event-logger/index.ts'),
+      handler: 'handler',
+      memorySize: 128,
+      timeout: cdk.Duration.seconds(30),
+      logGroup: transactionalEventLoggerLogGroup,
+      bundling: {
+        externalModules: ['@aws-sdk/*'],
+        minify: true,
+        sourceMap: false,
+        forceDockerBundling: false,
+      },
+    });
+
+    transactionalEventsTopic.addSubscription(
+      new subscriptions.LambdaSubscription(transactionalEventLogger),
+    );
 
     // CloudFormation outputs
     new cdk.CfnOutput(this, 'BounceQueueUrl', {

--- a/infrastructure/test/unit/email-forwarder.test.ts
+++ b/infrastructure/test/unit/email-forwarder.test.ts
@@ -786,6 +786,58 @@ describe('T9 — Email rewriting and forwarding', () => {
     const result = rewriteEmail(emailWithDkim, rewriteOptions);
     expect(result).not.toContain('DKIM-Signature:');
   });
+
+  // ----- Single-mail speaker mode: override visible To + add moderator Cc -----
+
+  test('should_overrideToHeader_when_toRecipientsProvided', () => {
+    const result = rewriteEmail(sampleEmail, {
+      ...rewriteOptions,
+      toRecipients: ['alice@example.com', 'bob@example.com'],
+    });
+    // The original alias To is replaced with the visible speaker list
+    expect(result).toContain('To: alice@example.com, bob@example.com');
+    expect(result).not.toContain('To: ok@batbern.ch');
+  });
+
+  test('should_addCcHeader_when_ccRecipientsProvided', () => {
+    const result = rewriteEmail(sampleEmail, {
+      ...rewriteOptions,
+      toRecipients: ['alice@example.com'],
+      ccRecipients: ['moderator@batbern.ch'],
+    });
+    expect(result).toContain('Cc: moderator@batbern.ch');
+  });
+
+  test('should_replaceExistingCc_when_ccRecipientsProvided', () => {
+    const emailWithCc = sampleEmail.replace(
+      'Subject: Test forwarding',
+      'Cc: someone@example.com\r\nSubject: Test forwarding',
+    );
+    const result = rewriteEmail(emailWithCc, {
+      ...rewriteOptions,
+      ccRecipients: ['moderator@batbern.ch'],
+    });
+    expect(result).toContain('Cc: moderator@batbern.ch');
+    expect(result).not.toContain('Cc: someone@example.com');
+  });
+
+  test('should_leaveToUnchanged_when_noRecipientsProvided', () => {
+    const result = rewriteEmail(sampleEmail, rewriteOptions);
+    expect(result).toContain('To: ok@batbern.ch');
+  });
+
+  test('should_injectConfigurationSetHeader_when_configurationSetProvided', () => {
+    const result = rewriteEmail(sampleEmail, {
+      ...rewriteOptions,
+      configurationSet: 'batbern-staging-forwarder',
+    });
+    expect(result).toContain('X-SES-CONFIGURATION-SET: batbern-staging-forwarder');
+  });
+
+  test('should_notInjectConfigurationSetHeader_when_notProvided', () => {
+    const result = rewriteEmail(sampleEmail, rewriteOptions);
+    expect(result).not.toContain('X-SES-CONFIGURATION-SET');
+  });
 });
 
 // ========================
@@ -943,5 +995,149 @@ describe('T11 — isCalendarReply suppresses iMIP acceptance fan-out', () => {
       'No method=REPLY here.',
     ].join('\r\n');
     expect(isCalendarReply(raw)).toBe(false);
+  });
+});
+
+// ========================
+// T12: handler() — single mail to all speakers with moderator in Cc
+// ========================
+
+import { mockClient } from 'aws-sdk-client-mock';
+import { SESClient, SendRawEmailCommand } from '@aws-sdk/client-ses';
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { CloudWatchClient, PutMetricDataCommand } from '@aws-sdk/client-cloudwatch';
+import { handler as forwarderHandler } from '../../lambda/email-forwarder/index';
+import { resetCache as resetAuthCache } from '../../lambda/email-forwarder/sender-auth';
+
+// Module-scope mocks patched once at load, against the SAME SDK module the
+// statically-imported handler uses (no jest.resetModules here, which would
+// create a divergent unmocked client).
+const sesMock = mockClient(SESClient);
+const s3Mock = mockClient(S3Client);
+const cwMock = mockClient(CloudWatchClient);
+
+describe('T12 — handler sends one visible mail to speakers, moderator in Cc', () => {
+  const originalFetch = global.fetch;
+  const env = process.env;
+
+  beforeEach(() => {
+    sesMock.reset();
+    s3Mock.reset();
+    cwMock.reset();
+    resetAuthCache();
+    cwMock.on(PutMetricDataCommand).resolves({});
+    sesMock.on(SendRawEmailCommand).resolves({ MessageId: 'mid-1' });
+    process.env = {
+      ...env,
+      SES_SENDER_ADDRESS: 'noreply@batbern.ch',
+      FORWARDING_DOMAIN: 'batbern.ch',
+      API_GATEWAY_URL: 'https://api.batbern.ch',
+      SES_CONFIGURATION_SET: 'batbern-staging-forwarder',
+    };
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env = env;
+  });
+
+  function mockS3(rawEmail: string): void {
+    s3Mock.on(GetObjectCommand).resolves({
+      Body: { transformToString: async () => rawEmail },
+    } as never);
+  }
+
+  function s3Event(): unknown {
+    return {
+      Records: [
+        { s3: { bucket: { name: 'inbound-bucket' }, object: { key: 'forwarding/abc' } } },
+      ],
+    };
+  }
+
+  function mockFetch(): void {
+    global.fetch = jest.fn(async (url: string | URL | Request) => {
+      const u = url.toString();
+      const json = (body: unknown) =>
+        ({ ok: true, status: 200, json: async () => body }) as Response;
+      if (u.includes('role=ORGANIZER')) {
+        return json({ data: [{ email: 'org@test.ch' }], pagination: { totalPages: 1, page: 0 } });
+      }
+      if (u.includes('/distribution-list/speakers')) {
+        return json({ emails: ['alice@example.com', 'bob@example.com'] });
+      }
+      if (u.includes('/distribution-list/moderator')) {
+        return json({ emails: ['mod@batbern.ch'] });
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as Response;
+    }) as jest.Mock;
+  }
+
+  test('should_sendSingleMail_withSpeakersInToAndModeratorInCc_when_speakerAlias', async () => {
+    mockFetch();
+    mockS3(
+      [
+        'From: Org <org@test.ch>',
+        'To: batbern59-speaker@batbern.ch',
+        'Subject: Info for speakers',
+        'Content-Type: text/plain',
+        '',
+        'Hello speakers',
+      ].join('\r\n'),
+    );
+
+    await forwarderHandler(s3Event() as never);
+
+    // Exactly ONE send (not one-per-recipient)
+    const calls = sesMock.commandCalls(SendRawEmailCommand);
+    expect(calls).toHaveLength(1);
+
+    const input = calls[0].args[0].input;
+    // Both speakers AND the moderator are actual SES destinations
+    expect(input.Destinations).toEqual(
+      expect.arrayContaining(['alice@example.com', 'bob@example.com', 'mod@batbern.ch']),
+    );
+    expect(input.Destinations).toHaveLength(3);
+
+    const raw = (input.RawMessage!.Data as Buffer).toString('utf-8');
+    // Visible To lists the speakers; moderator is visibly Cc'd
+    expect(raw).toContain('To: alice@example.com, bob@example.com');
+    expect(raw).toContain('Cc: mod@batbern.ch');
+    // Delivery tracking config set attached
+    expect(raw).toContain('X-SES-CONFIGURATION-SET: batbern-staging-forwarder');
+  });
+
+  test('should_keepIndividualSends_when_nonSpeakerAlias', async () => {
+    mockFetch();
+    mockS3(
+      [
+        'From: Org <org@test.ch>',
+        'To: ok@batbern.ch',
+        'Subject: Hi organizers',
+        'Content-Type: text/plain',
+        '',
+        'Hello',
+      ].join('\r\n'),
+    );
+    // ok@ resolves to organizers (one in this mock) → existing individual-send path
+    global.fetch = jest.fn(async (url: string | URL | Request) => {
+      const u = url.toString();
+      if (u.includes('role=ORGANIZER')) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ data: [{ email: 'org@test.ch' }, { email: 'org2@test.ch' }], pagination: { totalPages: 1, page: 0 } }),
+        } as Response;
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as Response;
+    }) as jest.Mock;
+
+    await forwarderHandler(s3Event() as never);
+
+    // Individual sends preserved: one per organizer, each isolated (no Cc)
+    const calls = sesMock.commandCalls(SendRawEmailCommand);
+    expect(calls).toHaveLength(2);
+    for (const c of calls) {
+      expect(c.args[0].input.Destinations).toHaveLength(1);
+    }
   });
 });

--- a/infrastructure/test/unit/event-management-iam.test.ts
+++ b/infrastructure/test/unit/event-management-iam.test.ts
@@ -25,7 +25,10 @@ const TEST_ACCOUNT = '123456789012';
 const TEST_REGION = 'eu-central-1';
 const SES_CONFIG_SET = 'batbern-staging-newsletter';
 
-function buildTemplate(sesConfigurationSetName?: string): Template {
+function buildTemplate(
+  sesConfigurationSetName?: string,
+  sesTransactionalConfigurationSetName?: string,
+): Template {
   const app = new App();
   const parent = new Stack(app, 'Parent', {
     env: { account: TEST_ACCOUNT, region: TEST_REGION },
@@ -59,6 +62,7 @@ function buildTemplate(sesConfigurationSetName?: string): Template {
     userPool,
     userPoolClient,
     sesConfigurationSetName,
+    sesTransactionalConfigurationSetName,
     env: { account: TEST_ACCOUNT, region: TEST_REGION },
   });
 
@@ -84,7 +88,8 @@ describe('EventManagementStack — SES IAM policy', () => {
     });
 
     // Regression guard: this specific ARN was missing on 2026-05-05, causing silent
-    // AccessDenied on every registration confirmation email send.
+    // AccessDenied on every registration confirmation email send. The grant is now a
+    // wildcard covering both the newsletter and transactional sets (batbern-{env}-*).
     test('should_includeConfigurationSetArn_in_taskRolePolicy_when_sesConfigSetNameProvided', () => {
       template.hasResourceProperties('AWS::IAM::Policy', {
         PolicyDocument: {
@@ -92,7 +97,7 @@ describe('EventManagementStack — SES IAM policy', () => {
             Match.objectLike({
               Action: Match.arrayWith(['ses:SendRawEmail']),
               Resource: Match.arrayWith([
-                Match.stringLikeRegexp(`configuration-set/${SES_CONFIG_SET}$`),
+                Match.stringLikeRegexp('configuration-set/batbern-staging-'),
               ]),
             }),
           ]),
@@ -124,6 +129,27 @@ describe('EventManagementStack — SES IAM policy', () => {
             }),
           ]),
         },
+      });
+    });
+  });
+
+  describe('transactional + newsletter env wiring', () => {
+    let template: Template;
+
+    beforeAll(() => {
+      template = buildTemplate('batbern-staging-newsletter', 'batbern-staging-transactional');
+    });
+
+    test('should_setTransactionalSetAsDefault_and_newsletterAsSeparateEnv', () => {
+      template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Environment: Match.arrayWith([
+              { Name: 'BATBERN_SES_CONFIGURATION_SET_NAME', Value: 'batbern-staging-transactional' },
+              { Name: 'BATBERN_SES_NEWSLETTER_CONFIGURATION_SET_NAME', Value: 'batbern-staging-newsletter' },
+            ]),
+          }),
+        ]),
       });
     });
   });

--- a/infrastructure/test/unit/inbound-email-stack.test.ts
+++ b/infrastructure/test/unit/inbound-email-stack.test.ts
@@ -224,6 +224,67 @@ describe('InboundEmailStack', () => {
     });
   });
 
+  // Delivery tracking (Option A): dedicated forwarder SES configuration set
+  test('should_createDedicatedForwarderConfigurationSet_when_stackDeployed', () => {
+    template.hasResourceProperties('AWS::SES::ConfigurationSet', {
+      Name: 'batbern-staging-forwarder',
+    });
+  });
+
+  test('should_routeForwarderEventsToCloudWatch_when_configSetCreated', () => {
+    template.hasResourceProperties('AWS::SES::ConfigurationSetEventDestination', {
+      EventDestination: Match.objectLike({
+        Enabled: true,
+        MatchingEventTypes: Match.arrayWith(['delivery', 'bounce', 'complaint', 'reject']),
+        CloudWatchDestination: Match.anyValue(),
+      }),
+    });
+  });
+
+  test('should_passConfigurationSetNameToForwarderLambda_when_created', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: 'batbern-email-forwarder-staging',
+      Environment: Match.objectLike({
+        Variables: Match.objectLike({
+          SES_CONFIGURATION_SET: 'batbern-staging-forwarder',
+        }),
+      }),
+    });
+  });
+
+  // Per-recipient delivery tracking: SES → SNS → logger Lambda → CloudWatch Logs
+  test('should_createForwarderEventsSnsTopic_when_stackDeployed', () => {
+    template.hasResourceProperties('AWS::SNS::Topic', {
+      TopicName: 'batbern-staging-ses-forwarder-events',
+    });
+  });
+
+  test('should_routeForwarderEventsToSns_when_configSetCreated', () => {
+    template.hasResourceProperties('AWS::SES::ConfigurationSetEventDestination', {
+      EventDestination: Match.objectLike({
+        Enabled: true,
+        MatchingEventTypes: Match.arrayWith(['delivery', 'bounce', 'complaint', 'reject']),
+        SnsDestination: Match.anyValue(),
+      }),
+    });
+  });
+
+  test('should_createSesEventLoggerLambda_with_ownLogGroup', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: 'batbern-staging-ses-event-logger',
+      Runtime: 'nodejs20.x',
+    });
+    template.hasResourceProperties('AWS::Logs::LogGroup', {
+      LogGroupName: '/aws/lambda/batbern-staging-ses-event-logger',
+    });
+  });
+
+  test('should_subscribeLoggerLambdaToEventsTopic_when_stackDeployed', () => {
+    template.hasResourceProperties('AWS::SNS::Subscription', {
+      Protocol: 'lambda',
+    });
+  });
+
   // T12 — Story 10.26: MX record for SES inbound SMTP when hosted zone provided
   test('should_createMxRecord_when_hostedZoneProvided', () => {
     const mxApp = new App();

--- a/infrastructure/test/unit/ses-event-logger.test.ts
+++ b/infrastructure/test/unit/ses-event-logger.test.ts
@@ -1,0 +1,125 @@
+/**
+ * SES Event Logger Lambda — unit tests
+ *
+ * The logger turns SES configuration-set event notifications (delivered via SNS)
+ * into one structured CloudWatch log line PER RECIPIENT, so an operator can answer
+ * "did <address> deliver / bounce / get marked spam?" with a Logs Insights query.
+ */
+
+import type { SNSEvent } from 'aws-lambda';
+import { handler } from '../../lambda/ses-event-logger/index';
+
+function snsEvent(notification: unknown): SNSEvent {
+  return {
+    Records: [
+      {
+        EventSource: 'aws:sns',
+        Sns: { Message: JSON.stringify(notification) },
+      } as never,
+    ],
+  } as SNSEvent;
+}
+
+describe('ses-event-logger handler', () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  function loggedRecipients(): Array<Record<string, unknown>> {
+    return logSpy.mock.calls
+      .filter((c) => c[0] === 'SES delivery event')
+      .map((c) => c[1] as Record<string, unknown>);
+  }
+
+  test('should_logDeliveryPerRecipient_when_deliveryNotification', async () => {
+    await handler(
+      snsEvent({
+        eventType: 'Delivery',
+        mail: {
+          messageId: 'msg-1',
+          source: 'noreply@batbern.ch',
+          destination: ['sue.ajdini@enersuisse.ch', 'bob@example.com'],
+        },
+        delivery: {
+          recipients: ['sue.ajdini@enersuisse.ch', 'bob@example.com'],
+          smtpResponse: '250 2.0.0 OK',
+        },
+      }),
+    );
+
+    const recs = loggedRecipients();
+    expect(recs).toHaveLength(2);
+    expect(recs.map((r) => r.recipient)).toEqual(
+      expect.arrayContaining(['sue.ajdini@enersuisse.ch', 'bob@example.com']),
+    );
+    expect(recs[0].eventType).toBe('delivery');
+    expect(recs[0].messageId).toBe('msg-1');
+  });
+
+  test('should_logBouncePerRecipient_withBounceType_when_bounceNotification', async () => {
+    await handler(
+      snsEvent({
+        eventType: 'Bounce',
+        mail: { messageId: 'msg-2', destination: ['gone@example.com'] },
+        bounce: {
+          bounceType: 'Permanent',
+          bounceSubType: 'General',
+          bouncedRecipients: [
+            { emailAddress: 'gone@example.com', diagnosticCode: 'smtp; 550 5.1.1 user unknown' },
+          ],
+        },
+      }),
+    );
+
+    const recs = loggedRecipients();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].recipient).toBe('gone@example.com');
+    expect(recs[0].eventType).toBe('bounce');
+    expect(String(recs[0].status)).toContain('Permanent');
+    expect(String(recs[0].diagnostic)).toContain('550');
+  });
+
+  test('should_logComplaintPerRecipient_when_complaintNotification', async () => {
+    await handler(
+      snsEvent({
+        eventType: 'Complaint',
+        mail: { messageId: 'msg-3', destination: ['angry@example.com'] },
+        complaint: { complainedRecipients: [{ emailAddress: 'angry@example.com' }] },
+      }),
+    );
+
+    const recs = loggedRecipients();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].recipient).toBe('angry@example.com');
+    expect(recs[0].eventType).toBe('complaint');
+  });
+
+  test('should_logReject_when_rejectNotification', async () => {
+    await handler(
+      snsEvent({
+        eventType: 'Reject',
+        mail: { messageId: 'msg-4', destination: ['virus@example.com'] },
+        reject: { reason: 'Bad content' },
+      }),
+    );
+
+    const recs = loggedRecipients();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].recipient).toBe('virus@example.com');
+    expect(recs[0].eventType).toBe('reject');
+    expect(String(recs[0].status)).toContain('Bad content');
+  });
+
+  test('should_notThrow_when_messageUnparseable', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const bad = { Records: [{ EventSource: 'aws:sns', Sns: { Message: 'not-json{' } }] } as never;
+    await expect(handler(bad as SNSEvent)).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/infrastructure/test/unit/ses-stack.test.ts
+++ b/infrastructure/test/unit/ses-stack.test.ts
@@ -95,6 +95,62 @@ describe('SesStack', () => {
     expect(stack.configurationSetName).toBe('batbern-staging-newsletter');
   });
 
+  // ----- Dedicated transactional config set (Option 2) -----
+
+  test('should_createTransactionalConfigurationSet_when_sesStackDeployed', () => {
+    template.hasResourceProperties('AWS::SES::ConfigurationSet', {
+      Name: 'batbern-staging-transactional',
+    });
+  });
+
+  test('should_exposeTransactionalConfigurationSetName_when_sesStackCreated', () => {
+    expect(stack.transactionalConfigurationSetName).toBe('batbern-staging-transactional');
+  });
+
+  test('should_routeTransactionalEventsToCloudWatchAndSns_when_configSetCreated', () => {
+    // CloudWatch aggregate metrics destination
+    template.hasResourceProperties('AWS::SES::ConfigurationSetEventDestination', {
+      EventDestination: Match.objectLike({
+        Enabled: true,
+        MatchingEventTypes: Match.arrayWith(['delivery', 'bounce', 'complaint', 'reject']),
+        CloudWatchDestination: Match.anyValue(),
+      }),
+    });
+    // Per-recipient SNS destination
+    template.hasResourceProperties('AWS::SES::ConfigurationSetEventDestination', {
+      EventDestination: Match.objectLike({
+        MatchingEventTypes: Match.arrayWith(['delivery', 'bounce', 'complaint', 'reject']),
+        SnsDestination: Match.anyValue(),
+      }),
+    });
+  });
+
+  test('should_createTransactionalEventLogger_withOwnLogGroup_andSubscription', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: 'batbern-staging-transactional-event-logger',
+      Runtime: 'nodejs20.x',
+    });
+    template.hasResourceProperties('AWS::Logs::LogGroup', {
+      LogGroupName: '/aws/lambda/batbern-staging-transactional-event-logger',
+    });
+    template.hasResourceProperties('AWS::SNS::Subscription', {
+      Protocol: 'lambda',
+    });
+  });
+
+  test('should_keepNewsletterBounceSqsPipeline_intact_alongsideTransactionalSet', () => {
+    // Newsletter set still routes bounce/complaint to SNS (the suppression pipeline)
+    template.hasResourceProperties('AWS::SES::ConfigurationSetEventDestination', {
+      EventDestination: Match.objectLike({
+        MatchingEventTypes: ['bounce', 'complaint'],
+        SnsDestination: Match.anyValue(),
+      }),
+    });
+    template.hasResourceProperties('AWS::SQS::Queue', {
+      QueueName: 'batbern-staging-bounce-processing',
+    });
+  });
+
   // Tags applied
   test('should_applyEnvironmentTags_when_sesStackDeployed', () => {
     expect(stack.stackName).toBe('TestSesStack');

--- a/services/event-management-service/src/main/java/ch/batbern/events/repository/SessionUserRepository.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/repository/SessionUserRepository.java
@@ -75,24 +75,30 @@ public interface SessionUserRepository extends JpaRepository<SessionUser, UUID> 
     List<SessionUser> findAllByEventId(@Param("eventId") UUID eventId);
 
     /**
-     * Find all PRIMARY_SPEAKER session_users on <strong>scheduled</strong> sessions of an event
-     * (i.e. sessions where {@code start_time IS NOT NULL}).
+     * Find all presenting speakers — PRIMARY_SPEAKER <strong>and</strong> CO_SPEAKER — on
+     * <strong>scheduled</strong> sessions of an event (i.e. sessions where
+     * {@code start_time IS NOT NULL}). MODERATOR and PANELIST roles are intentionally excluded.
      *
      * <p>Spec: {@code _bmad-output/implementation-artifacts/spec-auto-participant-email-aliases-excel-export.md}
      * (F2) — backs the {@code batbern{N}-speaker@} distribution-list resolution: only speakers
      * whose sessions have been timetabled (a real talk slot, not just a placeholder pool row)
      * should appear on the alias.
      *
+     * <p>Co-speakers were previously dropped (PRIMARY_SPEAKER-only), so a mail to the speaker
+     * alias never reached them — see event-59 incident (a co-speaker reported a missed mail).
+     *
      * @param eventId event UUID
-     * @return list of SessionUser rows; empty when no scheduled primary speakers exist yet
+     * @return list of SessionUser rows; empty when no scheduled speakers exist yet
      */
     @Query("SELECT su FROM SessionUser su "
         + "JOIN su.session s "
         + "WHERE s.eventId = :eventId "
         + "AND s.startTime IS NOT NULL "
-        + "AND su.speakerRole = ch.batbern.events.domain.SessionUser.SpeakerRole.PRIMARY_SPEAKER "
-        + "ORDER BY s.startTime ASC")
-    List<SessionUser> findScheduledPrimarySpeakersByEventId(@Param("eventId") UUID eventId);
+        + "AND su.speakerRole IN ("
+        + "  ch.batbern.events.domain.SessionUser.SpeakerRole.PRIMARY_SPEAKER, "
+        + "  ch.batbern.events.domain.SessionUser.SpeakerRole.CO_SPEAKER) "
+        + "ORDER BY s.startTime ASC, su.speakerRole ASC")
+    List<SessionUser> findScheduledSpeakersByEventId(@Param("eventId") UUID eventId);
 
     /**
      * Find PRIMARY_SPEAKER + CO_SPEAKER session_users for the given event.

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/DistributionListService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/DistributionListService.java
@@ -25,8 +25,9 @@ import java.util.Set;
  * <p>Spec: {@code _bmad-output/implementation-artifacts/spec-auto-participant-email-aliases-excel-export.md}
  * (F2). Two kinds are supported:
  * <ul>
- *   <li>{@code speakers} → {@code batbern{N}-speaker@}: PRIMARY_SPEAKER of every scheduled
- *       session of the event, plus each speaker's verified additionalEmails.</li>
+ *   <li>{@code speakers} → {@code batbern{N}-speaker@}: PRIMARY_SPEAKER + CO_SPEAKER of every
+ *       scheduled session of the event, plus each speaker's verified additionalEmails.
+ *       MODERATOR / PANELIST roles are excluded.</li>
  *   <li>{@code moderator} → {@code batbern{N}-moderator@}: the event lead organizer
  *       ({@code Event.organizerUsername}), plus their additionalEmails. BATbern's "event
  *       moderator" interpretation; {@code SessionUser.MODERATOR} is per-session and not
@@ -57,7 +58,7 @@ public class DistributionListService {
     public Set<String> resolveSpeakers(String eventCode) {
         Event event = loadEvent(eventCode);
         List<SessionUser> speakers =
-                sessionUserRepository.findScheduledPrimarySpeakersByEventId(event.getId());
+                sessionUserRepository.findScheduledSpeakersByEventId(event.getId());
 
         Set<String> result = new LinkedHashSet<>();
         for (SessionUser su : speakers) {

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/NewsletterEmailService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/NewsletterEmailService.java
@@ -132,8 +132,14 @@ public class NewsletterEmailService {
     @Value("${app.base-url:https://batbern.ch}")
     private String baseUrl;
 
-    /** Story 10.29 AC4: SES Configuration Set name for bounce/complaint tracking. Null = disabled. */
-    @Value("${batbern.ses.configuration-set-name:#{null}}")
+    /**
+     * Newsletter-only SES Configuration Set (bounce/complaint → SNS → SQS →
+     * BounceProcessingService suppression). Bound to its OWN property so newsletter
+     * blasts always use the newsletter set regardless of the shared EmailService
+     * default (which now points at the transactional set). Null = disabled.
+     * See spec-transactional-ses-config-set.md.
+     */
+    @Value("${batbern.ses.newsletter-configuration-set-name:#{null}}")
     private String configurationSetName;
 
     /**
@@ -530,7 +536,7 @@ public class NewsletterEmailService {
                     String mergedHtml = emailService.replaceVariables(
                             emailTemplateService.mergeWithLayout(contentHtml, LAYOUT_KEY, locale),
                             recipientVars);
-                    emailService.sendHtmlEmailSync(email, subject, mergedHtml);
+                    emailService.sendHtmlEmailSync(email, subject, mergedHtml, configurationSetName);
                     newlySent++;
                 } catch (Exception e) {
                     log.error("Newsletter retry (failed) failed for {}: {}", email, e.getMessage());
@@ -559,7 +565,7 @@ public class NewsletterEmailService {
                     String mergedHtml = emailService.replaceVariables(
                             emailTemplateService.mergeWithLayout(contentHtml, LAYOUT_KEY, locale),
                             recipientVars);
-                    emailService.sendHtmlEmailSync(email, subject, mergedHtml);
+                    emailService.sendHtmlEmailSync(email, subject, mergedHtml, configurationSetName);
                     newlySent++;
                 } catch (Exception e) {
                     log.error("Newsletter retry (uncontacted) failed for {}: {}", email, e.getMessage());

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/VenueCoordinationService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/VenueCoordinationService.java
@@ -77,7 +77,10 @@ public class VenueCoordinationService {
     private final UserApiClient userApiClient;
     private final ObjectMapper objectMapper;
 
-    @Value("${app.email.configuration-set:}")
+    // Transactional SES configuration set (delivery tracking, no suppression). Bound to
+    // the shared default property so venue/partner-meeting invites are tracked like all
+    // other transactional mail. See spec-transactional-ses-config-set.md.
+    @Value("${batbern.ses.configuration-set-name:#{null}}")
     private String configurationSetName;
 
     // ── Preview ───────────────────────────────────────────────────────────────

--- a/services/event-management-service/src/test/java/ch/batbern/events/repository/SessionUserRepositoryIntegrationTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/repository/SessionUserRepositoryIntegrationTest.java
@@ -314,6 +314,36 @@ class SessionUserRepositoryIntegrationTest extends AbstractIntegrationTest {
                 .containsExactlyInAnyOrder(username1, username3);
     }
 
+    @Test
+    void should_findScheduledSpeakers_includingCoSpeakers_excludingModeratorPanelistAndUnscheduled() {
+        // Given: scheduled sessions with mixed roles, plus an unscheduled session
+        createSessionUser(testSession1, username1, SpeakerRole.PRIMARY_SPEAKER);
+        createSessionUser(testSession1, username2, SpeakerRole.CO_SPEAKER);
+        createSessionUser(testSession1, username3, SpeakerRole.MODERATOR);
+        createSessionUser(testSession2, "panel.pat", SpeakerRole.PANELIST);
+
+        // Unscheduled session (start_time IS NULL) — its PRIMARY_SPEAKER must be excluded
+        Session unscheduled = sessionRepository.save(Session.builder()
+                .sessionSlug("session-pool")
+                .eventId(testEvent.getId())
+                .eventCode(testEvent.getEventCode())
+                .title("Pool Session")
+                .sessionType("presentation")
+                .startTime(null)
+                .build());
+        createSessionUser(unscheduled, "pool.speaker", SpeakerRole.PRIMARY_SPEAKER);
+
+        // When
+        List<SessionUser> result =
+                sessionUserRepository.findScheduledSpeakersByEventId(testEvent.getId());
+
+        // Then: only PRIMARY + CO on scheduled sessions; MODERATOR, PANELIST, unscheduled excluded
+        assertThat(result).extracting(SessionUser::getUsername)
+                .containsExactlyInAnyOrder(username1, username2);
+        assertThat(result).extracting(SessionUser::getSpeakerRole)
+                .containsExactlyInAnyOrder(SpeakerRole.PRIMARY_SPEAKER, SpeakerRole.CO_SPEAKER);
+    }
+
     // Helper method
     private SessionUser createSessionUser(Session session, String username, SpeakerRole role) {
         SessionUser sessionUser = SessionUser.builder()

--- a/services/event-management-service/src/test/java/ch/batbern/events/service/DistributionListServiceTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/service/DistributionListServiceTest.java
@@ -63,13 +63,13 @@ class DistributionListServiceTest {
     }
 
     @Test
-    @DisplayName("speakers: fans out PRIMARY_SPEAKER + additionalEmails, lowercased & deduped")
-    void should_returnPrimarySpeakerEmails_withAdditionalEmails() {
+    @DisplayName("speakers: fans out scheduled PRIMARY + CO speakers + additionalEmails, lowercased & deduped")
+    void should_returnSpeakerEmails_withAdditionalEmails() {
         when(eventRepository.findByEventCode(EVENT_CODE)).thenReturn(Optional.of(event));
-        SessionUser su1 = sessionUserOf("speaker.bob");
-        SessionUser su2 = sessionUserOf("speaker.carol");
-        when(sessionUserRepository.findScheduledPrimarySpeakersByEventId(EVENT_ID))
-                .thenReturn(List.of(su1, su2));
+        SessionUser primary = sessionUserOf("speaker.bob", SessionUser.SpeakerRole.PRIMARY_SPEAKER);
+        SessionUser coSpeaker = sessionUserOf("speaker.carol", SessionUser.SpeakerRole.CO_SPEAKER);
+        when(sessionUserRepository.findScheduledSpeakersByEventId(EVENT_ID))
+                .thenReturn(List.of(primary, coSpeaker));
         when(userApiClient.getUserByUsername("speaker.bob")).thenReturn(
                 userWithAdditional("speaker.bob", "Bob@Example.com",
                         List.of("bob.work@example.com")));
@@ -78,6 +78,7 @@ class DistributionListServiceTest {
 
         Set<String> emails = service.resolveSpeakers(EVENT_CODE);
 
+        // Co-speaker (carol) is included, not just the primary speaker (regression: event 59)
         assertThat(emails).containsExactly(
                 "bob@example.com",
                 "bob.work@example.com",
@@ -91,7 +92,7 @@ class DistributionListServiceTest {
         when(eventRepository.findByEventCode(EVENT_CODE)).thenReturn(Optional.of(event));
         SessionUser su1 = sessionUserOf("speaker.bob");
         SessionUser su2 = sessionUserOf("speaker.bob.alt"); // same person, different login
-        when(sessionUserRepository.findScheduledPrimarySpeakersByEventId(EVENT_ID))
+        when(sessionUserRepository.findScheduledSpeakersByEventId(EVENT_ID))
                 .thenReturn(List.of(su1, su2));
         when(userApiClient.getUserByUsername("speaker.bob")).thenReturn(
                 userWithAdditional("speaker.bob", "BOB@example.com", List.of()));
@@ -109,7 +110,7 @@ class DistributionListServiceTest {
         when(eventRepository.findByEventCode(EVENT_CODE)).thenReturn(Optional.of(event));
         SessionUser su1 = sessionUserOf("speaker.bob");
         SessionUser su2 = sessionUserOf("speaker.missing");
-        when(sessionUserRepository.findScheduledPrimarySpeakersByEventId(EVENT_ID))
+        when(sessionUserRepository.findScheduledSpeakersByEventId(EVENT_ID))
                 .thenReturn(List.of(su1, su2));
         when(userApiClient.getUserByUsername("speaker.bob")).thenReturn(
                 userWithAdditional("speaker.bob", "bob@example.com", List.of()));
@@ -125,7 +126,7 @@ class DistributionListServiceTest {
     @DisplayName("speakers: empty list when event has no scheduled primary speakers")
     void should_returnEmpty_when_noScheduledPrimarySpeakers() {
         when(eventRepository.findByEventCode(EVENT_CODE)).thenReturn(Optional.of(event));
-        when(sessionUserRepository.findScheduledPrimarySpeakersByEventId(EVENT_ID))
+        when(sessionUserRepository.findScheduledSpeakersByEventId(EVENT_ID))
                 .thenReturn(List.of());
 
         Set<String> emails = service.resolveSpeakers(EVENT_CODE);
@@ -179,9 +180,13 @@ class DistributionListServiceTest {
     // ---- helpers ----
 
     private SessionUser sessionUserOf(String username) {
+        return sessionUserOf(username, SessionUser.SpeakerRole.PRIMARY_SPEAKER);
+    }
+
+    private SessionUser sessionUserOf(String username, SessionUser.SpeakerRole role) {
         SessionUser su = new SessionUser();
         su.setUsername(username);
-        su.setSpeakerRole(SessionUser.SpeakerRole.PRIMARY_SPEAKER);
+        su.setSpeakerRole(role);
         // Session FK is irrelevant for the service test (resolver only uses the username)
         return su;
     }

--- a/shared-kernel/src/main/java/ch/batbern/shared/service/EmailService.java
+++ b/shared-kernel/src/main/java/ch/batbern/shared/service/EmailService.java
@@ -70,10 +70,14 @@ public class EmailService {
     private String replyToEmail;
 
     /**
-     * Default SES Configuration Set applied to every send so BOUNCE/COMPLAINT events
-     * route to SNS → SQS → BounceProcessingService for ALL email kinds (transactional
-     * and newsletter). Null in local/test or when not configured. Explicit overrides
-     * via the *Sync(... configurationSetName) overloads still work.
+     * Default SES Configuration Set applied to every send. This is the TRANSACTIONAL set
+     * (delivery/bounce/complaint/reject → CloudWatch metrics + a per-recipient SNS logger,
+     * with NO auto-suppression) — it is wired in each service stack via
+     * {@code BATBERN_SES_CONFIGURATION_SET_NAME}. Newsletter blasts deliberately override
+     * this with the newsletter set (which routes bounces to SQS → BounceProcessingService
+     * for suppression) — see {@code NewsletterEmailService}. Null in local/test or when not
+     * configured. Explicit overrides via the {@code *Sync(... configurationSetName)}
+     * overloads still work. See {@code spec-transactional-ses-config-set.md}.
      */
     @Value("${batbern.ses.configuration-set-name:#{null}}")
     private String configurationSetName;


### PR DESCRIPTION
## Why

Investigating a report that **event-59 speakers didn't all receive an organizer mail**, CloudWatch showed the `batbern59-speaker@` distribution list resolved only **6 of 11** speaking people — the query was `PRIMARY_SPEAKER`-only, silently dropping all **co-speakers**. SES accepted the 6 with zero bounces, so the gap was in *recipient resolution*, not delivery. We also had no per-recipient delivery visibility for forwarded or transactional mail (only account-wide stats).

## What

**1. Speaker recipients (root-cause fix)** — `event-management`
- `findScheduledPrimarySpeakersByEventId` → `findScheduledSpeakersByEventId`: now `PRIMARY_SPEAKER + CO_SPEAKER` on scheduled sessions (MODERATOR/PANELIST excluded, matching the badge-export definition).

**2. Forwarder — one visible mail, moderator in Cc** — `email-forwarder`
- The `batbern{N}-speaker@` alias now sends **one** mail with `To:` all speakers (visible) and the event moderator **auto-Cc'd**, so the moderator can verify recipients. Other aliases keep per-recipient sends. `rewriteEmail` gained `To`/`Cc` override + `X-SES-CONFIGURATION-SET` header.

**3. Delivery tracking — dedicated forwarder config set**
- `batbern-{env}-forwarder` SES config set: CloudWatch metrics + per-recipient `SNS → ses-event-logger` Lambda → own log group. Decoupled from the newsletter bounce/suppression pipeline.

**4. Transactional config set (Option 2)** — `shared-kernel` + 3 service stacks
- New `batbern-{env}-transactional` set (CloudWatch + per-recipient logger, **no suppression**), wired as the shared `EmailService` default across `event-management`, `partner-coordination`, `company-user-management`. `NewsletterEmailService` now binds its **own** newsletter property and passes it explicitly on all sends, so newsletter blasts keep their set + bounce→SQS→suppression.

After this, "did `<address>` deliver/bounce?" is a Logs Insights query:
```
fields @timestamp, eventType, recipient, status, diagnostic
| filter recipient = "someone@example.com" | sort @timestamp desc
```

## Tests
- `event-management` Java suite green (distribution + repository + newsletter + venue).
- **135** infra jest tests green (ses-stack, event-management-iam, company-management, inbound-email, forwarder, ses-event-logger); `tsc` clean.
- Adds the previously-missing forwarder + ses-event-logger handler tests.

## Risk / rollout
- **Deploys to the staging account (production).** `SesStack` must deploy before the service stacks — `addDependency(sesStack)` added for partner + CUMS (EMS already had it).
- **Intended behavior change:** transactional bounces (speaker invites, registration confirmations, partner invites, CUMS verification) **no longer auto-suppress** — the prior newsletter coupling was accidental. Newsletter suppression is preserved.
- No DB migrations.

Specs: `spec-transactional-ses-config-set.md`; `spec-auto-participant-email-aliases-excel-export.md` §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)