### PR TITLE
fix(events): homepage features the just-completed event through its afterglow window

### DIFF
--- a/docs/api/events-api.openapi.yml
+++ b/docs/api/events-api.openapi.yml
@@ -298,15 +298,22 @@ paths:
     get:
       tags:
         - Events
-      summary: Get current published event
+      summary: Get current event for the public homepage
       description: |
-        Retrieve the next upcoming published event for the public website.
+        Retrieve the event the public homepage should feature. No authentication required.
 
         **Story**: 4.1.3 - Public event landing page hero section
         **Public Access**: No authentication required
 
-        Returns the earliest published event by date (next upcoming event).
-        If no published events exist, returns 404.
+        Two-phase selection (afterglow takes precedence):
+        1. **Afterglow**: the most recently completed event still inside its 14-day post-event
+           window (EVENT_COMPLETED, date within the last 14 days). It keeps featuring on the
+           homepage so attendees get the post-event experience, even if the next event has
+           already published its topic/speakers/agenda. The scheduler auto-archives after 14 days.
+        2. **Upcoming**: otherwise, the earliest upcoming published event by date
+           (currentPublishedPhase != null).
+
+        If neither exists, returns 404.
 
         **Performance**: <150ms (P95)
 

--- a/services/event-management-service/src/main/java/ch/batbern/events/controller/EventController.java
+++ b/services/event-management-service/src/main/java/ch/batbern/events/controller/EventController.java
@@ -752,9 +752,9 @@ public class EventController {
      *
      * GET /api/v1/events/current?include=topics,venue,speakers,sessions
      *
-     * Returns the next upcoming event with status published, registration_open, or
-     * registration_closed. If multiple events match, returns the one nearest to the current
-     * date. This is a public endpoint (no authentication required) used by the public website.
+     * Afterglow takes precedence: if an event is still within its 14-day post-event window
+     * (EVENT_COMPLETED), it is returned so the homepage keeps featuring it. Otherwise the next
+     * upcoming published event (nearest by date) is returned. Public endpoint (no auth).
      *
      * @param include Comma-separated list of resources to expand
      * @return Current event or 404 if none exists
@@ -762,8 +762,9 @@ public class EventController {
     @GetMapping("/current")
     @Operation(
             summary = "Get Current Event",
-            description = "Retrieve the next upcoming event (published, registration_open, or "
-                + "registration_closed) for the public website. No authentication required."
+            description = "Retrieve the event the public homepage should feature: the recently "
+                + "completed event within its 14-day post-event window if one exists, otherwise "
+                + "the next upcoming published event. No authentication required."
     )
     public ResponseEntity<EventResponse> getCurrentEvent(
             @Parameter(description = "Comma-separated list of resources to include "
@@ -772,15 +773,20 @@ public class EventController {
     ) {
         log.debug("GET /api/v1/events/current - include: {}", include);
 
-        // Two-phase lookup for the public homepage current event:
-        // Phase 1: Prefer the next upcoming event that has been explicitly published
-        //          (currentPublishedPhase IS NOT NULL). Events in early internal states
-        //          (SPEAKER_IDENTIFICATION, SLOT_ASSIGNMENT) without a published phase must NOT
-        //          block the Phase 2 fallback — only events the organiser has actively published
-        //          (topics / speakers / agenda) are eligible for public display.
-        // Phase 2: Fallback — show the most recently completed event within the 14-day
-        //          post-event window, so the homepage is not blank right after an event.
-        // After 14 days the scheduler auto-archives the event and the page returns 404.
+        // Two-phase lookup for the public homepage current event (afterglow takes precedence):
+        // Phase 1: Prefer the most recently completed event still inside its 14-day post-event
+        //          window (EVENT_COMPLETED, date within the last 14 days). While an event is in
+        //          this afterglow window the homepage keeps showing it so attendees get the
+        //          post-event experience (Q&A, slides-online, thank-the-organisers, …) — even if
+        //          the NEXT event has already published its topic/speakers/agenda. The scheduler
+        //          auto-archives the event after 14 days, ending the afterglow.
+        // Phase 2: Fallback — the next upcoming event that has been explicitly published
+        //          (currentPublishedPhase IS NOT NULL). Events in early internal states without a
+        //          published phase are NOT eligible for public display. This also serves the
+        //          event-day case (EVENT_LIVE, date == today) which Phase 1 excludes (date < today).
+        // If neither matches the page returns 404.
+        // Precedence is afterglow-first (changed 2026-06-20): BATbern is quarterly, so a completed
+        // event ≤14 days old can never coexist with a live/upcoming event within 14 days.
         // 8-State Model (V82): AGENDA_FINALIZED removed, scheduler transitions AGENDA_PUBLISHED → EVENT_LIVE
         List<EventWorkflowState> activeWorkflowStates = List.of(
                 EventWorkflowState.SPEAKER_IDENTIFICATION,
@@ -791,26 +797,26 @@ public class EventController {
         ZoneId bernZone = ZoneId.of("Europe/Zurich");
         Instant startOfToday = LocalDate.now(bernZone).atStartOfDay(bernZone).toInstant();
 
-        // Phase 1: upcoming published event (today or future, currentPublishedPhase set)
+        // Phase 1: afterglow — most recently completed event within the 14-day post-event window
+        Instant twoWeeksAgo = startOfToday.minus(14, ChronoUnit.DAYS);
         Event currentEvent = eventRepository
-                .findFirstByWorkflowStateInAndDateGreaterThanEqualAndCurrentPublishedPhaseIsNotNullOrderByDateAsc(
-                        activeWorkflowStates, startOfToday)
+                .findFirstByWorkflowStateAndDateGreaterThanEqualAndDateBeforeOrderByDateDesc(
+                        EventWorkflowState.EVENT_COMPLETED,
+                        twoWeeksAgo,
+                        startOfToday
+                )
                 .orElse(null);
+        if (currentEvent != null) {
+            log.debug("Afterglow: showing recently completed event {} within 14-day window",
+                    currentEvent.getEventCode());
+        }
 
-        // Phase 2: fallback — recently completed event within 14-day post-event window
+        // Phase 2: fallback — next upcoming published event (today or future, currentPublishedPhase set)
         if (currentEvent == null) {
-            Instant twoWeeksAgo = startOfToday.minus(14, ChronoUnit.DAYS);
             currentEvent = eventRepository
-                    .findFirstByWorkflowStateAndDateGreaterThanEqualAndDateBeforeOrderByDateDesc(
-                            EventWorkflowState.EVENT_COMPLETED,
-                            twoWeeksAgo,
-                            startOfToday
-                    )
+                    .findFirstByWorkflowStateInAndDateGreaterThanEqualAndCurrentPublishedPhaseIsNotNullOrderByDateAsc(
+                            activeWorkflowStates, startOfToday)
                     .orElse(null);
-            if (currentEvent != null) {
-                log.debug("Fallback: showing recently completed event {} within 14-day window",
-                        currentEvent.getEventCode());
-            }
         }
 
         if (currentEvent == null) {

--- a/services/event-management-service/src/test/java/ch/batbern/events/controller/EventControllerIntegrationTest.java
+++ b/services/event-management-service/src/test/java/ch/batbern/events/controller/EventControllerIntegrationTest.java
@@ -2387,19 +2387,43 @@ public class EventControllerIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("should_preferUpcomingEvent_when_bothUpcomingAndRecentlyCompletedExist")
-    void should_preferUpcomingEvent_when_bothUpcomingAndRecentlyCompletedExist() throws Exception {
-        // Given: a recently completed event AND an upcoming published event
+    @DisplayName("should_preferRecentlyCompletedEvent_when_bothUpcomingAndRecentlyCompletedExist")
+    void should_preferRecentlyCompletedEvent_when_bothUpcomingAndRecentlyCompletedExist() throws Exception {
+        // Given: a recently completed event AND an upcoming published event.
+        // The afterglow (EVENT_COMPLETED, within the 14-day post-event window) takes precedence:
+        // while the event is in its post-event window, the homepage keeps showing it so attendees
+        // get the post-event experience — even though the next event is already published.
         eventRepository.deleteAll();
         String sevenDaysAgo = Instant.now().minus(7, ChronoUnit.DAYS).toString();
         String tomorrow = Instant.now().plus(1, ChronoUnit.DAYS).toString();
         createTestEvent("Recent Completed", sevenDaysAgo, "EVENT_COMPLETED");
         createTestEvent("Upcoming Event", tomorrow, "AGENDA_PUBLISHED", "agenda");
 
-        // When / Then: upcoming event is preferred
+        // When / Then: the recently completed afterglow event is preferred over the upcoming one
         mockMvc.perform(get("/api/v1/events/current"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.title").value("Upcoming Event"));
+                .andExpect(jsonPath("$.title").value("Recent Completed"))
+                .andExpect(jsonPath("$.workflowState").value("EVENT_COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("should_preferCompletedAfterglow_when_nextEventHasPublishedTopic")
+    void should_preferCompletedAfterglow_when_nextEventHasPublishedTopic() throws Exception {
+        // Regression test for the BATbern59/BATbern60 bug (2026-06-20): a just-completed event was
+        // dropped from the homepage because the NEXT event (months out) was already in
+        // SPEAKER_IDENTIFICATION with currentPublishedPhase=TOPIC, so the old "upcoming first"
+        // precedence returned the future event. The afterglow event must win during its window.
+        eventRepository.deleteAll();
+        String yesterday = Instant.now().minus(1, ChronoUnit.DAYS).toString();
+        String monthsOut = Instant.now().plus(140, ChronoUnit.DAYS).toString();
+        createTestEvent("Just Completed (afterglow)", yesterday, "EVENT_COMPLETED", "agenda");
+        createTestEvent("Next Event (topic published)", monthsOut, "SPEAKER_IDENTIFICATION", "topic");
+
+        // When / Then: the afterglow event wins despite the next event having a published topic
+        mockMvc.perform(get("/api/v1/events/current"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Just Completed (afterglow)"))
+                .andExpect(jsonPath("$.workflowState").value("EVENT_COMPLETED"));
     }
 
     @Test

--- a/web-frontend/src/types/generated/events-api.types.ts
+++ b/web-frontend/src/types/generated/events-api.types.ts
@@ -99,14 +99,21 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * Get current published event
-     * @description Retrieve the next upcoming published event for the public website.
+     * Get current event for the public homepage
+     * @description Retrieve the event the public homepage should feature. No authentication required.
      *
      *     **Story**: 4.1.3 - Public event landing page hero section
      *     **Public Access**: No authentication required
      *
-     *     Returns the earliest published event by date (next upcoming event).
-     *     If no published events exist, returns 404.
+     *     Two-phase selection (afterglow takes precedence):
+     *     1. **Afterglow**: the most recently completed event still inside its 14-day post-event
+     *        window (EVENT_COMPLETED, date within the last 14 days). It keeps featuring on the
+     *        homepage so attendees get the post-event experience, even if the next event has
+     *        already published its topic/speakers/agenda. The scheduler auto-archives after 14 days.
+     *     2. **Upcoming**: otherwise, the earliest upcoming published event by date
+     *        (currentPublishedPhase != null).
+     *
+     *     If neither exists, returns 404.
      *
      *     **Performance**: <150ms (P95)
      */


### PR DESCRIPTION
## Problem

After BATbern59 (event date 2026-06-19) completed, the public homepage immediately switched to featuring **BATbern60** — the November event — instead of keeping BATbern59 visible during its post-event afterglow window.

**Root cause:** `GET /events/current` did a two-phase lookup with **upcoming first**:
1. next upcoming published event (`date >= today`, `currentPublishedPhase != null`)
2. *fallback only if (1) is null:* most recently completed event within the 14-day window

BATbern60 is months out but already had `currentPublishedPhase = TOPIC` (state `SPEAKER_IDENTIFICATION`), so Phase 1 matched it and the afterglow fallback never ran. The just-completed event's 14-day window was cut short.

(Note: the scheduler is **not** at fault — BATbern59 correctly transitioned to `EVENT_COMPLETED` at end of event day via the UTC cron. The bug was purely the public-endpoint precedence.)

## Fix

Invert the precedence in `EventController.getCurrentEvent`:
1. **Afterglow first** — the most recently completed event still inside its 14-day window (`EVENT_COMPLETED`).
2. **Upcoming fallback** — the next upcoming published event, only when there's no afterglow event.

After 14 days the existing archive scheduler flips `EVENT_COMPLETED → ARCHIVED`, the afterglow query stops matching, and the upcoming event takes over — exactly the intended "show the completed event until it's archived, then the next one."

Safe at BATbern's quarterly cadence: a completed event ≤14 days old can never coexist with a live/upcoming event within 14 days. The event-day case (`EVENT_LIVE`, date == today) is still served by the upcoming phase (afterglow excludes `date < today`).

## Tests
- Flipped the test that locked in the old behaviour: `should_preferUpcomingEvent...` → `should_preferRecentlyCompletedEvent_when_bothUpcomingAndRecentlyCompletedExist`.
- Added `should_preferCompletedAfterglow_when_nextEventHasPublishedTopic` mirroring the exact BATbern59/BATbern60 data (completed yesterday + `SPEAKER_IDENTIFICATION`/`TOPIC` future event).
- All `EventControllerIntegrationTest` current-event tests green (PostgreSQL Testcontainers): live-today, completed-yesterday, upcoming-only, nearest, >14-days-404 all still pass.
- OpenAPI spec + generated FE types updated to describe afterglow-first selection.

## Verification note
Local dev has no production data mirror, so the BATbern59/60 scenario can't be reproduced on the local stack — it's covered by the PostgreSQL integration test here and will be exercised end-to-end by the **staging Bruno + Playwright gates** on this PR (against real data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)