### PR TITLE
fix(events): add-participant sends a proper 'added by organizer' confirmation (not the waitlist email)

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-organizer-add-participant.md
+++ b/_bmad-output/implementation-artifacts/spec-organizer-add-participant.md
@@ -34,7 +34,13 @@
 - **Capacity:** `activeCount = countByEventIdAndStatusIn(eventId, CAPACITY_STATUSES)`; if `capacity != null && activeCount >= capacity && !force` → throw a capacity-exceeded exception → `409` (message names the count/capacity). When `force=true`, create anyway (organizer override).
 - Build `Registration` with `status="confirmed"`, real attendee fields from the user, `registrationDate=now()`. **Audit metadata** `addedByOrganizer=<currentUsername>` — but **NOT** `Registration.AUTO_REGISTERED_FROM_KEY` (that key excludes a row from `realAttendeeCount`; a manually-added participant IS a real attendee and should count for capacity + the delete-guard).
 - `deregistrationToken` auto-generates via the existing `@PrePersist`.
-- If `notify`, send the standard registration-confirmation email (reuse `RegistrationEmailService` confirmed-path) so the attendee gets their cancel/deregistration link.
+- If `notify`, send a **dedicated** "added by the organizing team" confirmation via
+  `RegistrationEmailService.sendOrganizerAddedConfirmation` (template `registration-organizer-added-{de,en}`).
+  This is NOT the double-opt-in registration-confirmation email and NOT the waitlist-promotion
+  email: the place is already confirmed, so there is no "please confirm" CTA, no waitlist
+  narrative, and no registration code — just a "you're registered, your place is confirmed"
+  notice with the event details, a calendar (.ics) invite, and the self-service deregistration
+  link. (Corrected 2026-06-16 after the first cut wrongly reused the waitlist-promotion email.)
 
 ### FR3 — OpenAPI + types
 - Add the operation + `AddParticipantRequest` schema to `docs/api/events-api.openapi.yml`.

--- a/docs/user-guide/appendix/changelog.md
+++ b/docs/user-guide/appendix/changelog.md
@@ -51,6 +51,11 @@ Each release includes:
 - ✅ New `batbern{N}-participants@batbern.ch` mailing alias fans out to every active registrant — "Way 2" (same audience as Way 1)
 - ✅ Consolidated the older bare `batbern{N}@batbern.ch` alias: now **deprecated** and forwards to the same participants resolution as `batbern{N}-participants@` (clearer name, matches `-speaker@`/`-moderator@`); logs a deprecation warning, sender auth unchanged (organizers only)
 
+**New Feature — Organizer "Add participant" (2026-06-16)**:
+- ✅ Organizers can manually add an existing user to an event **directly as a confirmed participant** from the Registrations tab (4th action button) — for VIPs, late phone/email requests, or colleagues — skipping the self-registration + email-confirmation step.
+- ✅ Existing-users-only picker (the shared `UserAutocomplete`); capacity respected with an explicit "add anyway" override; counts as a real attendee.
+- ✅ The added participant receives a dedicated **"you're registered — your place is confirmed"** email (event details + calendar invite + self-service cancel link) — not a "please confirm" or waitlist message.
+
 > **Note**: The former "v1.3.0 — Speaker Authentication Unification (Epic 9)" plan has shipped in a
 > different form. Epic 9's JWT magic-link approach was **superseded** by Epic 11 (unified Cognito
 > speaker workflow) and Epic 12 (Google SSO), both released in v1.3.0 below.

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/RegistrationEmailService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/RegistrationEmailService.java
@@ -145,6 +145,83 @@ public class RegistrationEmailService {
     }
 
     /**
+     * Send the "added by the organizing team" confirmation for an organizer-added participant
+     * (the "Add participant" feature). Unlike {@link #sendRegistrationConfirmation}, the place is
+     * ALREADY confirmed: no confirm-your-registration CTA, no waitlist narrative, no registration
+     * code — just a "you're registered, your place is confirmed" notice with the event details, a
+     * calendar invite, and the self-service deregistration link.
+     *
+     * @param registration the (confirmed) registration that was just created
+     * @param userProfile  the added user's profile
+     * @param event        the event
+     * @param locale       the user's locale (DE → German, anything else → English fallback)
+     */
+    @Async
+    public void sendOrganizerAddedConfirmation(
+            Registration registration,
+            UserResponse userProfile,
+            Event event,
+            Locale locale
+    ) {
+        try {
+            log.info("Sending organizer-added confirmation email to: {} for event: {}",
+                    LoggingUtils.maskEmail(userProfile.getEmail()), event.getEventCode());
+
+            Locale emailLocale = (locale != null) ? locale : Locale.GERMAN;
+            String localeStr = emailLocale.getLanguage().equals("de") ? "de" : "en";
+            ZonedDateTime eventDateTime = resolveEventDateTime(event);
+
+            String template = loadHtmlContent("registration-organizer-added", localeStr,
+                    "email-templates/registration-organizer-added-" + localeStr + ".html");
+
+            String deregistrationUrl = registration.getDeregistrationToken() != null
+                    ? baseUrl + "/deregister?token=" + registration.getDeregistrationToken()
+                    : baseUrl + "/events";
+
+            Map<String, String> variables = Map.ofEntries(
+                    Map.entry("attendeeFirstName",
+                            userProfile.getFirstName() != null ? userProfile.getFirstName() : ""),
+                    Map.entry("attendeeLastName",
+                            userProfile.getLastName() != null ? userProfile.getLastName() : ""),
+                    Map.entry("eventCode", event.getEventCode()),
+                    Map.entry("eventTitle", event.getTitle()),
+                    Map.entry("eventDate", eventDateTime.format(DATE_FORMATTER)),
+                    Map.entry("eventTime",
+                            eventDateTime.format(TIME_FORMATTER) + (localeStr.equals("de") ? " Uhr" : "")),
+                    Map.entry("venueName", event.getVenueName() != null ? event.getVenueName() : "TBA"),
+                    Map.entry("venueAddress", event.getVenueAddress() != null ? event.getVenueAddress() : "TBA"),
+                    Map.entry("deregistrationUrl", deregistrationUrl),
+                    Map.entry("eventUrl", baseUrl + "/events/" + event.getEventCode()),
+                    Map.entry("supportUrl", baseUrl + "/support"),
+                    Map.entry("currentYear", String.valueOf(java.time.Year.now().getValue())),
+                    Map.entry("logoUrl", baseUrl + "/BATbern_white_logo.png")
+            );
+
+            String html = emailService.replaceVariables(template, variables);
+            String subject = emailTemplateService.resolveSubject("registration-organizer-added", localeStr)
+                    .map(s -> emailService.replaceVariables(s, variables))
+                    .orElseGet(() -> localeStr.equals("de")
+                            ? "Anmeldebestätigung – " + event.getTitle()
+                            : "Registration confirmed – " + event.getTitle());
+
+            byte[] icsFile = generateCalendarFile(event, eventDateTime);
+            EmailService.EmailAttachment calendarAttachment = new EmailService.EmailAttachment(
+                    "event.ics", icsFile, "text/calendar; charset=utf-8; method=REQUEST", true);
+
+            List<String> cc = additionalEmailsFor(userProfile);
+            emailService.sendHtmlEmailWithAttachments(
+                    userProfile.getEmail(), cc, subject, html, List.of(calendarAttachment));
+
+            log.info("Organizer-added confirmation email sent successfully to: {}",
+                    LoggingUtils.maskEmail(userProfile.getEmail()));
+        } catch (Exception e) {
+            log.error("Failed to send organizer-added confirmation email to: {}",
+                    LoggingUtils.maskEmail(userProfile.getEmail()), e);
+            // Don't re-throw — email failure must not block the add.
+        }
+    }
+
+    /**
      * Story 10.32 — collect additional emails from the (Story 10.32-aware)
      * UserResponse DTO. Returns an empty list for anonymous registrants and
      * for users whose CUMS response predates the additional-emails field.

--- a/services/event-management-service/src/main/java/ch/batbern/events/service/RegistrationService.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/service/RegistrationService.java
@@ -28,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -636,11 +637,14 @@ public class RegistrationService {
         log.info("Organizer {} added {} as confirmed participant for event {} (force={})",
                 addedBy, username, event.getEventCode(), force);
 
-        // Notify reuses the waitlist-promotion "you now have a confirmed spot" email (DE+EN
-        // templates exist; correct "you're in" semantic — unlike the double-opt-in registration-
-        // confirmation email). A dedicated "added-by-organizer" template is a future polish.
+        // Notify with a dedicated "added by the organizing team" confirmation: the place is
+        // already confirmed, so this is NOT the double-opt-in registration-confirmation email and
+        // NOT the waitlist-promotion email (no "confirm please", no waitlist story, no reg code).
         if (notify) {
-            waitlistPromotionEmailService.sendPromotionEmail(saved);
+            String pref = userApiClient.getPreferredLanguage(username);
+            Locale locale = (pref != null && pref.toLowerCase(Locale.ROOT).startsWith("de"))
+                    ? Locale.GERMAN : Locale.ENGLISH;
+            registrationEmailService.sendOrganizerAddedConfirmation(saved, user, event, locale);
         }
 
         return saved;

--- a/services/event-management-service/src/main/resources/email-templates/registration-organizer-added-de.html
+++ b/services/event-management-service/src/main/resources/email-templates/registration-organizer-added-de.html
@@ -1,0 +1,46 @@
+<!-- subject: Anmeldebestätigung – {{eventTitle}} -->
+<!-- registration-organizer-added-de.html — "Vom Organisationsteam angemeldet"-Bestätigung (Deutsch) -->
+<!--
+  Geht an eine Person, die ein Organisator MANUELL als bestätigten Teilnehmer hinzugefügt hat
+  ("Teilnehmer hinzufügen"). KEINE Bestätigungsaufforderung (der Platz ist bereits bestätigt),
+  KEIN Wartelisten-Bezug, KEIN Anmeldecode. Content-Fragment für das batbern-default Layout.
+  Variablen: {{attendeeFirstName}} {{attendeeLastName}} {{eventTitle}} {{eventDate}}
+             {{eventTime}} {{venueName}} {{venueAddress}} {{eventUrl}} {{deregistrationUrl}}
+-->
+<h2>🎟️ Sie sind angemeldet</h2>
+
+<p>Hallo {{attendeeFirstName}} {{attendeeLastName}},</p>
+
+<p>das BATbern-Organisationsteam hat Sie für die folgende Veranstaltung angemeldet.
+   <strong>Ihr Platz ist bestätigt</strong> – Sie müssen nichts weiter tun.</p>
+
+<div class="event-details">
+    <h2>{{eventTitle}}</h2>
+    <div class="detail-row">
+        <span class="detail-label">Datum:</span>
+        <span class="detail-value">{{eventDate}}</span>
+    </div>
+    <div class="detail-row">
+        <span class="detail-label">Uhrzeit:</span>
+        <span class="detail-value">{{eventTime}}</span>
+    </div>
+    <div class="detail-row">
+        <span class="detail-label">Veranstaltungsort:</span>
+        <span class="detail-value">{{venueName}}<br>{{venueAddress}}</span>
+    </div>
+</div>
+
+<div style="text-align: center;">
+    <a href="{{eventUrl}}" class="cta-button">Zur Event-Seite</a>
+</div>
+
+<p>Ein Kalendereintrag (.ics Datei) ist dieser E-Mail als Anhang beigefügt.</p>
+
+<p>Wir freuen uns darauf, Sie am Event zu sehen!</p>
+
+<p style="font-size: 12px; color: #666; margin-top: 24px; border-top: 1px solid #eee; padding-top: 16px;">
+    Sie können leider doch nicht teilnehmen? <a href="{{deregistrationUrl}}" style="color: #666;">Hier abmelden</a>
+</p>
+
+<p>Mit freundlichen Grüssen,<br>
+<strong>Das BATbern Team</strong></p>

--- a/services/event-management-service/src/main/resources/email-templates/registration-organizer-added-en.html
+++ b/services/event-management-service/src/main/resources/email-templates/registration-organizer-added-en.html
@@ -1,0 +1,46 @@
+<!-- subject: Registration confirmed – {{eventTitle}} -->
+<!-- registration-organizer-added-en.html — "Added by the organizing team" confirmation (English) -->
+<!--
+  Sent to a person an organizer MANUALLY added as a confirmed participant ("Add participant").
+  NO confirm-your-registration call-to-action (the place is already confirmed), NO waitlist
+  narrative, NO registration code. Content fragment for the batbern-default layout.
+  Variables: {{attendeeFirstName}} {{attendeeLastName}} {{eventTitle}} {{eventDate}}
+             {{eventTime}} {{venueName}} {{venueAddress}} {{eventUrl}} {{deregistrationUrl}}
+-->
+<h2>🎟️ You're registered</h2>
+
+<p>Hello {{attendeeFirstName}} {{attendeeLastName}},</p>
+
+<p>the BATbern organizing team has registered you for the following event.
+   <strong>Your place is confirmed</strong> — there's nothing more you need to do.</p>
+
+<div class="event-details">
+    <h2>{{eventTitle}}</h2>
+    <div class="detail-row">
+        <span class="detail-label">Date:</span>
+        <span class="detail-value">{{eventDate}}</span>
+    </div>
+    <div class="detail-row">
+        <span class="detail-label">Time:</span>
+        <span class="detail-value">{{eventTime}}</span>
+    </div>
+    <div class="detail-row">
+        <span class="detail-label">Venue:</span>
+        <span class="detail-value">{{venueName}}<br>{{venueAddress}}</span>
+    </div>
+</div>
+
+<div style="text-align: center;">
+    <a href="{{eventUrl}}" class="cta-button">View the event page</a>
+</div>
+
+<p>A calendar entry (.ics file) is attached to this email.</p>
+
+<p>We look forward to seeing you at the event!</p>
+
+<p style="font-size: 12px; color: #666; margin-top: 24px; border-top: 1px solid #eee; padding-top: 16px;">
+    Can't make it after all? <a href="{{deregistrationUrl}}" style="color: #666;">Cancel your registration here</a>
+</p>
+
+<p>Kind regards,<br>
+<strong>The BATbern Team</strong></p>

--- a/services/event-management-service/src/test/java/ch/batbern/events/controller/ParticipantsControllerIntegrationTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/controller/ParticipantsControllerIntegrationTest.java
@@ -38,8 +38,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -71,6 +74,12 @@ class ParticipantsControllerIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoBean
     private UserApiClient userApiClient;
+
+    @MockitoBean
+    private ch.batbern.events.service.RegistrationEmailService registrationEmailService;
+
+    @MockitoBean
+    private ch.batbern.events.service.WaitlistPromotionEmailService waitlistPromotionEmailService;
 
     private static final String EVENT_CODE = "BATbern1999";
     private static final String ORGANIZER_USERNAME = "organizer.alice";
@@ -357,6 +366,20 @@ class ParticipantsControllerIntegrationTest extends AbstractIntegrationTest {
                         .content("{\"username\":\"jane.doe\",\"force\":true,\"notify\":false}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value("confirmed"));
+    }
+
+    @Test
+    @DisplayName("notify=true sends the organizer-added confirmation, NOT the waitlist-promotion email")
+    @WithMockUser(username = ORGANIZER_USERNAME, roles = {"ORGANIZER"})
+    void should_sendOrganizerAddedConfirmation_not_waitlist_when_notify() throws Exception {
+        // notify omitted → defaults true.
+        mockMvc.perform(post("/api/v1/events/{eventCode}/participants", EVENT_CODE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"jane.doe\"}"))
+                .andExpect(status().isCreated());
+
+        verify(registrationEmailService).sendOrganizerAddedConfirmation(any(), any(), any(), any());
+        verify(waitlistPromotionEmailService, never()).sendPromotionEmail(any());
     }
 
     @Test


### PR DESCRIPTION
## Add-participant: send a proper "added by the organizer" confirmation (not the waitlist email)

Follow-up fix to the organizer **Add participant** feature (#792). The first cut reused the
**waitlist-promotion** email, which told the added participant they were *"promoted from the
waiting list"*, asked them to **confirm their registration**, and referenced a **registration
code** we don't expose. An organizer-added participant is **already confirmed** and was never on
a waitlist — all three are wrong.

### Change
- **New template** `registration-organizer-added-{de,en}` (REGISTRATION category via the seed
  service's `registration-` prefix): a *"you're registered — your place is confirmed"* notice.
  No confirm CTA, no waitlist narrative, no registration code; includes the event details, a
  calendar (.ics) invite, and the self-service deregistration link.
- `RegistrationEmailService.sendOrganizerAddedConfirmation` renders + sends it (CCs additional
  emails; locale DE → German, else English).
- `RegistrationService.addParticipant` now calls it (resolving the attendee's preferred language)
  instead of `waitlistPromotionEmailService.sendPromotionEmail`.

### Tests
- Integration test asserts `notify=true` fires the organizer-added confirmation and **not** the
  waitlist-promotion email. Full `ParticipantsControllerIntegrationTest` green (19 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
