### PR TITLE
fix(present): agenda title positioning + upcoming-events slide cleanup

### DIFF
--- a/web-frontend/src/hooks/usePresentationData.ts
+++ b/web-frontend/src/hooks/usePresentationData.ts
@@ -111,8 +111,8 @@ export function usePresentationData(eventCode: string): UsePresentationDataResul
   });
 
   const upcomingQuery = useQuery({
-    queryKey: ['presentation-upcoming-events'],
-    queryFn: getUpcomingEvents,
+    queryKey: ['presentation-upcoming-events', eventCode],
+    queryFn: () => getUpcomingEvents(eventCode),
     staleTime: 5 * 60 * 1000,
     retry: 1,
   });

--- a/web-frontend/src/pages/PresentationPage.tsx
+++ b/web-frontend/src/pages/PresentationPage.tsx
@@ -247,49 +247,9 @@ export function PresentationPage(): JSX.Element {
       <TopicBackground imageUrl={data.event?.themeImageUrl ?? undefined} />
 
       {/* ----------------------------------------------------------------
-          Agenda heading — separate from the FLIP element so its height
-          doesn't affect the FLIP rect measurement. Lives in its own
-          AnimatePresence so it can slide in/out with the section direction
-          while the FLIP list animates independently. (ACs #1-4, #11, #14)
-          ---------------------------------------------------------------- */}
-      <AnimatePresence custom={direction}>
-        {isAgendaCenter && (
-          <motion.div
-            key="agenda-heading"
-            custom={direction}
-            variants={slideVariants}
-            initial="enter"
-            animate="center"
-            exit="exit"
-            transition={slideTransition}
-            style={{
-              position: 'fixed',
-              zIndex: 3,
-              top: 'calc(50vh - 10.833vw)',
-              left: 0,
-              right: 0,
-              display: 'flex',
-              justifyContent: 'center',
-              pointerEvents: 'none',
-            }}
-          >
-            <h2
-              style={{
-                margin: 0,
-                fontSize: '2.5vw',
-                fontWeight: 700,
-                color: '#4f9cf9',
-              }}
-            >
-              Agenda
-            </h2>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      {/* ----------------------------------------------------------------
           FLIP agenda — center-stage (agenda-preview / agenda-recap)
-          Simple centering wrapper — heading is a separate element above.
+          The "Agenda" heading is rendered inside AgendaView (center layout)
+          so it is laid out with the list and centered as one group. (ACs #1-4, #11, #14)
           ---------------------------------------------------------------- */}
       {isAgendaCenter && (
         <div

--- a/web-frontend/src/pages/presentation/AgendaView.module.css
+++ b/web-frontend/src/pages/presentation/AgendaView.module.css
@@ -21,6 +21,14 @@
   opacity: 0.85;
 }
 
+.agendaTitle {
+  margin: 0 0 2.5vw; /* gap above the first session, scales with viewport */
+  font-size: 2.5vw;
+  font-weight: 700;
+  color: #4f9cf9; /* BATbern blue accent */
+  text-align: center;
+}
+
 .sessionRow {
   display: flex;
   align-items: baseline;

--- a/web-frontend/src/pages/presentation/AgendaView.tsx
+++ b/web-frontend/src/pages/presentation/AgendaView.tsx
@@ -55,6 +55,11 @@ export function AgendaView({
 
   return (
     <div className={layout === 'center' ? styles.center : styles.sidebar}>
+      {/* Heading lives inside the center-layout view so it is laid out with the
+          list and centered as one group — always correctly spaced above the
+          sessions at any session count. Omitted in sidebar layout so it does
+          not appear during session slides (and stays out of the FLIP box). */}
+      {layout === 'center' && <h2 className={styles.agendaTitle}>Agenda</h2>}
       {visible.map((s) => {
         if (s.sessionType && BREAK_SESSION_TYPES.has(s.sessionType)) {
           return (

--- a/web-frontend/src/pages/presentation/slides/UpcomingEventsSlide.tsx
+++ b/web-frontend/src/pages/presentation/slides/UpcomingEventsSlide.tsx
@@ -48,14 +48,15 @@ export function UpcomingEventsSlide({ events }: UpcomingEventsSlideProps): JSX.E
       <div
         style={{
           display: 'flex',
-          gap: '1.667vw',
+          gap: '2.5vw',
           justifyContent: 'center',
+          alignItems: 'stretch',
           flexWrap: 'wrap',
-          maxWidth: '62.5vw',
+          maxWidth: '85vw',
         }}
       >
         {upcoming.length === 0 ? (
-          <p style={{ fontSize: '1.25vw', color: 'rgba(255,255,255,0.6)' }}>
+          <p style={{ fontSize: '1.5vw', color: 'rgba(255,255,255,0.6)' }}>
             Keine weiteren Events geplant.
           </p>
         ) : (
@@ -68,36 +69,40 @@ export function UpcomingEventsSlide({ events }: UpcomingEventsSlideProps): JSX.E
 
 function EventCard({ event }: { event: Event }): JSX.Element {
   const dateStr = event.date ? format(new Date(event.date), 'dd. MMMM yyyy') : '—';
-  const titleDisplay = event.title ?? 'TBD';
+  const hasTitle = Boolean(event.title);
+  const titleDisplay = event.title ?? 'Thema folgt';
 
   return (
     <div
       style={{
+        display: 'flex',
+        flexDirection: 'column',
         background: 'rgba(255,255,255,0.08)',
         border: '1px solid rgba(255,255,255,0.15)',
-        borderRadius: '0.625vw',
-        padding: '1.667vw',
-        minWidth: '14.583vw',
-        maxWidth: '17.708vw',
+        borderRadius: '1.25vw',
+        padding: '2.917vw 2.5vw',
+        minWidth: '24vw',
+        maxWidth: '30vw',
         textAlign: 'center',
       }}
     >
       <div
         style={{
-          fontSize: '1.667vw',
+          fontSize: '2.708vw',
           fontWeight: 800,
           color: '#4f9cf9',
-          marginBottom: '0.625vw',
+          marginBottom: '1.25vw',
+          letterSpacing: '-0.01em',
         }}
       >
-        #{event.eventNumber}
+        #{event.eventCode}
       </div>
 
       <div
         style={{
-          fontSize: '1.042vw',
+          fontSize: '1.458vw',
           color: 'rgba(255,255,255,0.7)',
-          marginBottom: '0.417vw',
+          marginBottom: '1.25vw',
         }}
       >
         {dateStr}
@@ -105,9 +110,11 @@ function EventCard({ event }: { event: Event }): JSX.Element {
 
       <div
         style={{
-          fontSize: '0.917vw',
-          color: 'rgba(255,255,255,0.5)',
-          fontStyle: titleDisplay === 'TBD' ? 'italic' : 'normal',
+          fontSize: '1.667vw',
+          fontWeight: 600,
+          lineHeight: 1.3,
+          color: hasTitle ? 'rgba(255,255,255,0.92)' : 'rgba(255,255,255,0.5)',
+          fontStyle: hasTitle ? 'normal' : 'italic',
         }}
       >
         {titleDisplay}

--- a/web-frontend/src/services/presentationService.test.ts
+++ b/web-frontend/src/services/presentationService.test.ts
@@ -85,6 +85,23 @@ describe('presentationService', () => {
       expect(result.map((e) => e.eventCode)).toEqual(['EVT2', 'EVT1', 'EVT3']);
     });
 
+    it('should exclude the currently-presented event', async () => {
+      const now = new Date();
+      const future1 = new Date(now.getTime() + 5 * 86400_000).toISOString(); // +5 days
+      const future2 = new Date(now.getTime() + 10 * 86400_000).toISOString(); // +10 days
+
+      const mockEvents = [
+        { eventCode: 'CURRENT', date: future1 },
+        { eventCode: 'NEXT', date: future2 },
+      ];
+      mockApiClient.get.mockResolvedValue({ data: { data: mockEvents } });
+
+      const result = await getUpcomingEvents('CURRENT');
+
+      // CURRENT is in the future but is the event on screen → excluded
+      expect(result.map((e) => e.eventCode)).toEqual(['NEXT']);
+    });
+
     it('should handle API returning flat array (no pagination wrapper)', async () => {
       const now = new Date();
       const future = new Date(now.getTime() + 86400_000).toISOString();

--- a/web-frontend/src/services/presentationService.ts
+++ b/web-frontend/src/services/presentationService.ts
@@ -53,8 +53,14 @@ export const getPublicOrganizers = async (): Promise<User[]> => {
 /**
  * Fetches the next 3 upcoming events for the Upcoming Events slide.
  * Public endpoint — no auth required.
+ *
+ * @param excludeEventCode — the event currently being presented; excluded from
+ *   the result so the slide shows only genuinely *future* events, not the
+ *   current one (whose date is still in the future).
  */
-export const getUpcomingEvents = async (): Promise<components['schemas']['Event'][]> => {
+export const getUpcomingEvents = async (
+  excludeEventCode?: string
+): Promise<components['schemas']['Event'][]> => {
   const response = await apiClient.get<{ data: components['schemas']['Event'][] }>('/events', {
     params: {
       status: 'AGENDA_PUBLISHED,TOPIC_SELECTION_DONE,TOPIC_SELECTION,CREATED',
@@ -67,10 +73,10 @@ export const getUpcomingEvents = async (): Promise<components['schemas']['Event'
   const events =
     response.data.data ?? (response.data as unknown as components['schemas']['Event'][]);
   // Filter to strictly future events (same pattern as public UpcomingEventsSection),
-  // then sort by date ascending and take the first 3.
+  // excluding the event currently on screen, then sort by date ascending and take the first 3.
   const now = new Date();
   return events
-    .filter((e) => new Date(e.date) > now)
+    .filter((e) => new Date(e.date) > now && e.eventCode !== excludeEventCode)
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     .slice(0, 3);
 };


### PR DESCRIPTION
## Summary

Two fixes to the fullscreen moderator presentation page (`/present/:eventCode`), verified on `beta.batbern.ch` against the full-day event agenda.

### 1. Agenda title overlapped the sessions on full-day events
The "Agenda" heading was a fixed layer pinned at a constant offset above vertical center, while the session list is vertically centered. With few sessions (evening events) the short list stayed below the heading; with ~7 sessions (full-day events) the taller centered list climbed above the fixed heading and the title landed on top of the sessions.

**Fix:** the heading now renders *inside* `AgendaView` (center layout only), so it's laid out with the list and centered as one group — correct spacing at any session count, identical forward and backward, and kept out of the sidebar FLIP box during session slides.

### 2. Upcoming-events slide
- **Excluded the current event** — `getUpcomingEvents(excludeEventCode)` drops the event being presented (its date is still in the future, so it was appearing in its own "next events" list). Exclusion happens *before* the slice-to-3, so no slot is lost.
- **Full event code** — title shows `#BATbern60` (`eventCode`) instead of `#60` (`eventNumber`).
- **Bigger, more legible cards** — larger code/title/date, wider padding and gap; empty-topic placeholder reads *"Thema folgt"* instead of "TBD".

## Testing
- `tsc --noEmit` clean · eslint clean
- `PresentationPage.test.tsx`, `usePresentationData.test.ts`, `presentationService.test.ts` — all green (added a service test asserting the current event is excluded)
- Manually verified on beta: full-day agenda (no overlap), evening agenda (centered look preserved), agenda→session FLIP, upcoming-events slide

🤖 Generated with [Claude Code](https://claude.com/claude-code)