### PR TITLE
fix: deregister verify 404 hardening + hero countdown off-by-one

### DIFF
--- a/docs/api/events-api.openapi.yml
+++ b/docs/api/events-api.openapi.yml
@@ -3858,7 +3858,8 @@ paths:
       summary: Verify deregistration token (public)
       description: |
         Verifies a deregistration token and returns registration details for confirmation.
-        Returns 404 if token is unknown or registration is already cancelled.
+        Returns 404 if the token is unknown, already cancelled, or absent/malformed
+        (e.g. an email client truncated the link) — an invalid link is always a 404, never a 500.
 
         **Story**: 10.12 — Self-Service Deregistration
         **Security**: Public endpoint — UUID token provides authentication

--- a/services/event-management-service/src/main/java/ch/batbern/events/controller/DeregistrationController.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/controller/DeregistrationController.java
@@ -45,13 +45,23 @@ public class DeregistrationController {
      * Verify a deregistration token and return registration details.
      * Used by the frontend to show a confirmation page before the attendee confirms.
      *
+     * <p>The {@code token} param is optional and parsed defensively: a missing, blank, or
+     * malformed (non-UUID) value is treated as an invalid link → 404, the same outcome the
+     * frontend already handles for an unknown/expired token. Field report (2026-06-16
+     * deregistration-call blast): a recipient's mail client truncated the link at
+     * {@code ?token=}, so verify was called with no token; the missing {@code @RequestParam}
+     * raised {@code MissingServletRequestParameterException} which fell through to the
+     * catch-all handler and returned a 500. A bad link is a not-found link, never a 500.
+     *
      * @param token UUID deregistration token (from email link)
-     * @return 200 with registration summary, 404 if token invalid or already cancelled
+     * @return 200 with registration summary; 404 if the token is absent, malformed, unknown,
+     *         or already cancelled
      */
     @GetMapping("/verify")
-    public ResponseEntity<DeregistrationVerifyResponse> verifyToken(@RequestParam String token) {
+    public ResponseEntity<DeregistrationVerifyResponse> verifyToken(
+            @RequestParam(required = false) String token) {
         DeregistrationService.DeregistrationVerifyResult result =
-                deregistrationService.verifyToken(java.util.UUID.fromString(token));
+                deregistrationService.verifyToken(parseTokenOrNotFound(token));
 
         DeregistrationVerifyResponse response = new DeregistrationVerifyResponse(
                 result.registrationCode(),
@@ -96,5 +106,21 @@ public class DeregistrationController {
                 .message("If you have a registration for this event, you'll receive an email"
                         + " with a cancellation link shortly.");
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Parse a raw token string into a UUID, mapping any absent/blank/malformed value to a
+     * {@link java.util.NoSuchElementException} so {@link ch.batbern.events.exception.GlobalExceptionHandler}
+     * renders the same 404 "invalid_token" response as an unknown token (never a 400 or 500).
+     */
+    private java.util.UUID parseTokenOrNotFound(String token) {
+        if (token == null || token.isBlank()) {
+            throw new java.util.NoSuchElementException("invalid_token");
+        }
+        try {
+            return java.util.UUID.fromString(token.trim());
+        } catch (IllegalArgumentException ex) {
+            throw new java.util.NoSuchElementException("invalid_token");
+        }
     }
 }

--- a/services/event-management-service/src/test/java/ch/batbern/events/controller/DeregistrationControllerIntegrationTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/controller/DeregistrationControllerIntegrationTest.java
@@ -174,6 +174,35 @@ class DeregistrationControllerIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isNotFound());
     }
 
+    // ── Bugfix: malformed / missing token must be a clean 404, never a 500 ────
+    // Field report (2026-06-16 deregistration-call blast): an email client truncated the
+    // link at "?token=", so the frontend called verify with an empty/absent token. The
+    // missing @RequestParam raised MissingServletRequestParameterException → caught by the
+    // catch-all Exception handler → 500 CRITICAL. A bad link is a not-found link: 404.
+
+    @Test
+    @DisplayName("GET /deregister/verify with NO token param → 404 (not 500)")
+    void verifyToken_missingTokenParam_returns404() throws Exception {
+        mockMvc.perform(get("/api/v1/registrations/deregister/verify"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /deregister/verify with empty token param → 404 (not 400/500)")
+    void verifyToken_emptyTokenParam_returns404() throws Exception {
+        mockMvc.perform(get("/api/v1/registrations/deregister/verify")
+                        .param("token", ""))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /deregister/verify with malformed (non-UUID) token → 404 (not 400/500)")
+    void verifyToken_malformedToken_returns404() throws Exception {
+        mockMvc.perform(get("/api/v1/registrations/deregister/verify")
+                        .param("token", "not-a-uuid"))
+                .andExpect(status().isNotFound());
+    }
+
     // ── T5.2.3: POST /deregister → 200; status = cancelled ───────────────────
 
     @Test

--- a/web-frontend/src/components/public/Event/CountdownTimer.test.tsx
+++ b/web-frontend/src/components/public/Event/CountdownTimer.test.tsx
@@ -1,151 +1,128 @@
 /**
  * CountdownTimer Component Tests
  * Story 4.1.3: Event Landing Page Hero Section
+ *
+ * These tests use REAL date-fns + fake timers (no module mock) so they exercise the
+ * actual day-difference math. The previous version mocked differenceInDays and fed it
+ * hand-picked integers, which masked a real off-by-one: differenceInDays counts whole
+ * 24h periods, so an event at 00:00 two calendar days out read as "Tomorrow!". The fix
+ * is differenceInCalendarDays; the regression test below pins it.
+ *
+ * Dates are built with the local-time constructor (new Date(y, mIdx, d, h)) so the
+ * calendar-day arithmetic is deterministic regardless of the test runner's timezone.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { CountdownTimer } from './CountdownTimer';
 
-// Mock date-fns
-vi.mock('date-fns', () => ({
-  differenceInDays: vi.fn(),
-}));
-
-import { differenceInDays } from 'date-fns';
-
 describe('CountdownTimer', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.useFakeTimers();
   });
 
-  it('should render countdown when event is today', () => {
-    vi.mocked(differenceInDays).mockReturnValue(0);
-    const futureDate = new Date('2025-03-15');
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
-    render(<CountdownTimer eventDate={futureDate} />);
+  it('should render "Today!" when the event is later the same calendar day', () => {
+    vi.setSystemTime(new Date(2026, 5, 19, 8, 0)); // 2026-06-19 08:00 local
+    render(<CountdownTimer eventDate={new Date(2026, 5, 19, 20, 0)} />); // same day, 20:00
 
     expect(screen.getByText('Next Event')).toBeInTheDocument();
     expect(screen.getByText('Today!')).toBeInTheDocument();
   });
 
-  it('should render countdown when event is tomorrow', () => {
-    vi.mocked(differenceInDays).mockReturnValue(1);
-    const futureDate = new Date('2025-03-16');
+  it('should render "Tomorrow!" when the event is the next calendar day', () => {
+    vi.setSystemTime(new Date(2026, 5, 18, 9, 0)); // 2026-06-18 09:00 local
+    render(<CountdownTimer eventDate={new Date(2026, 5, 19, 0, 0)} />); // next day, midnight
 
-    render(<CountdownTimer eventDate={futureDate} />);
-
-    expect(screen.getByText('Next Event')).toBeInTheDocument();
     expect(screen.getByText('Tomorrow!')).toBeInTheDocument();
   });
 
-  it('should render countdown for multiple days', () => {
-    vi.mocked(differenceInDays).mockReturnValue(15);
-    const futureDate = new Date('2025-03-30');
+  it('should say "2 days until event" — not "Tomorrow!" — for an event two calendar days out at midnight (regression: BATbern59 on 2026-06-19 shown from 2026-06-17)', () => {
+    vi.setSystemTime(new Date(2026, 5, 17, 9, 0)); // Wed 2026-06-17 09:00 local
+    render(<CountdownTimer eventDate={new Date(2026, 5, 19, 0, 0)} />); // Fri 2026-06-19 00:00
 
-    render(<CountdownTimer eventDate={futureDate} />);
+    expect(screen.getByText('2 days until event')).toBeInTheDocument();
+    expect(screen.queryByText('Tomorrow!')).not.toBeInTheDocument();
+  });
+
+  it('should render countdown for multiple days', () => {
+    vi.setSystemTime(new Date(2026, 5, 1, 12, 0));
+    render(<CountdownTimer eventDate={new Date(2026, 5, 16, 12, 0)} />); // +15 calendar days
 
     expect(screen.getByText('Next Event')).toBeInTheDocument();
     expect(screen.getByText('15 days until event')).toBeInTheDocument();
   });
 
-  it('should render countdown for 1 day with singular form', () => {
-    vi.mocked(differenceInDays).mockReturnValue(1);
-    const futureDate = new Date('2025-03-16');
-
-    render(<CountdownTimer eventDate={futureDate} />);
-
-    // Should say "Tomorrow!" for 1 day
-    expect(screen.getByText('Tomorrow!')).toBeInTheDocument();
-  });
-
   it('should not render when event is more than 30 days away', () => {
-    vi.mocked(differenceInDays).mockReturnValue(35);
-    const futureDate = new Date('2025-04-20');
-
-    const { container } = render(<CountdownTimer eventDate={futureDate} />);
+    vi.setSystemTime(new Date(2026, 5, 1, 12, 0));
+    const { container } = render(<CountdownTimer eventDate={new Date(2026, 6, 6, 12, 0)} />); // +35
 
     expect(container.firstChild).toBeNull();
   });
 
   it('should not render when event has passed', () => {
-    vi.mocked(differenceInDays).mockReturnValue(-1);
-    const pastDate = new Date('2025-01-01');
-
-    const { container } = render(<CountdownTimer eventDate={pastDate} />);
+    vi.setSystemTime(new Date(2026, 5, 17, 12, 0));
+    const { container } = render(<CountdownTimer eventDate={new Date(2026, 5, 16, 12, 0)} />); // -1
 
     expect(container.firstChild).toBeNull();
   });
 
   it('should render at exactly 30 days', () => {
-    vi.mocked(differenceInDays).mockReturnValue(30);
-    const futureDate = new Date('2025-04-14');
-
-    render(<CountdownTimer eventDate={futureDate} />);
+    vi.setSystemTime(new Date(2026, 5, 1, 12, 0));
+    render(<CountdownTimer eventDate={new Date(2026, 6, 1, 12, 0)} />); // June 1 → July 1 = 30
 
     expect(screen.getByText('Next Event')).toBeInTheDocument();
     expect(screen.getByText('30 days until event')).toBeInTheDocument();
   });
 
+  it('should not render at 31 days', () => {
+    vi.setSystemTime(new Date(2026, 5, 1, 12, 0));
+    const { container } = render(<CountdownTimer eventDate={new Date(2026, 6, 2, 12, 0)} />); // 31
+
+    expect(container.firstChild).toBeNull();
+  });
+
   it('should render pulsing animation elements', () => {
-    vi.mocked(differenceInDays).mockReturnValue(7);
-    const futureDate = new Date('2025-03-22');
+    vi.setSystemTime(new Date(2026, 5, 1, 12, 0));
+    const { container } = render(<CountdownTimer eventDate={new Date(2026, 5, 8, 12, 0)} />); // +7
 
-    const { container } = render(<CountdownTimer eventDate={futureDate} />);
-
-    // Check for pulsing dot container
     const pulsingContainer = container.querySelector('.relative');
     expect(pulsingContainer).toBeInTheDocument();
 
-    // Check for animated elements
     const animatedDots = container.querySelectorAll('.animate-pulse, .animate-ping');
     expect(animatedDots.length).toBeGreaterThan(0);
   });
 
   it('should have correct styling classes', () => {
-    vi.mocked(differenceInDays).mockReturnValue(10);
-    const futureDate = new Date('2025-03-25');
-
-    const { container } = render(<CountdownTimer eventDate={futureDate} />);
+    vi.setSystemTime(new Date(2026, 5, 1, 12, 0));
+    const { container } = render(<CountdownTimer eventDate={new Date(2026, 5, 11, 12, 0)} />); // +10
 
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper).toHaveClass('flex', 'items-center', 'gap-3');
   });
 
   it('should display "Next Event" text with primary color', () => {
-    vi.mocked(differenceInDays).mockReturnValue(5);
-    const futureDate = new Date('2025-03-20');
-
-    render(<CountdownTimer eventDate={futureDate} />);
+    vi.setSystemTime(new Date(2026, 5, 1, 12, 0));
+    render(<CountdownTimer eventDate={new Date(2026, 5, 6, 12, 0)} />); // +5
 
     const nextEventText = screen.getByText('Next Event');
     expect(nextEventText).toHaveClass('text-primary', 'font-medium');
   });
 
-  it('should handle edge case of 31 days (should not render)', () => {
-    vi.mocked(differenceInDays).mockReturnValue(31);
-    const futureDate = new Date('2025-04-15');
-
-    const { container } = render(<CountdownTimer eventDate={futureDate} />);
-
-    expect(container.firstChild).toBeNull();
-  });
-
   it('should display today with green color emphasis', () => {
-    vi.mocked(differenceInDays).mockReturnValue(0);
-    const futureDate = new Date('2025-03-15');
-
-    render(<CountdownTimer eventDate={futureDate} />);
+    vi.setSystemTime(new Date(2026, 5, 19, 8, 0));
+    render(<CountdownTimer eventDate={new Date(2026, 5, 19, 20, 0)} />);
 
     const todayText = screen.getByText('Today!');
     expect(todayText).toHaveClass('text-green-400', 'font-medium');
   });
 
   it('should display tomorrow with orange color emphasis', () => {
-    vi.mocked(differenceInDays).mockReturnValue(1);
-    const futureDate = new Date('2025-03-16');
-
-    render(<CountdownTimer eventDate={futureDate} />);
+    vi.setSystemTime(new Date(2026, 5, 18, 9, 0));
+    render(<CountdownTimer eventDate={new Date(2026, 5, 19, 0, 0)} />);
 
     const tomorrowText = screen.getByText('Tomorrow!');
     expect(tomorrowText).toHaveClass('text-orange-400', 'font-medium');

--- a/web-frontend/src/components/public/Event/CountdownTimer.tsx
+++ b/web-frontend/src/components/public/Event/CountdownTimer.tsx
@@ -3,7 +3,7 @@
  * Displays countdown to upcoming event if within 30 days
  */
 
-import { differenceInDays } from 'date-fns';
+import { differenceInCalendarDays } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
 interface CountdownTimerProps {
@@ -12,7 +12,12 @@ interface CountdownTimerProps {
 
 export const CountdownTimer = ({ eventDate }: CountdownTimerProps) => {
   const { t } = useTranslation('common');
-  const daysUntil = differenceInDays(eventDate, new Date());
+  // differenceInCalendarDays (not differenceInDays): "today / tomorrow / N days" is a
+  // calendar-boundary question, not a 24h-period one. differenceInDays truncates whole
+  // 24h spans, so an event at 00:00 two calendar days out read as 1 → "Tomorrow!" (the
+  // BATbern59 2026-06-19 bug seen on 2026-06-17). Calendar-day diff is timezone-local,
+  // matching how a visitor reads the date on the page.
+  const daysUntil = differenceInCalendarDays(eventDate, new Date());
 
   // Only show if event is within 30 days and in the future
   if (daysUntil < 0 || daysUntil > 30) {

--- a/web-frontend/src/types/generated/events-api.types.ts
+++ b/web-frontend/src/types/generated/events-api.types.ts
@@ -1535,7 +1535,8 @@ export interface paths {
     /**
      * Verify deregistration token (public)
      * @description Verifies a deregistration token and returns registration details for confirmation.
-     *     Returns 404 if token is unknown or registration is already cancelled.
+     *     Returns 404 if the token is unknown, already cancelled, or absent/malformed
+     *     (e.g. an email client truncated the link) — an invalid link is always a 404, never a 500.
      *
      *     **Story**: 10.12 — Self-Service Deregistration
      *     **Security**: Public endpoint — UUID token provides authentication


### PR DESCRIPTION
Two small, independent production fixes surfaced from the 2026-06-16 BATbern59 deregistration-call blast and a hero-badge report.

## 1. Deregister verify returns 404 for missing/malformed token (was 500)
`GET /api/v1/registrations/deregister/verify` declared a **required** `@RequestParam token` parsed straight through `UUID.fromString`. A missing token raised `MissingServletRequestParameterException` → caught by the catch-all `@ExceptionHandler(Exception.class)` → **500 CRITICAL**; an empty/non-UUID token → 400. Both diverge from the documented contract (verify returns **404** for any unresolvable token, which the frontend's invalid-link page already handles).

**Seen in production (2026-06-16):** during the deregistration-call blast (264/267 sent, link worked for ~25 deregistrations) one verify call 500'd because a mail client truncated the link at `?token=`.

**Fix:** `token` is now optional and parsed defensively — absent / blank / malformed → `NoSuchElementException("invalid_token")` → **404**, identical to an unknown token. OpenAPI `verify` description updated in the same commit.

**Tests:** added missing / empty / malformed-token → 404 cases to `DeregistrationControllerIntegrationTest` (RED: 500/400/400 → GREEN). 13/13 pass.

## 2. Hero "Next Event" countdown off-by-one
`CountdownTimer` used date-fns `differenceInDays`, which counts whole 24h periods. BATbern59 (2026-06-19T00:00Z) viewed on 2026-06-17 → `1 day 17h` truncated to **1** → **"Tomorrow!"**, though it is two calendar days away.

**Fix:** switch to `differenceInCalendarDays` (timezone-local, matching the date a visitor reads). Rewrote the test to use **real date-fns + fake timers** instead of mocking `differenceInDays` (the mock is what hid the bug), and added a regression test pinning the 2-calendar-days-out-at-midnight case to "2 days until event". 13/13 pass.

## Test plan
- `./gradlew :services:event-management-service:test --tests DeregistrationControllerIntegrationTest` → 13/13 green
- `npx vitest run src/components/public/Event/CountdownTimer.test.tsx` → 13/13 green
- Pre-push (unit) + ESLint/Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)